### PR TITLE
docs: wire gaussianization into jupyterbook + shorten sidebar titles

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -91,6 +91,13 @@ project:
                 - file: projects/plume_simulation/notebooks/les_fvm/00_eulerian_dispersion_derivation
                 - file: projects/plume_simulation/notebooks/les_fvm/01_eulerian_dispersion_l2
                 - file: projects/plume_simulation/notebooks/les_fvm/03_puff_vs_eulerian
+        - title: Gaussianization flows
+          children:
+            - file: projects/gaussianization/README
+            - file: projects/gaussianization/notebooks/01_gaussianization_2d
+            - file: projects/gaussianization/notebooks/02_coupling_flow_2d
+            - file: projects/gaussianization/notebooks/03_iterative_gaussianization_init
+            - file: projects/gaussianization/notebooks/04_coupling_equivalence
     - title: API Reference
       children:
         - file: docs/api/reference

--- a/notebooks/coordax/derivatives/05_finite_difference.ipynb
+++ b/notebooks/coordax/derivatives/05_finite_difference.ipynb
@@ -5,6 +5,10 @@
    "id": "74bc78ec",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Finite-difference gradients\"\n",
+    "---\n",
+    "\n",
     "# Part 5: Coordinate-Aware Gradient Operators\n",
     "\n",
     "This notebook demonstrates how to compute derivatives with respect to physical coordinates (not just array indices) using finite differences."

--- a/notebooks/coordax/derivatives/06_spherical_harmonics_derivatives.ipynb
+++ b/notebooks/coordax/derivatives/06_spherical_harmonics_derivatives.ipynb
@@ -5,6 +5,10 @@
    "id": "999233ee",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Spherical-harmonic derivatives\"\n",
+    "---\n",
+    "\n",
     "# Part 5.2: Spherical-Harmonic Derivatives on a Lat-Lon Grid\n",
     "\n",
     "Computing derivatives on the sphere via finite differences on a regular lat-lon grid runs into three problems: the meridian is not periodic (so naive Fourier along latitude is wrong), the zonal spacing $\\Delta x = a\\cos\\phi\\,\\Delta\\lambda$ shrinks to zero at the poles, and the metric factor $1/\\cos\\phi$ in the vector calculus identities is singular there.\n",

--- a/notebooks/coordax/derivatives/07_finite_volume.ipynb
+++ b/notebooks/coordax/derivatives/07_finite_volume.ipynb
@@ -5,6 +5,10 @@
    "id": "35f31f70",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Finite-volume advection\"\n",
+    "---\n",
+    "\n",
     "# Part 5.3: Finite Volume Advection on a Staggered Grid\n",
     "\n",
     "Staggered grids (Arakawa C-grid) place velocities at cell faces and scalars at cell centers. Coordax's distinct named axes prevent accidental mixing of the two grids."

--- a/notebooks/coordax/dynamics/08_ode_integration.ipynb
+++ b/notebooks/coordax/dynamics/08_ode_integration.ipynb
@@ -5,6 +5,10 @@
    "id": "569f6ed6",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"ODE integration (Diffrax)\"\n",
+    "---\n",
+    "\n",
     "# Part 6: The JAX Superpower — JIT, vmap, and PDE Integration (Diffrax)\n",
     "\n",
     "Coordax Fields are JAX pytrees, so they work seamlessly with `jax.jit`, `jax.grad`, and libraries like Diffrax."

--- a/notebooks/coordax/dynamics/09_ode_parameter_state_estimation.ipynb
+++ b/notebooks/coordax/dynamics/09_ode_parameter_state_estimation.ipynb
@@ -5,6 +5,10 @@
    "id": "f95c248f",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"ODE parameter/state estimation\"\n",
+    "---\n",
+    "\n",
     "# Part 6.4: State and Parameter Estimation for ODEs\n",
     "\n",
     "Estimating initial conditions (state estimation) and physical parameters (parameter estimation) from noisy observations of the Lorenz63 system.\n",

