### PR TITLE
fix(pages): set BASE_URL for GitHub Pages project site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,8 @@ jobs:
           cache: true
           frozen: true
       - name: Build docs
+        env:
+          BASE_URL: /research_notebook
         run: pixi run -e docs docs-build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Sets `BASE_URL=/research_notebook` on the `docs-build` step so MyST emits correct absolute asset paths for the project-pages URL (`jejjohnson.github.io/research_notebook/`).

## Why
The deployed site at https://jejjohnson.github.io/research_notebook/ currently shows the MyST warning banner "Site not loading correctly? This may be due to an incorrect BASE_URL configuration" and CSS/JS assets fail to load because MyST bakes in absolute `/`-rooted URLs by default. Project Pages require the subpath prefix.

## Test plan
- [ ] Re-run the Deploy Docs workflow on `main` after merge
- [ ] Verify the banner disappears and styles load at https://jejjohnson.github.io/research_notebook/

🤖 Generated with [Claude Code](https://claude.com/claude-code)