--- a/notebooks/coordax/dynamics/10_pde_parameter_estimation.ipynb
+++ b/notebooks/coordax/dynamics/10_pde_parameter_estimation.ipynb
@@ -5,6 +5,10 @@
    "id": "efabbcbc",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"PDE parameter estimation\"\n",
+    "---\n",
+    "\n",
     "# Part 6.3: Fitting a PDE Model to Data\n",
     "\n",
     "Estimate advection velocity (U) and diffusion coefficient (κ) of the 1D advection-diffusion equation from synthetic observations.\n",

--- a/notebooks/coordax/foundations/01_create_datasets.ipynb
+++ b/notebooks/coordax/foundations/01_create_datasets.ipynb
@@ -5,6 +5,10 @@
    "id": "a951c437",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Creating DataArrays\"\n",
+    "---\n",
+    "\n",
     "# Creating DataArrays in Coordax: A Pedagogical Introduction\n",
     "\n",
     "This guide demonstrates how to create `Field` objects (coordax's equivalent to xarray DataArrays) for different types of scientific data."

--- a/notebooks/coordax/foundations/02_ops_unary_binary.ipynb
+++ b/notebooks/coordax/foundations/02_ops_unary_binary.ipynb
@@ -5,6 +5,10 @@
    "id": "0b3d5b34",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Unary & binary ops\"\n",
+    "---\n",
+    "\n",
     "# Part 2: Safe, Labeled Arithmetic (Unary & Binary Ops)\n",
     "\n",
     "This notebook demonstrates how coordax provides safe, dimension-aware arithmetic operations that automatically handle broadcasting and alignment."

--- a/notebooks/coordax/foundations/03_ops_coordinates.ipynb
+++ b/notebooks/coordax/foundations/03_ops_coordinates.ipynb
@@ -5,6 +5,10 @@
    "id": "6ef1d30c",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Coordinate-aware ops\"\n",
+    "---\n",
+    "\n",
     "# Part 4: Coordinate-Aware Analysis (Ops Using Coordinate Info)\n",
     "\n",
     "This notebook demonstrates how to leverage physical coordinate values for selection, slicing, regridding, and interpolation."

--- a/notebooks/coordax/foundations/04_reductions.ipynb
+++ b/notebooks/coordax/foundations/04_reductions.ipynb
@@ -5,6 +5,10 @@
    "id": "846414b1",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Reductions\"\n",
+    "---\n",
+    "\n",
     "# Part 3: Aggregations by Name (Functional Ops on Dims)\n",
     "\n",
     "This notebook demonstrates dimension-aware reductions and numerical integration using the `untag` + `cmap` pattern."

--- a/notebooks/pyrox/ensembles/ensemble_primitives_tutorial.ipynb
+++ b/notebooks/pyrox/ensembles/ensemble_primitives_tutorial.ipynb
@@ -5,6 +5,10 @@
    "id": "2fa385c7",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Ensemble primitives\"\n",
+    "---\n",
+    "\n",
     "# Ensemble Primitives Tutorial — Three Ways to Drive `ensemble_step`\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jejjohnson/pyrox/blob/main/docs/notebooks/ensemble_primitives_tutorial.ipynb)\n",

--- a/notebooks/pyrox/ensembles/ensemble_runner_tutorial.ipynb
+++ b/notebooks/pyrox/ensembles/ensemble_runner_tutorial.ipynb
@@ -5,6 +5,10 @@
    "id": "de77ea6e",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Ensemble runners\"\n",
+    "---\n",
+    "\n",
     "# Ensemble Runner Tutorial — `EnsembleMAP` & `EnsembleVI`\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jejjohnson/pyrox/blob/main/docs/notebooks/ensemble_runner_tutorial.ipynb)\n",

--- a/notebooks/pyrox/gp/exact_gp_regression.ipynb
+++ b/notebooks/pyrox/gp/exact_gp_regression.ipynb
@@ -5,6 +5,10 @@
    "id": "66358939",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Exact GP regression\"\n",
+    "---\n",
+    "\n",
     "# Exact GP Regression — the Three Patterns\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jejjohnson/pyrox/blob/main/docs/notebooks/exact_gp_regression.ipynb)\n",

--- a/notebooks/pyrox/gp/latent_gp_classification.ipynb
+++ b/notebooks/pyrox/gp/latent_gp_classification.ipynb
@@ -5,6 +5,10 @@
    "id": "c3441ceb",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Latent GP classification\"\n",
+    "---\n",
+    "\n",
     "# Latent GP Classification — the Three Patterns\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jejjohnson/pyrox/blob/main/docs/notebooks/latent_gp_classification.ipynb)\n",

--- a/notebooks/pyrox/masterclass/regression_masterclass_parameterized.ipynb
+++ b/notebooks/pyrox/masterclass/regression_masterclass_parameterized.ipynb
@@ -5,6 +5,10 @@
    "id": "4ab14fd5",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Pattern 3 — `Parameterized`\"\n",
+    "---\n",
+    "\n",
     "# Regression Masterclass — Pattern 3: `Parameterized` + `PyroxParam` + native `pyrox.gp`\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jejjohnson/pyrox/blob/main/docs/notebooks/regression_masterclass_parameterized.ipynb)\n",

--- a/notebooks/pyrox/masterclass/regression_masterclass_pyrox_sample.ipynb
+++ b/notebooks/pyrox/masterclass/regression_masterclass_pyrox_sample.ipynb
@@ -5,6 +5,10 @@
    "id": "ef1ceb1f",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Pattern 2 — `PyroxModule`\"\n",
+    "---\n",
+    "\n",
     "# Regression Masterclass — Pattern 2: `PyroxModule` + `pyrox_sample`\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jejjohnson/pyrox/blob/main/docs/notebooks/regression_masterclass_pyrox_sample.ipynb)\n",

--- a/notebooks/pyrox/masterclass/regression_masterclass_treeat.ipynb
+++ b/notebooks/pyrox/masterclass/regression_masterclass_treeat.ipynb
@@ -5,6 +5,10 @@
    "id": "a049fd4c",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Pattern 1 — `eqx.tree_at`\"\n",
+    "---\n",
+    "\n",
     "# Regression Masterclass — Pattern 1: `eqx.tree_at` + raw NumPyro\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jejjohnson/pyrox/blob/main/docs/notebooks/regression_masterclass_treeat.ipynb)\n",

--- a/projects/gaussianization/README.md
+++ b/projects/gaussianization/README.md
@@ -1,0 +1,84 @@
+---
+title: Gaussianization flows — pure-Keras bijectors and density estimation
+---
+
+# Gaussianization flows
+
+A self-contained sub-project for **Gaussianization flows** — normalising flows built from two kinds of bijectors stacked in blocks:
+
+1. **Rotation** — a trainable Householder product `Q = H_0 … H_{K-1}` or a fixed orthogonal matrix (optionally initialised from the data PCA).
+2. **Marginal transform** — a per-dim mixture-CDF Gaussianization `u_i = F_i(x_i)`, `z_i = Φ⁻¹(u_i)`.
+
+Both operators are **pure Keras 3** layers that work across TensorFlow, JAX, and PyTorch back-ends via `keras.ops`. The library also ships a conditional **coupling** variant driven by an MLP conditioner, and an **iterative-Gaussianization** warm-start (`initialize_flow_from_ig`) that greedy-fits each block to the data before gradient training.
+
+## Sub-package
+
+- [`gauss_keras`](src/gaussianization/gauss_keras/) — the full library:
+  - `bijectors.rotation` — `Householder`, `FixedOrtho` (+ `from_pca` factory).
+  - `bijectors.marginal` — `MixtureCDFGaussianization` (mixture-CDF forward + bisection inverse).
+  - `bijectors.coupling` — `MixtureCDFCoupling` with user-supplied conditioner, plus `make_mlp_conditioner` / `make_shared_mlp_conditioner` builders.
+  - `bijectors.flow` — `GaussianizationFlow` model (`log_prob`, `sample`, `invert`, `forward_with_intermediates`).
+  - `ig_init` — `initialize_flow_from_ig(flow, X)`, the iterative-Gaussianization warm-start using sklearn PCA + GMM.
+  - `training` — `base_nll_loss` + `make_gaussianization_flow` / `make_coupling_flow` factories.
+
+## Notebooks
+
+- [01_gaussianization_2d](notebooks/01_gaussianization_2d.ipynb) — canonical Gaussianization flow on the two-moons distribution; compares iterative and parametric formulations.
+- [02_coupling_flow_2d](notebooks/02_coupling_flow_2d.ipynb) — coupling flow with a mixture-CDF bijector driven by an MLP conditioner; dissects residual / bijector layers and shapes.
+- [03_iterative_gaussianization_init](notebooks/03_iterative_gaussianization_init.ipynb) — warm-start initialisation with `initialize_flow_from_ig`, compared head-to-head against random init on both diagonal and coupling flows.
+- [04_coupling_equivalence](notebooks/04_coupling_equivalence.ipynb) — proof (and empirical check) that a zero-kernel-initialised coupling flow is numerically equivalent to its diagonal-marginal counterpart; training then breaks that equivalence.
+
+## Layout
+
+```
+projects/gaussianization/
+├── pyproject.toml                        # standalone package "gaussianization"
+├── src/gaussianization/gauss_keras/
+│   ├── _math.py                          # standard-normal CDF / quantile / log pdf
+│   ├── mixtures/gaussian.py              # MixtureOfGaussians (cdf, pdf, log_pdf)
+│   ├── bijectors/
+│   │   ├── base.py                       # Bijector ABC + hybrid call
+│   │   ├── rotation.py                   # Householder, FixedOrtho
+│   │   ├── marginal.py                   # MixtureCDFGaussianization
+│   │   ├── coupling.py                   # MixtureCDFCoupling + conditioner builders
+│   │   ├── flow.py                       # GaussianizationFlow model
+│   │   └── _householder_decomp.py        # QR decomposition helper
+│   ├── ig_init.py                        # iterative-Gaussianization warm-start
+│   └── training.py                       # loss + flow factories
+├── notebooks/
+└── tests/
+```
+
+## Running
+
+The package is a standalone Python project under `projects/gaussianization/`. Tests default to the TensorFlow backend (set via `KERAS_BACKEND`); JAX and PyTorch back-ends also work, they just aren't exercised in CI.
+
+```bash
+cd projects/gaussianization
+uv sync --all-extras          # or: pip install -e ".[dev,notebooks]"
+KERAS_BACKEND=tensorflow uv run pytest tests -v
+```
+
+## Public API
+
+```python
+from gaussianization.gauss_keras import (
+    # core bijectors
+    Bijector,
+    Householder, FixedOrtho,
+    MixtureCDFGaussianization,
+    MixtureCDFCoupling,
+    # flow + training helpers
+    GaussianizationFlow,
+    base_nll_loss,
+    make_gaussianization_flow, make_coupling_flow,
+    # coupling conditioner builders
+    default_half_mask,
+    make_mlp_conditioner, make_shared_mlp_conditioner,
+    tanh_log_scale_clamp, sigmoid_log_scale_clamp,
+    # iterative-Gaussianization warm-start
+    initialize_flow_from_ig,
+    # mixture primitive
+    MixtureOfGaussians,
+)
+```

--- a/projects/gaussianization/notebooks/01_gaussianization_2d.ipynb
+++ b/projects/gaussianization/notebooks/01_gaussianization_2d.ipynb
@@ -5,6 +5,10 @@
    "id": "9653e470",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Flow on two-moons\"\n",
+    "---\n",
+    "\n",
     "# Gaussianization Flow on Two-Moons\n",
     "\n",
     "A minimal demonstration of a *Gaussianization flow* — a normalising flow built from two kinds of bijectors stacked in blocks:\n",

--- a/projects/gaussianization/notebooks/02_coupling_flow_2d.ipynb
+++ b/projects/gaussianization/notebooks/02_coupling_flow_2d.ipynb
@@ -5,6 +5,10 @@
    "id": "89267111",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Coupling flow\"\n",
+    "---\n",
+    "\n",
     "# Coupling Flow with Mixture-CDF Transform\n",
     "\n",
     "The first notebook trained a Gaussianization flow by stacking *unconditional* marginal layers (mixture CDF per dim) and rotations. The marginal layers can only Gaussianize each dimension independently; cross-dimensional structure is left entirely to the rotations.\n",

--- a/projects/gaussianization/notebooks/03_iterative_gaussianization_init.ipynb
+++ b/projects/gaussianization/notebooks/03_iterative_gaussianization_init.ipynb
@@ -5,6 +5,10 @@
    "id": "1d082861",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"IG warm-start init\"\n",
+    "---\n",
+    "\n",
     "# Iterative-Gaussianization warm start\n",
     "\n",
     "Notebooks 01 and 02 trained Gaussianization / coupling flows from *random* initialisation. That works, but spends the first hundreds of epochs pulling the flow from a near-identity map towards the data.\n",

--- a/projects/gaussianization/notebooks/04_coupling_equivalence.ipynb
+++ b/projects/gaussianization/notebooks/04_coupling_equivalence.ipynb
@@ -5,6 +5,10 @@
    "id": "1943cfe5",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Zero-kernel ≡ diagonal\"\n",
+    "---\n",
+    "\n",
     "# Zero-kernel coupling  ≡  diagonal Gaussianization\n",
     "\n",
     "A coupling flow with mixture-CDF blocks normally captures cross-dim dependence via the conditioner. But when the conditioner is *zero-initialised* — specifically, when the **final** Dense of the conditioner has kernel $W = 0$ — something interesting happens: the flow collapses into a plain diagonal Gaussianization flow.\n",

--- a/projects/plume_simulation/notebooks/gauss_puff/01_gaussian_puff_forward.ipynb
+++ b/projects/plume_simulation/notebooks/gauss_puff/01_gaussian_puff_forward.ipynb
@@ -5,6 +5,10 @@
    "id": "e1f44ac9",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Puff — forward simulation\"\n",
+    "---\n",
+    "\n",
     "# Gaussian puff — forward simulation\n",
     "\n",
     "This notebook exercises the time-resolved Gaussian-puff forward model in `plume_simulation.gauss_puff`. Unlike the steady plume, the puff model releases a sequence of instantaneous puffs at fixed cadence; each puff travels with the (possibly time-varying) wind and spreads as a 3-D Gaussian. The total concentration field is the superposition of all active puffs.\n",

--- a/projects/plume_simulation/notebooks/gauss_puff/02_emission_rate_parameter_estimation.ipynb
+++ b/projects/plume_simulation/notebooks/gauss_puff/02_emission_rate_parameter_estimation.ipynb
@@ -5,6 +5,10 @@
    "id": "91f81b5e",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Puff — parameter estimation\"\n",
+    "---\n",
+    "\n",
     "# Gaussian puff — parameter estimation of a constant emission rate\n",
     "\n",
     "Given a time-series of concentration observations at a handful of downwind sensors, we invert the puff forward model to recover the source emission rate Q. The setup closely parallels the plume parameter-estimation notebook, but the puff model's time-axis means each observation carries its own evaluation time — the NUTS posterior absorbs both spatial variation and the puff-cadence structure of the field.\n",

--- a/projects/plume_simulation/notebooks/gauss_puff/03_puff_state_estimation.ipynb
+++ b/projects/plume_simulation/notebooks/gauss_puff/03_puff_state_estimation.ipynb
@@ -5,6 +5,10 @@
    "id": "998d7f88",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Puff — state estimation\"\n",
+    "---\n",
+    "\n",
     "# Gaussian puff — state estimation of a time-varying emission rate\n",
     "\n",
     "When the source strength changes over time — a turned-valve event, a burst, or a slowly-modulating leak — fitting a *constant* Q to observations is model-mis-specified. The posterior mean becomes the time-average of the true Q series, and per-time residuals inflate the inferred observation noise. The puff model is natively time-indexed (each puff has its own release time), so we can relax the constant-Q assumption by giving each puff its own Q_i with a **Gaussian random-walk prior** on `ln Q_i`.\n",

--- a/projects/plume_simulation/notebooks/les_fvm/01_eulerian_dispersion_l2.ipynb
+++ b/projects/plume_simulation/notebooks/les_fvm/01_eulerian_dispersion_l2.ipynb
@@ -5,6 +5,10 @@
    "id": "5bed063f",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Eulerian — forward demo\"\n",
+    "---\n",
+    "\n",
     "# Eulerian 3-D dispersion (L2) — forward-model demo\n",
     "\n",
     "This notebook exercises `plume_simulation.les_fvm.simulate_eulerian_dispersion` on two scenarios: (a) a steady uniform wind, and (b) a time-varying wind described by a `gauss_puff.wind.WindSchedule`. We plot horizontal and vertical slices of the methane concentration and the column-integrated tracer as sanity checks. For the underlying math and numerical scheme see [00_eulerian_dispersion_derivation.md](00_eulerian_dispersion_derivation.md)."

--- a/projects/plume_simulation/notebooks/les_fvm/03_puff_vs_eulerian.ipynb
+++ b/projects/plume_simulation/notebooks/les_fvm/03_puff_vs_eulerian.ipynb
@@ -5,6 +5,10 @@
    "id": "cfef8393",
    "metadata": {},
    "source": [
+    "---\n",
+    "title: \"Puff vs Eulerian\"\n",
+    "---\n",
+    "\n",
     "# Cross-check: Gaussian puff (L1) vs Eulerian finite volume (L2)\n",
     "\n",
     "The two models solve the *same* tracer transport equation under different simplifying assumptions, so pointwise agreement is **not** expected. What *should* agree is:\n",


### PR DESCRIPTION
## Summary

- Adds the four gaussianization notebooks (merged in #18) to the MyST TOC under a new **Projects / Gaussianization flows** section, with a new `projects/gaussianization/README.md` as the section landing page (matching the pattern used by `methane_pod` and `plume_simulation`).
- Shortens long sidebar titles across the book via MyST `title:` frontmatter blocks — the same pattern already in use for the methane_pod notebooks. The on-page H1s are untouched; only sidebar / breadcrumb / browser-tab titles change.

Scope: 27 notebooks touched. Diff is minimal — each notebook gets a 4-line frontmatter block prepended to its first markdown cell; no outputs, code, or body prose are modified.

### Short titles applied

| Area | Before → After |
|---|---|
| gaussianization × 4 | `Gaussianization Flow on Two-Moons` → `Flow on two-moons`, etc. |
| pyrox/gp × 2 | `Exact GP Regression — the Three Patterns` → `Exact GP regression` |
| pyrox/masterclass × 3 | `Regression Masterclass — Pattern N: …` → `Pattern N — \`...\`` |
| pyrox/ensembles × 2 | `Ensemble … Tutorial — …` → `Ensemble primitives` / `Ensemble runners` |
| coordax/foundations × 4 | `Part N: Long Prose (Sub-prose)` → short imperative (e.g. `Reductions`) |
| coordax/derivatives × 3 | `Part 5.x: …` → `Finite-difference gradients`, etc. |
| coordax/dynamics × 3 | `Part 6.x: …` → `ODE integration (Diffrax)`, etc. |
| plume_simulation/gauss_puff × 3 | `Gaussian puff — …` → `Puff — …` |
| plume_simulation/les_fvm × 2 | `Eulerian 3-D dispersion (L2) — …` → `Eulerian — …` |

Left alone: existing frontmatter-curated titles in `methane_pod/` and `plume_simulation/*` plume + derivation `.md` files (already short-ish, user-curated).

## Test plan

- [x] Every `file:` entry in `myst.yml` resolves to a `.md` or `.ipynb` on disk (57/57).
- [x] Every touched notebook parses as valid JSON and has a `title:` frontmatter in its first markdown cell (26/26).
- [ ] Visual spot-check the rendered site sidebar after CI deploys, confirm no title is wrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)