### PR TITLE
docs(interpolation): add SSH reconstruction project (5 derivation notes)

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -109,6 +109,14 @@ project:
             - file: projects/gaussianization/notebooks/02_coupling_flow_2d
             - file: projects/gaussianization/notebooks/03_iterative_gaussianization_init
             - file: projects/gaussianization/notebooks/04_coupling_equivalence
+        - title: Interpolation (SSH reconstruction)
+          children:
+            - file: projects/interpolation/README
+            - file: projects/interpolation/notebooks/00_ssh_pathwise_sampling
+            - file: projects/interpolation/notebooks/01_efficient_machinery
+            - file: projects/interpolation/notebooks/02_physics_aware_ssh
+            - file: projects/interpolation/notebooks/03_global_scaling_patches
+            - file: projects/interpolation/notebooks/04_variational_dynamical_priors
         - title: Gaussian processes
           children:
             - file: projects/gaussian_processes/README

--- a/projects/interpolation/README.md
+++ b/projects/interpolation/README.md
@@ -1,0 +1,102 @@
+---
+title: Interpolation — sparse-to-dense reconstruction of geophysical fields
+---
+
+# Interpolation
+
+Worked examples for spatial and spatiotemporal interpolation of geophysical fields from sparse, irregular observations — anchored on **sea-surface-height (SSH) reconstruction from satellite altimetry** as the running case study. The current entry point is a **Gaussian-process pathwise sampler** built on [`gaussx`](https://github.com/jejjohnson/gaussx) and [`pyrox`](https://github.com/jejjohnson/pyrox), but the notes also place that recipe in context against the wider menu of methods used in operational SSH mapping (DUACS, MIOST, DYMOST, BFN-QG, 4DVarNet) so the trade-offs are explicit.
+
+The notes are deliberately **derivation-first**: math, complexity, and references before any code. The goal is that someone reading them — including future-me — can pick the right tool for the job without re-deriving the screening property of local GP inversions or re-discovering that MIOST wavelets are just sparse RFF features in disguise.
+
+```{important}
+Five short notes, in increasing order of structural sophistication. Each one builds directly on the previous; jumping in at 03 without reading 00–01 will not work.
+```
+
+## Reading order
+
+| # | Note | Layer | What you get |
+|---|---|---|---|
+| 00 | [GP pathwise sampling for SSH](notebooks/00_ssh_pathwise_sampling.md) | Math | Matheron's-rule conditioning by sampling, derived from scratch for a Mediterranean SSH problem. Storage + compute analysis. |
+| 01 | [Efficient machinery from gaussx + pyrox](notebooks/01_efficient_machinery.md) | Compute | Matrix-free kernels, preconditioned CG, Woodbury, LOVE variance, the `PathwiseSampler` drop-in. Wall-clock budgets for MedSea / N. Atlantic / global, 1–6 months. |
+| 02 | [Physics-aware SSH reconstruction](notebooks/02_physics_aware_ssh.md) | Prior | Two axes — modify the data $y$ (preprocessing, derivative obs from drifters), modify the kernel $K$ (SQG spectral prior, MIOST multi-scale Gabor wavelets). |
+| 03 | [Scaling to the globe with patch decomposition](notebooks/03_global_scaling_patches.md) | Geometry | Local-GP recipe at global scale via `xrpatcher` + `BallTree` + Gaspari–Cohn overlap-add + dask. ~800× speed-up over monolithic global GP. |
+| 04 | [Variational SSH reconstruction with dynamical priors](notebooks/04_variational_dynamical_priors.md) | Outside framework | 3D-Var / 4D-Var / DYMOST / BFN-QG / 4DVarNet — methods that replace the GP prior with QG dynamics or a learned regulariser. Comparison targets, not extensions. |
+
+## Highlights at a glance
+
+```{note}
+**00 — pathwise GP**: $\mathcal{O}(m^3 + nm)$ naïvely; $4\,\text{GB}$ peak memory just to materialise $K_{\mathcal{X}^*\mathcal{X}}$.
+```
+
+```{tip}
+**01 — wall-clock budget** with the matrix-free machinery on an A100, full SWOT-era data:
+
+| Region | 1 month | 3 months | 6 months |
+|---|---|---|---|
+| Mediterranean | 3 s (RFF+) / 2 min (exact) | 9 s / 6 min | 18 s / 12 min |
+| North Atlantic | 20 s (RFF+) / 10 h (exact) | 1 min / 30 h | 2 min / 60 h |
+| Global ocean | 2.5 min (RFF+) / **infeasible** (exact) | 7.5 min | 15 min |
+
+Patch decomposition (03) brings global *exact* GP down to 12 s/day on 8× A100.
+```
+
+```{seealso}
+- [`gaussx`](https://github.com/jejjohnson/gaussx) — structured linear algebra primitives the 00/01 pipeline is built on
+- [`pyrox`](https://github.com/jejjohnson/pyrox) — pathwise sampler + RFF feature primitives
+- [`xrpatcher`](https://github.com/jejjohnson/xrpatcher) — patch-extraction layer used in 03
+- The plume-simulation project's [3D-Var note](../plume_simulation/notebooks/assimilation/00_3dvar_derivation.md) — companion derivation in the methane-retrieval setting; equations are identical
+```
+
+## Map of methods
+
+The five notes cover three different framings of the same SSH-mapping problem:
+
+```text
+                       ┌─────────────────────────────┐
+                       │   Sparse altimeter obs y    │
+                       │   on a global ocean grid    │
+                       └──────────────┬──────────────┘
+                                      │
+              ┌───────────────────────┼───────────────────────┐
+              │                       │                       │
+              ▼                       ▼                       ▼
+    ┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
+    │  GP pathwise     │    │  Variational DA  │    │  Learned variant │
+    │  (00, 01, 02, 03)│    │  3DVar / 4DVar   │    │  4DVarNet  (04)  │
+    │                  │    │  DYMOST / BFN-QG │    │                  │
+    │  static prior K  │    │  dynamic prior   │    │  learned prior   │
+    │  closed-form     │    │  via QG model    │    │  Φ_θ autoencoder │
+    │  posterior + MC  │    │       (04)       │    │  + ConvLSTM solv │
+    └──────────────────┘    └──────────────────┘    └──────────────────┘
+```
+
+00–03 stay inside the static-prior GP world: the prior $K$ is a kernel, the inverse problem is linear, and the gaussx/pyrox stack does the work. 04 is a separate framework — a dynamical model replaces $K$, and the SSH community's ~50 years of variational data-assimilation work takes over. The two stacks meet at the boundary: see 04 §8 for two practical hybrid recipes (GP residual after a dynamical first guess; GP warm-start for 4DVarNet).
+
+## Layout
+
+```text
+projects/interpolation/
+├── README.md                                       # this file
+└── notebooks/
+    ├── 00_ssh_pathwise_sampling.md                 # math derivation
+    ├── 01_efficient_machinery.md                   # gaussx + pyrox primitives + wall-clock
+    ├── 02_physics_aware_ssh.md                     # data + kernel knobs (DATA / KERNEL axes)
+    ├── 03_global_scaling_patches.md                # patch decomp via xrpatcher + dask
+    └── 04_variational_dynamical_priors.md          # 3DVar / 4DVar / DYMOST / BFN-QG / 4DVarNet
+```
+
+No `src/` package yet — these are derivations and pseudocode, not a runnable port. A future iteration of the project would add a `plume_simulation`-style `src/interpolation/` package implementing the patch-decomposition pipeline from 03 against real CMEMS data.
+
+## Running
+
+These notes are pure Markdown — they render directly in MyST without execution. There is no per-project pixi environment; the wider repo's `pyrox` env covers the package vocabulary referenced in the pseudocode.
+
+```bash
+# View locally as part of the MyST book
+make docs-serve
+
+# Or open any single note in VS Code with the MyST extension for inline math
+code projects/interpolation/notebooks/00_ssh_pathwise_sampling.md
+```
+
+Run all commands from the repo root.

--- a/projects/interpolation/notebooks/00_ssh_pathwise_sampling.md
+++ b/projects/interpolation/notebooks/00_ssh_pathwise_sampling.md
@@ -1,0 +1,385 @@
+---
+title: "SSH reconstruction via GP pathwise sampling"
+---
+
+# SSH Reconstruction via GP Pathwise Sampling
+
+## The Inverse Problem
+
+**Goal:** Reconstruct the SSH anomaly field $\eta$ on a regular grid at a fixed target time $t$, using satellite altimeter tracks from a temporal window $[t - \tau, t + \tau]$. This is a **pure static inverse problem** — no dynamics, no time-stepping. We treat the SSH field as approximately stationary over the window and let the kernel handle temporal discounting automatically.
+
+**Why pool $t \pm \tau$?** A single Jason-3 pass covers roughly 1–5% of the Mediterranean at any given time, with a 10-day repeat cycle. A single Sentinel-6 pass is similar. Pooling passes from nearby times dramatically increases spatial coverage. The cost is a temporal mismatch — observations at $t \pm \tau$ represent the field at slightly different states. Rather than manually inflating error variances (as 3D-Var does), the GP handles this gracefully: a spatiotemporal kernel naturally assigns lower covariance to observation pairs that are far apart in time, so temporally distant tracks are automatically downweighted during inference.
+
+---
+
+## Domain and State
+
+| Symbol | Shape | Meaning |
+|---|---|---|
+| $n_{lat}, n_{lon}$ | scalars | Number of grid cells in latitude and longitude |
+| $n = n_{lat} \times n_{lon}$ | scalar | Total grid cells — e.g. $0.1°$ grid over Med $\approx 10^5$ |
+| $\eta \in \mathbb{R}^n$ | $(n,)$ | SSH anomaly field at time $t$, vectorised row-major over the grid |
+
+The field $\eta$ is what we want to recover. It is unobserved everywhere except along sparse satellite swaths.
+
+---
+
+## Observations
+
+Satellite altimeters sample SSH along 1D ground tracks — narrow strips that cross the Mediterranean at oblique angles. We pool three groups of passes:
+
+| Symbol | Shape | Meaning |
+|---|---|---|
+| $y_- \in \mathbb{R}^{m_-}$ | $(m_-,)$ | Along-track SSH anomaly measurements at time $t - \tau$ |
+| $y_0 \in \mathbb{R}^{m_0}$ | $(m_0,)$ | Along-track SSH anomaly measurements at time $t$ |
+| $y_+ \in \mathbb{R}^{m_+}$ | $(m_+,)$ | Along-track SSH anomaly measurements at time $t + \tau$ |
+| $y = [y_-;\, y_0;\, y_+]$ | $(m,)$ | Full concatenated observation vector, $m = m_- + m_0 + m_+$ |
+
+Typical values for the Mediterranean: $m_\pm \sim 500$–$2000$ per pass group, $m \sim 3000$–$8000$ total. Each observation $y_i$ has an associated position $(lon_i, lat_i)$ and time $t_i \in \{t-\tau, t, t+\tau\}$.
+
+---
+
+## The GP Prior
+
+A Gaussian process is a distribution over functions. Writing $f: \mathcal{X} \to \mathbb{R}$ where $\mathcal{X}$ is the joint (space, time) domain:
+
+$$f \sim \mathrm{GP}(0, k_\theta)$$
+
+This means: for any finite collection of inputs $\{(x_i, t_i)\}_{i=1}^m$, the vector of function values $[f(x_1, t_1), \ldots, f(x_m, t_m)]$ is jointly Gaussian with zero mean and covariance matrix whose $(i,j)$ entry is $k_\theta((x_i, t_i), (x_j, t_j))$.
+
+The **kernel** $k_\theta$ is the sole prior specification — it encodes everything we believe about the SSH field before seeing data: how smooth it is, how quickly correlations decay in space and time, and what its overall amplitude is.
+
+Zero mean is appropriate here because we work with SSH **anomalies** (mean SSH removed), so the prior mean is zero by construction.
+
+---
+
+## Training and Prediction Inputs
+
+The GP operates directly on (lon, lat, time) coordinates — no grid required at training time. Define:
+
+$$\mathcal{X} = \begin{bmatrix} lon_1^- & lat_1^- & t-\tau \\ \vdots & \vdots & \vdots \\ lon_{m_-}^- & lat_{m_-}^- & t-\tau \\ lon_1^0 & lat_1^0 & t \\ \vdots & \vdots & \vdots \\ lon_{m_+}^+ & lat_{m_+}^+ & t+\tau \end{bmatrix} \in \mathbb{R}^{m \times 3}$$
+
+Each row is one satellite observation's (lon, lat, time) coordinate. The prediction inputs are all grid cells at time $t$:
+
+$$\mathcal{X}^* = \begin{bmatrix} lon_1^* & lat_1^* & t \\ \vdots & \vdots & \vdots \\ lon_n^* & lat_n^* & t \end{bmatrix} \in \mathbb{R}^{n \times 3}$$
+
+All prediction points share the same time $t$ — we want the reconstructed field at the target time only.
+
+---
+
+## Kernel — Encoding Prior Physics
+
+Use a **separable spatiotemporal kernel** — separable means the spatial and temporal contributions multiply:
+
+$$k_\theta\!\left((x, t),\, (x', t')\right) = \sigma_\eta^2 \cdot k_s(x, x';\, L_s) \cdot k_t(t, t';\, L_t)$$
+
+### Spatial Kernel — Matérn-3/2
+
+The Matérn-3/2 kernel on the sphere (using great-circle distance $d$):
+
+$$k_s(x, x';\, L_s) = \left(1 + \frac{\sqrt{3}\,d(x,x')}{L_s}\right)\exp\!\left(-\frac{\sqrt{3}\,d(x,x')}{L_s}\right)$$
+
+**Why Matérn-3/2 and not Gaussian?** The squared-exponential (Gaussian) kernel produces infinitely differentiable sample paths — unrealistically smooth for SSH. Matérn-3/2 produces once mean-square differentiable paths, which is physically appropriate for mesoscale SSH fields that have sharp fronts and eddy boundaries. Matérn-5/2 (twice differentiable) is also a reasonable choice.
+
+**Why great-circle distance?** The Mediterranean spans enough longitude (~40°) that planar Euclidean distance is inaccurate. Great-circle distance respects the spherical geometry.
+
+### Temporal Kernel — Ornstein-Uhlenbeck
+
+$$k_t(t, t';\, L_t) = \exp\!\left(-\frac{|t - t'|}{L_t}\right)$$
+
+The OU kernel (Matérn-1/2) produces exponentially decaying temporal correlations. **The key physical consequence:** observations at $t \pm \tau$ contribute to the reconstruction at time $t$ with a weight of $\exp(-\tau / L_t)$ — automatically. If $L_t = 10$ days and $\tau = 3$ days, this factor is $\exp(-0.3) \approx 0.74$, meaning observations 3 days away carry about 74% of the weight of contemporaneous observations. No manual tuning of temporal weights needed.
+
+### Hyperparameters
+
+| Parameter | Meaning | Typical value (Med) |
+|---|---|---|
+| $\sigma_\eta^2$ | SSH anomaly marginal variance | $\sim 100\,\text{cm}^2$ |
+| $L_s$ | Spatial decorrelation length | $\sim 100\,\text{km}$ |
+| $L_t$ | Temporal decorrelation timescale | $\sim 10\,\text{days}$ |
+| $\sigma_{obs}^2$ | Altimeter noise variance | $\sim 4\,\text{cm}^2$ |
+
+---
+
+## Key Matrices
+
+These are the four objects that define all subsequent computation.
+
+**Gram matrix at training points:**
+
+$$K_{\mathcal{X}\mathcal{X}} \in \mathbb{R}^{m \times m}, \qquad [K_{\mathcal{X}\mathcal{X}}]_{ij} = k_\theta(\mathcal{X}_i, \mathcal{X}_j)$$
+
+This is a **dense symmetric PSD matrix**. Entry $(i,j)$ is the prior covariance between observations $i$ and $j$ — it encodes how similar the SSH field is expected to be at those two (location, time) pairs. Observations close in space and time will have high covariance; observations far apart will have near-zero covariance. The diagonal $[K_{\mathcal{X}\mathcal{X}}]_{ii} = \sigma_\eta^2$ (the full prior variance at each point).
+
+**Noisy Gram matrix:**
+
+$$C = K_{\mathcal{X}\mathcal{X}} + \sigma_{obs}^2 I_m \in \mathbb{R}^{m \times m}$$
+
+Adding $\sigma_{obs}^2 I_m$ accounts for altimeter instrument noise — it regularises the Gram matrix (ensuring it is strictly PD) and prevents overfitting to noisy observations. $C$ is the object we invert — it represents the total observation-space covariance including noise.
+
+**Cross-covariance matrix:**
+
+$$K_{\mathcal{X}^*\mathcal{X}} \in \mathbb{R}^{n \times m}, \qquad [K_{\mathcal{X}^*\mathcal{X}}]_{ij} = k_\theta(\mathcal{X}^*_i, \mathcal{X}_j)$$
+
+Row $i$ of this matrix is the prior covariance between grid cell $i$ (at time $t$) and observation $j$ (at its (location, time)). This is the **gain numerator** — it determines how strongly each observation influences each grid cell. A grid cell far from all tracks will have small entries across its entire row, meaning observations barely update it. A grid cell directly under a track will have large entries for nearby observations.
+
+**Prior variance at prediction points (diagonal only):**
+
+$$[K_{\mathcal{X}^*\mathcal{X}^*}]_{ii} = k_\theta(\mathcal{X}^*_i, \mathcal{X}^*_i) = \sigma_\eta^2 \quad \forall i$$
+
+Since all prediction points share time $t$ and the spatial kernel equals 1 at zero distance, the prior variance is $\sigma_\eta^2$ uniformly. The full matrix $K_{\mathcal{X}^*\mathcal{X}^*} \in \mathbb{R}^{n \times n}$ is never formed.
+
+---
+
+## Posterior Derivation
+
+The GP prior and the observation model:
+
+$$y = f(\mathcal{X}) + \varepsilon, \qquad \varepsilon \sim \mathcal{N}(0, \sigma_{obs}^2 I_m)$$
+
+together define a joint Gaussian over $(f(\mathcal{X}^*), y)$:
+
+$$\begin{bmatrix} f(\mathcal{X}^*) \\ y \end{bmatrix} \sim \mathcal{N}\!\left( \begin{bmatrix} 0 \\ 0 \end{bmatrix},\ \begin{bmatrix} K_{\mathcal{X}^*\mathcal{X}^*} & K_{\mathcal{X}^*\mathcal{X}} \\ K_{\mathcal{X}\mathcal{X}^*} & C \end{bmatrix} \right)$$
+
+Applying the Gaussian conditioning formula from the unifying framework with:
+
+$$\Sigma_{xx} = K_{\mathcal{X}^*\mathcal{X}^*}, \quad \Sigma_{xz} = K_{\mathcal{X}^*\mathcal{X}}, \quad \Sigma_{zz} = C$$
+
+the posterior is:
+
+$$f(\mathcal{X}^*) \mid y \;\sim\; \mathcal{N}\!\left(\mu_{f|y},\; \Sigma_{f|y}\right)$$
+
+$$\mu_{f|y} = K_{\mathcal{X}^*\mathcal{X}}\, C^{-1}\, y \qquad (n,)$$
+
+$$\Sigma_{f|y} = K_{\mathcal{X}^*\mathcal{X}^*} - K_{\mathcal{X}^*\mathcal{X}}\, C^{-1}\, K_{\mathcal{X}\mathcal{X}^*} \qquad (n, n)$$
+
+The posterior mean $\mu_{f|y}$ is the **minimum mean-square error estimate** of the SSH field — the best single map you can produce. The posterior covariance $\Sigma_{f|y}$ describes the joint uncertainty over all grid cells — but at $(n \times n)$ it is completely intractable to store or compute for $n = 10^5$.
+
+**Practical posterior quantities:** We never compute $\Sigma_{f|y}$ directly. Instead:
+
+- **Pointwise variance** (diagonal only): $[\Sigma_{f|y}]_{ii} = \sigma_\eta^2 - [K_{\mathcal{X}^*\mathcal{X}}\, C^{-1}\, K_{\mathcal{X}\mathcal{X}^*}]_{ii}$ — computed row by row, cost $\mathcal{O}(nm^2)$.
+- **Posterior samples** via pathwise update — this is the subject of the next section.
+
+---
+
+## The Pathwise Update — Correcting Prior Samples
+
+The standard posterior mean formula above requires $C^{-1}y$ — a single linear solve. That gives you a point estimate. To get **samples from the posterior**, the naive approach would be to Cholesky-factorise the $(n \times n)$ posterior covariance $\Sigma_{f|y}$ — completely intractable.
+
+**Matheron's rule** (Wilson et al., 2020) provides an exact alternative. The key insight is that for Gaussian random variables, the conditional distribution can be written as a **linear correction to a joint prior sample**:
+
+$$f(\mathcal{X}^*) \mid y \;\overset{d}{=}\; \tilde{f}(\mathcal{X}^*) + K_{\mathcal{X}^*\mathcal{X}}\, C^{-1}\,\bigl(y - \tilde{f}(\mathcal{X})\bigr)$$
+
+where $(\tilde{f}(\mathcal{X}^*), \tilde{f}(\mathcal{X}))$ is a **joint prior sample** drawn consistently from $\mathrm{GP}(0, k_\theta)$ at both the prediction and training inputs. This equality is in distribution — the right-hand side is an exact draw from the posterior $p(f \mid y)$.
+
+**Why does this work?** Because the correction term is the posterior mean applied not to $y$ but to the **innovation** $y - \tilde{f}(\mathcal{X})$. Since $(\tilde{f}(\mathcal{X}^*), \tilde{f}(\mathcal{X}))$ are jointly Gaussian, the correction is linear, and the result has exactly the right mean and covariance.
+
+**Why is this better than sampling from $\Sigma_{f|y}$ directly?**
+
+- Sampling from $\Sigma_{f|y}$ requires an $(n \times n)$ Cholesky: $\mathcal{O}(n^3)$ compute, $\mathcal{O}(n^2)$ storage — completely intractable for $n = 10^5$.
+- The pathwise update only requires an $(m \times m)$ Cholesky (computed once) plus an $\mathcal{O}(r(m+n))$ prior sample generation and an $\mathcal{O}(nm)$ mat-vec. All operations scale in $m$ and $n$ independently.
+
+---
+
+## Prior Sample via Random Fourier Features
+
+To apply Matheron's rule we need a joint prior sample $(\tilde{f}(\mathcal{X}^*), \tilde{f}(\mathcal{X}))$ drawn consistently from $\mathrm{GP}(0, k_\theta)$.
+
+Bochner's theorem guarantees that a stationary kernel $k_\theta(x, x') = k_\theta(x - x')$ can be written as the Fourier transform of a spectral density $p(\omega)$:
+
+$$k_\theta(x - x') = \int p(\omega)\, e^{i\omega^\top(x - x')}\, d\omega$$
+
+This motivates the **Random Fourier Features (RFF)** approximation. Sample $r$ frequency vectors $\{\omega_j\}_{j=1}^r$ from $p(\omega)$ and draw uniform phase offsets $\{b_j\}_{j=1}^r \sim \mathrm{Uniform}[0, 2\pi]$. Define the feature map:
+
+$$\phi_j(x) = \sqrt{\frac{2\sigma_\eta^2}{r}}\,\cos(\omega_j^\top x + b_j)$$
+
+Then the approximate prior sample is:
+
+$$\tilde{f}(x, t) = \sum_{j=1}^{r} w_j\, \phi_j^s(x)\, \phi_j^t(t), \qquad w_j \overset{\text{iid}}{\sim} \mathcal{N}(0, 1)$$
+
+where $\phi_j^s$ and $\phi_j^t$ are RFF features for the spatial and temporal kernels respectively (drawn once from their spectral densities). The weights $\{w_j\}$ are **fixed for a given sample draw** — evaluating $\tilde{f}$ at any point is then a deterministic computation.
+
+**Consistency:** because $\{w_j\}$ are fixed, evaluating $\tilde{f}$ at $\mathcal{X}$ and $\mathcal{X}^*$ uses the **same weights** — this is what makes the prior sample joint and consistent, which is required for Matheron's rule to produce exact posterior draws.
+
+**How many features $r$?** The RFF approximation introduces a bias of $\mathcal{O}(1/\sqrt{r})$ in the kernel approximation. For SSH reconstruction, $r \sim 1000$–$4000$ is typically sufficient. The approximation error in the posterior sample decreases as $r$ increases; the compute cost grows as $\mathcal{O}(r(m+n))$ per sample.
+
+---
+
+## Full Algorithm
+
+### Offline (once per time window)
+
+**Step 1 — Build the Gram matrix:**
+
+$$[K_{\mathcal{X}\mathcal{X}}]_{ij} = \sigma_\eta^2 \cdot k_s\!\left(x_i, x_j;\, L_s\right) \cdot k_t\!\left(t_i, t_j;\, L_t\right) \qquad (m, m)$$
+
+Evaluate $m^2$ kernel calls. Each call computes a great-circle distance and evaluates Matérn-3/2 × OU — $\mathcal{O}(1)$ per pair.
+
+**Step 2 — Form and Cholesky-factorise $C$:**
+
+$$C = K_{\mathcal{X}\mathcal{X}} + \sigma_{obs}^2 I_m \qquad (m, m)$$
+
+$$C = LL^\top, \qquad L \in \mathbb{R}^{m \times m} \text{ lower triangular}$$
+
+This is the **dominant computation**. $L$ is stored and reused for all subsequent solves and for every posterior sample.
+
+**Step 3 — Compute the posterior mean coefficient vector:**
+
+$$\alpha = C^{-1}y = L^{-\top}L^{-1}y \qquad (m,)$$
+
+Two triangular solves. $\alpha$ is the vector of **dual weights** — entry $\alpha_i$ is the weight assigned to observation $i$ in the posterior mean. Observations with high $\alpha_i$ are highly informative; those in dense clusters will have smaller $\alpha_i$ due to redundancy.
+
+**Step 4 — Build the cross-covariance matrix:**
+
+$$[K_{\mathcal{X}^*\mathcal{X}}]_{ij} = \sigma_\eta^2 \cdot k_s\!\left(x_i^*, x_j;\, L_s\right) \cdot k_t\!\left(t, t_j;\, L_t\right) \qquad (n, m)$$
+
+Evaluate $nm$ kernel calls. Since all prediction points share time $t$, the temporal factor $k_t(t, t_j; L_t)$ takes only three distinct values (one per time group $t-\tau, t, t+\tau$) — this allows factoring:
+
+$$K_{\mathcal{X}^*\mathcal{X}} = \begin{bmatrix} e^{-\tau/L_t}\, K^*_s(-, L_s) & K^*_s(0, L_s) & e^{-\tau/L_t}\, K^*_s(+, L_s) \end{bmatrix}$$
+
+where $K^*_s(\star, L_s) \in \mathbb{R}^{n \times m_\star}$ is the purely spatial cross-covariance matrix between all grid points and the $\star$-group track locations. This factorisation reduces the number of unique kernel evaluations to $n(m_- + m_0 + m_+)$ spatial evaluations plus $m$ cheap exponential evaluations.
+
+**Step 5 — Compute the posterior mean field:**
+
+$$\mu_{f|y} = K_{\mathcal{X}^*\mathcal{X}}\, \alpha \qquad (n,)$$
+
+A dense mat-vec: $(n \times m)$ times $(m \times 1)$. This gives the **interpolated SSH field** on the grid at time $t$.
+
+### Per Posterior Sample (repeat $S$ times)
+
+**Step 6 — Draw RFF weights:**
+
+$$w_j \overset{\text{iid}}{\sim} \mathcal{N}(0, 1), \quad j = 1, \ldots, r$$
+
+Sample spatial frequencies $\omega_j^s$ from the Matérn-3/2 spectral density, temporal frequencies $\omega_j^t$ from the OU spectral density (both done once, reused across samples if desired, or redrawn for fresh samples).
+
+**Step 7 — Evaluate prior sample at training and prediction inputs:**
+
+$$\tilde{f}(\mathcal{X}) \in \mathbb{R}^m, \qquad \tilde{f}(\mathcal{X}^*) \in \mathbb{R}^n$$
+
+Each evaluation: form the $(m+n) \times r$ feature matrix $\Phi$, then multiply by $w$. Cost $\mathcal{O}(r(m+n))$.
+
+**Step 8 — Compute the innovation:**
+
+$$\delta = y - \tilde{f}(\mathcal{X}) \qquad (m,)$$
+
+This is the residual between what the prior sample predicts at the track locations and what was actually observed. If the prior sample happened to pass through the data exactly, $\delta = 0$ and no correction is needed — the prior sample is already a valid posterior draw (this never happens in practice).
+
+**Step 9 — Solve the correction coefficient vector:**
+
+$$\beta = C^{-1}\delta = L^{-\top}L^{-1}\delta \qquad (m,)$$
+
+Two triangular solves using the already-computed $L$. This is $\mathcal{O}(m^2)$ — cheap because $L$ is already available.
+
+**Step 10 — Apply the pathwise correction:**
+
+$$\boxed{\eta^*_s = \tilde{f}(\mathcal{X}^*) + K_{\mathcal{X}^*\mathcal{X}}\,\beta \qquad (n,)}$$
+
+One dense mat-vec: $(n \times m)$ times $(m \times 1)$. The result $\eta^*_s$ is one **exact posterior sample** of the SSH field on the grid at time $t$.
+
+---
+
+## What the Output Looks Like
+
+After $S$ samples $\{\eta^*_s\}_{s=1}^S$:
+
+**Posterior mean estimate** (best single map):
+
+$$\hat{\eta} = \frac{1}{S}\sum_{s=1}^S \eta^*_s \approx \mu_{f|y} \qquad (n,)$$
+
+For large $S$ this converges to the exact posterior mean $K_{\mathcal{X}^*\mathcal{X}}\alpha$ computed in Step 5 — but you may as well use Step 5 directly.
+
+**Pointwise posterior standard deviation** (uncertainty map):
+
+$$\hat{\sigma}(x_i^*) = \sqrt{\frac{1}{S-1}\sum_{s=1}^S (\eta^*_s(x_i^*) - \hat{\eta}(x_i^*))^2} \qquad (n,)$$
+
+Large $\hat{\sigma}$ where tracks are sparse; small $\hat{\sigma}$ under dense track coverage. This is physically interpretable — you know exactly where the reconstruction is trustworthy.
+
+**Physically consistent realisations:** Each $\eta^*_s$ is a plausible SSH field — spatially smooth, consistent with the kernel's length scale, and passing through the observations within noise. These can be passed directly to downstream analyses (eddy detection, geostrophic current estimation) to propagate uncertainty.
+
+---
+
+## Storage Analysis
+
+All costs are at float64 (8 bytes). Let $n = 10^5$, $m = 5 \times 10^3$, $r = 2 \times 10^3$, $S = 100$.
+
+| Object | Shape | Dtype | Storage formula | Size |
+|---|---|---|---|---|
+| $\mathcal{X}$ | $(m, 3)$ | float64 | $24m$ bytes | $120\,\text{KB}$ |
+| $y$ | $(m,)$ | float64 | $8m$ bytes | $40\,\text{KB}$ |
+| $K_{\mathcal{X}\mathcal{X}}$ | $(m, m)$ | float64 | $8m^2$ bytes | $200\,\text{MB}$ |
+| $C = K_{\mathcal{X}\mathcal{X}} + \sigma^2 I$ | $(m, m)$ | float64 | $8m^2$ bytes | $200\,\text{MB}$ — can overwrite $K_{\mathcal{X}\mathcal{X}}$ |
+| $L$ (Cholesky factor) | $(m, m)$ | float64 | $4m^2$ bytes (triangular) | $100\,\text{MB}$ |
+| $\alpha = C^{-1}y$ | $(m,)$ | float64 | $8m$ bytes | $40\,\text{KB}$ |
+| $K_{\mathcal{X}^*\mathcal{X}}$ | $(n, m)$ | float64 | $8nm$ bytes | **$4\,\text{GB}$** |
+| RFF spectral params | $(r, 3)$ | float64 | $24r$ bytes | $48\,\text{KB}$ |
+| $\tilde{f}(\mathcal{X})$ | $(m,)$ | float64 | $8m$ bytes | $40\,\text{KB}$ |
+| $\tilde{f}(\mathcal{X}^*)$ | $(n,)$ | float64 | $8n$ bytes | $800\,\text{KB}$ |
+| $\beta = C^{-1}\delta$ | $(m,)$ | float64 | $8m$ bytes | $40\,\text{KB}$ |
+| $\eta^*_s$ (one sample) | $(n,)$ | float64 | $8n$ bytes | $800\,\text{KB}$ |
+| $\{\eta^*_s\}_{s=1}^S$ (all samples) | $(S, n)$ | float64 | $8Sn$ bytes | $80\,\text{MB}$ |
+
+**Total storage:** dominated by $K_{\mathcal{X}^*\mathcal{X}}$ at $\mathcal{O}(nm)$ — approximately **4 GB** for these parameters.
+
+$$\text{Storage} = \mathcal{O}(m^2 + nm)$$
+
+The $m^2$ term ($\sim 400\,\text{MB}$ combined for $K_{\mathcal{X}\mathcal{X}}$ and $L$) is secondary to the $nm$ term ($4\,\text{GB}$ for $K_{\mathcal{X}^*\mathcal{X}}$). If memory is tight, $K_{\mathcal{X}^*\mathcal{X}}$ can be computed in row-blocks and the mat-vecs in Steps 5 and 10 done blockwise — reducing peak memory to $\mathcal{O}(m^2 + b \cdot m)$ where $b$ is the block size.
+
+---
+
+## Compute Analysis
+
+Let $d_{ker}$ be the cost of a single kernel evaluation (great-circle distance + Matérn + OU): $\mathcal{O}(1)$ but with a non-trivial constant (trig functions for great-circle).
+
+### Offline (once per time window)
+
+| Step | Operation | Cost | Notes |
+|---|---|---|---|
+| Build $K_{\mathcal{X}\mathcal{X}}$ | $m^2$ kernel evaluations | $\mathcal{O}(m^2 d_{ker})$ | Symmetric: $m(m+1)/2$ unique evals |
+| Cholesky of $C$ | Dense factorisation | $\mathcal{O}(m^3 / 3)$ | **Dominant offline cost** |
+| Solve $\alpha = C^{-1}y$ | Two triangular solves | $\mathcal{O}(m^2)$ | Negligible after Cholesky |
+| Build $K_{\mathcal{X}^*\mathcal{X}}$ | $nm$ kernel evaluations | $\mathcal{O}(nm\, d_{ker})$ | Embarrassingly parallel |
+| Compute $\mu_{f|y} = K_{\mathcal{X}^*\mathcal{X}}\alpha$ | Dense mat-vec | $\mathcal{O}(nm)$ | BLAS-2, fast |
+
+**Total offline:** $\mathcal{O}(m^3 + nm)$
+
+For $m = 5\times10^3$: $m^3/3 \approx 4 \times 10^{10}$ flops. At $10^{12}$ flops/sec (modern CPU): $\sim 40$ seconds. $nm = 5 \times 10^8$ — sub-second.
+
+### Per Posterior Sample (Steps 6–10)
+
+| Step | Operation | Cost | Notes |
+|---|---|---|---|
+| Draw $w_j$ and spectral freqs | Sample $r$ Gaussians + $r$ uniforms | $\mathcal{O}(r)$ | Negligible |
+| Evaluate $\tilde{f}(\mathcal{X})$ | Form $(m \times r)$ feature matrix, multiply by $w$ | $\mathcal{O}(mr)$ | |
+| Evaluate $\tilde{f}(\mathcal{X}^*)$ | Form $(n \times r)$ feature matrix, multiply by $w$ | $\mathcal{O}(nr)$ | **Dominant per-sample cost if $nr > nm$** |
+| Compute $\delta = y - \tilde{f}(\mathcal{X})$ | Vector subtract | $\mathcal{O}(m)$ | Negligible |
+| Solve $\beta = C^{-1}\delta$ | Two triangular solves | $\mathcal{O}(m^2)$ | Fast — $L$ precomputed |
+| Correction $K_{\mathcal{X}^*\mathcal{X}}\beta$ | Dense mat-vec | $\mathcal{O}(nm)$ | BLAS-2, fast |
+| Add: $\eta^* = \tilde{f}(\mathcal{X}^*) + K_{\mathcal{X}^*\mathcal{X}}\beta$ | Vector add | $\mathcal{O}(n)$ | Negligible |
+
+**Total per sample:** $\mathcal{O}(r(m + n) + m^2 + nm) = \mathcal{O}(nm + rn)$
+
+For $n = 10^5$, $m = 5 \times 10^3$, $r = 2 \times 10^3$: $nm = 5 \times 10^8$, $nr = 2 \times 10^8$, $m^2 = 2.5 \times 10^7$. The dominant per-sample cost is the mat-vec $K_{\mathcal{X}^*\mathcal{X}}\beta$ at $\mathcal{O}(nm)$.
+
+**For $S = 100$ samples:** $100 \times (nm + rn) \approx 7 \times 10^{10}$ flops — about 70 seconds on CPU, or seconds on GPU (all mat-vecs are highly parallelisable).
+
+**Total end-to-end:**
+
+$$\text{Compute} = \underbrace{\mathcal{O}(m^3)}_{\text{Cholesky}} + \underbrace{\mathcal{O}(nm)}_{\text{cross-cov + mean}} + \underbrace{S \cdot \mathcal{O}(nm + rn)}_{\text{posterior samples}}$$
+
+---
+
+## Complexity Summary
+
+| Phase | Storage | Compute |
+|---|---|---|
+| Build $K_{\mathcal{X}\mathcal{X}}$, Cholesky | $\mathcal{O}(m^2)$ | $\mathcal{O}(m^3)$ |
+| Build $K_{\mathcal{X}^*\mathcal{X}}$, posterior mean | $\mathcal{O}(nm)$ — **bottleneck** | $\mathcal{O}(nm)$ |
+| $S$ posterior samples | $\mathcal{O}(Sn)$ | $S \cdot \mathcal{O}(nm + rn)$ |
+| **Total** | $\mathcal{O}(m^2 + nm)$ | $\mathcal{O}(m^3 + nm(1 + S) + Srn)$ |
+
+**Scaling regime:**
+
+- When $m$ is small ($m \lesssim 10^3$): Cholesky is fast; $K_{\mathcal{X}^*\mathcal{X}}$ and mat-vecs dominate.
+- When $m$ is large ($m \gtrsim 10^4$): Cholesky $\mathcal{O}(m^3)$ becomes intractable — need sparse GP / inducing points to bring $m$ back down.
+- When $S$ is large: per-sample mat-vec $\mathcal{O}(nm)$ dominates; batch across samples using $(n \times S)$ output matrix.
+- When $n$ is large ($n \gtrsim 10^6$, sub-$0.05°$ grid): $K_{\mathcal{X}^*\mathcal{X}}$ storage becomes intractable — compute in blocks of rows, never materialise the full matrix.

--- a/projects/interpolation/notebooks/01_efficient_machinery.md
+++ b/projects/interpolation/notebooks/01_efficient_machinery.md
@@ -1,0 +1,407 @@
+---
+title: "Efficient machinery for SSH pathwise sampling — a tour of gaussx + pyrox"
+---
+
+# Efficient machinery for SSH pathwise sampling
+
+The companion note [`00_ssh_pathwise_sampling.md`](00_ssh_pathwise_sampling.md) writes the algorithm out as if you were going to implement it from scratch — dense Gram matrices, dense Cholesky, dense cross-covariance, hand-rolled RFF prior. That description makes the math obvious but it carries three concrete costs that get unpleasant the moment you push to realistic Mediterranean grids:
+
+| Bottleneck in the naive write-up | Why it hurts |
+|---|---|
+| Materialise $K_{\mathcal{X}^*\mathcal{X}} \in \mathbb{R}^{n \times m}$ | $\sim 4\,\text{GB}$ at $n=10^5$, $m=5\times 10^3$ — the dominant memory term |
+| Cholesky of $C \in \mathbb{R}^{m \times m}$ | $\mathcal{O}(m^3)$ — single-threaded LAPACK, ~40 s at $m=5\text{k}$ |
+| Per-sample $K_{\mathcal{X}^*\mathcal{X}}\,\beta$ matvec, repeated $S$ times | $\mathcal{O}(Snm)$, plus the same $4\,\text{GB}$ buffer reused $S$ times |
+
+This note walks through the [gaussx](https://github.com/jejjohnson/gaussx) and [pyrox](https://github.com/jejjohnson/pyrox) primitives that fix each of those, with pseudocode close enough to real Python that you could turn it into runnable code in an afternoon. The point is not to refactor the SSH pipeline today — it is to leave a paper trail of *which existing primitive solves which step* so future-me (or future-anyone) can pick the right tool without re-deriving the algorithm.
+
+Throughout, the four "objects" from the 00 derivation keep their names: $K_{\mathcal{X}\mathcal{X}}$, $C = K_{\mathcal{X}\mathcal{X}} + \sigma_{obs}^2 I$, $K_{\mathcal{X}^*\mathcal{X}}$, and the prior path $\tilde f$.
+
+---
+
+## Machinery 1 — matrix-free kernels (kills the $4\,\text{GB}$ peak)
+
+The cross-covariance $K_{\mathcal{X}^*\mathcal{X}}$ is *only ever multiplied against vectors* in the algorithm: once for the posterior mean ($K_{\mathcal{X}^*\mathcal{X}}\,\alpha$), and once per sample for the correction ($K_{\mathcal{X}^*\mathcal{X}}\,\beta$). There is no reason to allocate the dense block.
+
+### The primitive
+
+[`gaussx.ImplicitCrossKernelOperator`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_operators/_implicit_cross_kernel.py) wraps any pure-function kernel `k(x_i, z_j) -> scalar` as a `lineax.AbstractLinearOperator` whose `.mv(v)` evaluates
+
+$$
+(K v)_i = \sum_{j=1}^{m} k(x_i, z_j)\, v_j
+$$
+
+via `jax.lax.scan` over rows of $\mathcal{X}^*$, in batches of size `batch_size`. Peak memory per matvec is $\mathcal{O}(\text{batch\_size} \cdot m)$ — set `batch_size` to fit in cache and you are done. It carries a `custom_jvp` so autodiff through hyperparameters stays cheap (vmap-vectorised JVP, transposes cleanly into a VJP).
+
+The square sibling, [`gaussx.ImplicitKernelOperator`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_operators/_implicit_kernel.py), does the same trick for $K_{\mathcal{X}\mathcal{X}}$ and accepts an optional `noise_var=σ²` so the **noisy Gram** $C = K_{\mathcal{X}\mathcal{X}} + \sigma^2 I$ is one operator with no extra allocation.
+
+### Pseudocode
+
+```python
+import gaussx as gx
+import lineax as lx
+
+def k_st(x, z, sigma2, Ls, Lt):
+    """One scalar evaluation of σ²·k_s·k_t. Pure function — no batching."""
+    d_space = great_circle(x[:2], z[:2])
+    d_time  = jnp.abs(x[2] - z[2])
+    spatial = matern32(d_space, Ls)
+    temporal = jnp.exp(-d_time / Lt)
+    return sigma2 * spatial * temporal
+
+# Noisy Gram C = K_XX + σ²I — never materialised.
+C_op = gx.ImplicitKernelOperator(
+    kernel_fn = lambda xi, xj: k_st(xi, xj, sigma2, Ls, Lt),
+    X         = X_train,                  # (m, 3)
+    noise_var = sigma_obs ** 2,
+    tags      = lx.positive_semidefinite_tag,
+)
+
+# Cross-covariance K_{X*, X} — never materialised.
+Kxs_op = gx.ImplicitCrossKernelOperator(
+    kernel_fn   = lambda xi, zj: k_st(xi, zj, sigma2, Ls, Lt),
+    X_data      = X_grid,                 # (n, 3) — the prediction inputs
+    X_inducing  = X_train,                # (m, 3)
+    batch_size  = 4096,                   # rows of X_grid per scan step
+)
+
+mean_field = Kxs_op.mv(alpha)             # (n,) — Step 5 of the 00 algorithm
+correction = Kxs_op.mv(beta)              # (n,) — Step 10, called once per sample
+```
+
+### What you save
+
+| Object | Naive | Matrix-free |
+|---|---|---|
+| Peak memory for cross-cov | $8nm$ B = $4\,\text{GB}$ | $8 \cdot \text{batch\_size} \cdot m$ B ≈ $160\,\text{MB}$ at `batch_size=4096` |
+| Peak memory for Gram | $8m^2$ B = $200\,\text{MB}$ | $8m$ B ≈ $40\,\text{KB}$ per row |
+| Per-matvec flops | $\mathcal{O}(nm)$ | $\mathcal{O}(nm)$ — same |
+
+The flop count does not change — but the working set goes from "blows your laptop" to "comfortably fits in L3 cache".
+
+---
+
+## Machinery 2 — avoiding the $m^3$ Cholesky
+
+You have two routes, depending on whether you want an *exact* solve against the dense Gram or an *approximate* solve against a low-rank surrogate.
+
+### Route A — preconditioned CG against the implicit Gram (exact)
+
+[`gaussx.PreconditionedCGSolver`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_strategies/_precond_cg.py) builds a rank-$k$ pivoted partial Cholesky preconditioner via `matfree.low_rank.cholesky_partial_pivot` and feeds it into `lineax.CG`. For $C = K_{\mathcal{X}\mathcal{X}} + \sigma^2 I$ — the textbook target of preconditioned GP CG — convergence is essentially independent of $m$ once the preconditioner captures the leading spectrum. Each CG iteration is one $C$-matvec ⇒ one `ImplicitKernelOperator` matvec ⇒ no dense matrix ever exists.
+
+```python
+solver = gx.PreconditionedCGSolver(
+    preconditioner_rank = 50,             # rank-50 partial Cholesky
+    shift               = sigma_obs ** 2, # the σ²I in C — used by Woodbury inside the precond
+    rtol                = 1e-6,
+    max_steps           = 200,            # 50–200 iters typical
+    lanczos_order       = 30,             # only used for SLQ logdet, irrelevant here
+)
+
+alpha = gx.solve(C_op, y, solver=solver)  # (m,) — Step 3 of the 00 algorithm
+# Per-sample correction also reuses the same solver:
+beta  = gx.solve(C_op, y - f_tilde_X, solver=solver)
+```
+
+Cost: $\mathcal{O}(\text{n\_iters} \cdot m^2)$ flops, $\mathcal{O}(\text{precond\_rank} \cdot m)$ memory. With `n_iters ≈ 100` and $m=5\text{k}$ that is $2.5 \times 10^9$ flops vs. $4 \times 10^{10}$ for dense Cholesky — about **15× faster**, and you skipped the $200\,\text{MB}$ Gram allocation along the way.
+
+### Route B — RFF + Woodbury (approximate, but very cheap when $r \ll m$)
+
+The 00 note is already going to compute RFF features for the prior path. Reuse them for the Gram itself: by Bochner's theorem $K_{\mathcal{X}\mathcal{X}} \approx \Phi \Phi^\top$ where $\Phi \in \mathbb{R}^{m \times r}$. Then $C \approx \sigma^2 I + \Phi \Phi^\top$, which is exactly the structure that [`gaussx.LowRankUpdate`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_operators/_low_rank_update.py) is built for, and `gx.solve` dispatches Woodbury on it automatically.
+
+[`gaussx.rff_operator`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_kernels/_kernel_approx.py) constructs this in one call:
+
+```python
+import jax.random as jr
+
+# Spectral frequencies for σ²·k_s·k_t — separable kernel ⇒ ω = (ω_s, ω_t)
+omega = sample_spectral_frequencies(key_omega, n_features=2000)   # (r, 3)
+phase = jr.uniform(key_phase, (2000,), maxval=2 * jnp.pi)
+
+K_lr = gx.rff_operator(X_train, omega=omega, b=phase)             # K ≈ ΦΦᵀ as LowRankUpdate
+C_lr = K_lr + lx.IdentityLinearOperator(in_struct, in_struct) * sigma_obs ** 2
+# (or: gx.low_rank_plus_diag(...) — see __init__.py for the helper)
+
+alpha = gx.solve(C_lr, y)                                          # Woodbury under the hood
+```
+
+Cost: $\mathcal{O}(r^3 + r^2 m)$ for the inner $r\times r$ solve, $\mathcal{O}(rm)$ memory. With $r=2\text{k}$, $m=5\text{k}$: $8 \times 10^9 + 2 \times 10^{10} = 2.8 \times 10^{10}$ flops — comparable to dense Cholesky on this size, but it scales as $rm^2$ instead of $m^3$, so it pulls ahead fast as $m$ grows.
+
+[`gaussx.nystrom_operator`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_kernels/_kernel_approx.py) is the inducing-point cousin if uniformly subsampled altimeter tracks make a better basis than RFF — same `LowRankUpdate` output, same Woodbury dispatch.
+
+---
+
+## Machinery 3 — the whole Matheron loop is already in pyrox
+
+[`pyrox.gp.PathwiseSampler`](https://github.com/jejjohnson/pyrox/blob/main/src/pyrox/gp/_pathwise.py) implements Steps 6–10 of the 00 algorithm verbatim. It combines:
+
+- [`pyrox._basis._rff.draw_rff_cosine_basis`](https://github.com/jejjohnson/pyrox/blob/main/src/pyrox/_basis/_rff.py) — draws `(variance, lengthscale, ω, phase, weights)` from the kernel's spectral density, supports RBF and Matérn (any $\nu$ — including $3/2$ used here);
+- `evaluate_rff_cosine_paths` — evaluates the prior path $\tilde f$ at any $X$, vectorised over `n_paths`;
+- a frozen `(X1, X2) -> K(X1, X2)` callable that bakes in the *same* hyperparameter draw used for the RFF, so the correction $K(\mathcal{X}^*, \mathcal{X})\,\beta$ stays consistent.
+
+The result is a `PathwiseFunction` you call at any $\mathcal{X}^*$ — the per-call cost is $\mathcal{O}(n_* F D + n_* m)$ per path.
+
+### Pseudocode — drop-in replacement for Steps 6–10
+
+```python
+from pyrox.gp import GPPrior, PathwiseSampler, Matern
+
+# Build a Matern-3/2 kernel on (lon, lat, t). Could also be a product of
+# spatial-Matern × temporal-OU (Matern-1/2) — pyrox supports kernel_mul.
+kernel = Matern(nu=1.5, lengthscale=Ls, variance=sigma_eta_2)
+
+prior     = GPPrior(kernel=kernel, X=X_train)            # ConditionedGP carries C internally
+posterior = prior.condition(y, noise_var=sigma_obs ** 2)
+
+sampler   = PathwiseSampler(posterior, n_features=2000)
+paths     = sampler.sample_paths(key, n_paths=100)       # PathwiseFunction
+samples   = paths(X_grid)                                # (100, n) — Step 10
+```
+
+That is the entire pathwise loop in five lines.
+
+### Caveat — swap the inner solver
+
+`PathwiseSampler` currently uses `gaussx.cholesky` for the $C^{-1}$ inside Matheron's correction. To combine wins #2 and #3 you would either (a) use Route B (low-rank $C$) so the Cholesky is cheap, or (b) pass a different solver into the sampler. The latter is a small monkeypatch / fork — flag it if you ever need $m \gtrsim 10^4$.
+
+---
+
+## Machinery 4 — pointwise posterior variance without the $nm^2$ row-loop
+
+The 00 note flags pointwise variance at $\mathcal{O}(nm^2)$ — one solve per test point. [`gaussx.love_cache`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_gp/_love.py) (LanczOs Variance Estimates, Pleiss et al. 2018) precomputes a rank-$k$ Lanczos factorisation of $C^{-1}$ once, after which every test-point variance costs $\mathcal{O}(mk)$ instead of $\mathcal{O}(m^2)$.
+
+```python
+cache = gx.love_cache(C_op, lanczos_order=50)            # one-time, ~50 CG-matvecs
+
+def post_var_at(x_star):
+    k_star_row = jax.vmap(lambda xj: k_st(x_star, xj, sigma2, Ls, Lt))(X_train)  # (m,)
+    return sigma_eta_2 - gx.love_variance(cache, k_star_row)
+
+post_var_map = jax.vmap(post_var_at)(X_grid)             # (n,)
+```
+
+For $n=10^5$, $m=5\text{k}$, $k=50$: cost drops from $\sim 2.5 \times 10^{12}$ flops (one solve per test point) to $\sim 2.5 \times 10^{10}$ — about **100× cheaper**. Use the empirical sample variance from $\{\eta^*_s\}$ when you only need a few samples; switch to LOVE when you specifically want a smooth, non-Monte-Carlo-noisy uncertainty map.
+
+---
+
+## Two structural exploits the libraries don't do for you
+
+These are not in gaussx/pyrox as primitives but they compose with the operators above and are worth coding by hand for an SSH-shaped problem.
+
+### Exploit A — temporal factor of $K_{\mathcal{X}^*\mathcal{X}}$ has only 3 distinct values
+
+All prediction points share time $t$, so for any observation $j$ in time group $t-\tau$, $t$, or $t+\tau$ the temporal weight $k_t(t, t_j; L_t)$ is one of three scalars: $e^{-\tau/L_t}$, $1$, $e^{-\tau/L_t}$. Build *spatial-only* implicit cross operators per time group and combine with scalar weights at matvec time:
+
+```python
+def make_block(X_train_group, weight):
+    spatial_op = gx.ImplicitCrossKernelOperator(
+        kernel_fn   = lambda x, z: sigma2 * matern32_great_circle(x[:2], z[:2], Ls),
+        X_data      = X_grid_xy,        # (n, 2) — drop time axis
+        X_inducing  = X_train_group,    # (m_group, 2)
+        batch_size  = 4096,
+    )
+    return weight, spatial_op
+
+w_minus = jnp.exp(-tau / Lt)
+blocks = [
+    make_block(X_train_minus_xy, w_minus),
+    make_block(X_train_zero_xy,  1.0),
+    make_block(X_train_plus_xy,  w_minus),
+]
+
+def Kxs_mv(beta):                           # beta is partitioned to match groups
+    out = 0.0
+    for (w, op), b_group in zip(blocks, beta_partition):
+        out = out + w * op.mv(b_group)
+    return out
+```
+
+This **halves the kernel-eval count** (one trig stack per spatial pair, not one per spatiotemporal pair) and lets you cache the spatial cross-covs across re-fits with different $L_t$ — handy when you sweep temporal length scales during hyperparameter learning.
+
+### Exploit B — the $3 \times 3$ block structure of $K_{\mathcal{X}\mathcal{X}}$
+
+The training inputs $\mathcal{X}$ split into 3 time groups, so $K_{\mathcal{X}\mathcal{X}}$ is a $3\times 3$ block matrix whose $(a,b)$ block is
+
+$$
+\bigl[K_{\mathcal{X}\mathcal{X}}\bigr]_{ab} = \sigma_\eta^2 \cdot e^{-|t_a - t_b|/L_t} \cdot K_s\bigl(\text{group}_a,\, \text{group}_b\bigr).
+$$
+
+Six unique spatial blocks (3 diagonal + 3 off-diagonal); the temporal weights are scalars. Build the spatial blocks once with `ImplicitKernelOperator` / `ImplicitCrossKernelOperator`, wrap with a temporally-weighted block matvec, and you avoid $\sim 8/9$ of the redundant great-circle evaluations on every Gram matvec inside CG.
+
+This composes with [`gaussx.BlockDiag`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_operators/_block_diag.py) for the within-group blocks, with the off-diagonal cross-blocks added back as scaled implicit operators inside a custom matvec. Worth the effort once you push to many time groups (a sliding window with $|\tau| \in \{1, 2, \ldots, 5\}$ days, say).
+
+---
+
+## Putting it all together — the efficient SSH algorithm
+
+The same ten-step algorithm from 00, rewritten with the machinery above. Storage is now $\mathcal{O}(m + r + n)$ throughout — never $nm$, never $m^2$.
+
+### Offline (once per time window)
+
+```python
+# --- Choose a structured representation of C ---
+# Route A (exact, preferred when m ≲ 5e4 and you have time for ~100 CG iters):
+C_op  = gx.ImplicitKernelOperator(k_st_curried, X_train, noise_var=sigma_obs ** 2,
+                                  tags=lx.positive_semidefinite_tag)
+solver = gx.PreconditionedCGSolver(preconditioner_rank=50, shift=sigma_obs ** 2,
+                                   rtol=1e-6, max_steps=200)
+
+# Route B (low-rank, preferred when m ≫ 1e4 and r ≪ m):
+# K_lr  = gx.rff_operator(X_train, omega=omega, b=phase)
+# C_lr  = K_lr + identity(m) * sigma_obs ** 2     # LowRankUpdate ⇒ Woodbury
+# solver = None                                    # gx.solve auto-dispatches Woodbury
+
+# --- Step 3: solve for the dual weights α ---
+alpha = gx.solve(C_op, y, solver=solver)          # (m,)
+
+# --- Steps 4–5: matrix-free posterior mean field ---
+Kxs_op = gx.ImplicitCrossKernelOperator(
+    kernel_fn  = k_st_curried,
+    X_data     = X_grid,                          # (n, 3)
+    X_inducing = X_train,                         # (m, 3)
+    batch_size = 4096,
+)
+mu_field = Kxs_op.mv(alpha)                       # (n,) — never materialise (n, m)
+```
+
+### Per posterior sample
+
+```python
+# --- Steps 6–7: RFF prior path at training + grid (one consistent draw) ---
+variance, lengthscale, omega, phase, weights = pyrox.rff.draw_rff_cosine_basis(
+    kernel      = matern_3_2,
+    key         = sample_key,
+    n_paths     = 1, n_features=2000, in_features=3, dtype=jnp.float64,
+)
+f_tilde_X     = pyrox.rff.evaluate_rff_cosine_paths(
+    X_train, variance=variance, lengthscale=lengthscale,
+    omega=omega, phase=phase, weights=weights)[0]
+f_tilde_grid  = pyrox.rff.evaluate_rff_cosine_paths(
+    X_grid,  variance=variance, lengthscale=lengthscale,
+    omega=omega, phase=phase, weights=weights)[0]
+
+# --- Step 8–9: innovation + correction solve (reuses solver) ---
+delta = y - f_tilde_X                             # (m,)
+beta  = gx.solve(C_op, delta, solver=solver)      # (m,) — same CG, same precond
+
+# --- Step 10: matrix-free correction ---
+eta_sample = f_tilde_grid + Kxs_op.mv(beta)       # (n,) — one exact posterior draw
+```
+
+Or, equivalently, the four-line version using the pre-built sampler:
+
+```python
+posterior = GPPrior(kernel=matern_3_2_x_OU, X=X_train).condition(y, sigma_obs ** 2)
+sampler   = PathwiseSampler(posterior, n_features=2000)
+paths     = sampler.sample_paths(key, n_paths=S)
+samples   = paths(X_grid)                          # (S, n)
+```
+
+### Pointwise variance map (optional, when sample-variance is too noisy)
+
+```python
+cache = gx.love_cache(C_op, lanczos_order=50)
+post_var_map = jax.vmap(
+    lambda x_star: sigma_eta_2 - gx.love_variance(
+        cache,
+        jax.vmap(lambda xj: k_st(x_star, xj, sigma2, Ls, Lt))(X_train),
+    )
+)(X_grid)                                          # (n,)
+```
+
+---
+
+## Cost recap
+
+Same complexity table as 00, side-by-side with what the machinery delivers.
+
+| Phase | Naive (00) | With machinery (here) |
+|---|---|---|
+| Build $K_{\mathcal{X}\mathcal{X}}$ + Cholesky | $\mathcal{O}(m^2)$ memory, $\mathcal{O}(m^3)$ flops | $\mathcal{O}(m)$ memory, $\mathcal{O}(\text{n\_iters} \cdot m^2)$ flops via PCG (Route A); or $\mathcal{O}(rm)$ + $\mathcal{O}(r^2 m + r^3)$ via Woodbury (Route B) |
+| Build $K_{\mathcal{X}^*\mathcal{X}}$ + posterior mean | $\mathcal{O}(nm)$ memory, $\mathcal{O}(nm)$ flops | $\mathcal{O}(\text{batch\_size} \cdot m)$ memory, $\mathcal{O}(nm)$ flops |
+| $S$ posterior samples | $\mathcal{O}(Sn)$ memory, $S \cdot \mathcal{O}(nm + rn)$ flops | same flops, but cross-cov memory shrinks from $nm$ to $\text{batch\_size} \cdot m$ — and the $C^{-1}\delta$ solve is the cheap PCG/Woodbury solve, not a fresh Cholesky |
+| Pointwise variance | $\mathcal{O}(nm^2)$ flops | $\mathcal{O}(nmk)$ flops via LOVE, $k\sim 50$ |
+
+The **memory bound drops from $\mathcal{O}(m^2 + nm)$ to $\mathcal{O}(m + r + n + \text{batch\_size}\cdot m)$** — i.e. from 4 GB to a few hundred MB at SSH-realistic scales. The **flop bound drops from $\mathcal{O}(m^3 + Snm)$ to $\mathcal{O}(\text{n\_iters}\cdot m^2 + Snm)$** with the same constants. Both wins compound: matrix-free + PCG means you can push to $m \sim 5 \times 10^4$ (a full Mediterranean month) on a single GPU, where the naive code would OOM long before it finished its first Cholesky.
+
+---
+
+## Wall-clock estimates for realistic SSH reconstructions
+
+Order-of-magnitude time budgets to reconstruct daily SSH fields over the **Mediterranean Sea**, **North Atlantic**, and **global ocean**, for both an analysis-day window $[t-\tau,\, t]$ (operational, 2 time groups) and a reanalysis-day window $[t-\tau,\, t,\, t+\tau]$ (3 time groups, lookahead allowed). All numbers below are accurate to a factor of $\sim 2$ — they exist to flag *which configurations are tractable on what hardware*, not to commit to a specific runtime.
+
+### Daily observation counts (Copernicus Marine Service catalogue, 2024–2026)
+
+CMEMS publishes the along-track and SWOT L3 streams as `SEALEVEL_GLO_PHY_L3_*_OBSERVATIONS_008_*` (NRT and reprocessed multi-mission), the SWOT KaRIn 7.5 km L3 as `SEALEVEL_GLO_PHY_L3_MY_008_069`, and tide-gauge SSH as `INSITU_GLO_PHY_SSH_DISCRETE_NRT_013_059`. Post-QC daily counts:
+
+| Stream | Per-satellite raw | After QC | Active in 2024–2026 |
+|---|---|---|---|
+| Nadir altimeters (1 Hz) | $\sim 86\text{k}$/day/sat | $\sim 50\text{k}$/day/sat | S3A, S3B, S6-MF, SARAL, CryoSat-2, HY-2B/C — **6 sats ⇒ $\sim 3\times 10^5$/day globally** |
+| SWOT KaRIn (2 km native, 7.5 km L3) | $\sim 5\times 10^6$/day | $\sim 2\times 10^6$/day | 1 mission, operational since 2023 |
+| In-situ SSH (tide gauges, GLOSS) | — | $\sim 10^4$/day | Negligible vs altimetry; anchors absolute datum |
+| **Combined total (post-QC)** | | **$\sim 2\times 10^6$/day globally** | SWOT dominates |
+
+Region fractions (area-weighted):
+
+| Region | Area | Fraction | Daily obs (with SWOT) | Daily obs (nadir-only, archived years) |
+|---|---|---|---|---|
+| Mediterranean Sea | $2.5\,\text{M km}^2$ | $0.7\%$ | $\sim 1.5\times 10^4$ | $\sim 2\times 10^3$ |
+| North Atlantic | $40\,\text{M km}^2$ | $11\%$ | $\sim 2.5\times 10^5$ | $\sim 3\times 10^4$ |
+| Global ocean | $360\,\text{M km}^2$ | $100\%$ | $\sim 2\times 10^6$ | $\sim 3\times 10^5$ |
+
+### Per-day problem sizes
+
+With $\tau \approx 2$–$3$ days and obs grouped by time-band:
+
+| Region | Grid $n$ ($0.1°$ res) | $m$ analysis (2 groups, with SWOT) | $m$ reanalysis (3 groups, with SWOT) | $m$ reanalysis (nadir-only) |
+|---|---|---|---|---|
+| Mediterranean | $10^5$ | $3\times 10^4$ | $4.5\times 10^4$ | $6\times 10^3$ |
+| North Atlantic | $6.5\times 10^5$ | $5\times 10^5$ | $7.5\times 10^5$ | $10^5$ |
+| Global ocean | $6.5\times 10^6$ | $4\times 10^6$ | $6\times 10^6$ | $10^6$ |
+
+### Per-day compute, two regimes
+
+Two implementation paths from above, with $r=2000$ RFF features and $S=100$ posterior samples per day. The "fully-RFF" column uses RFF for *both* the prior path *and* the cross-covariance — the per-sample correction matvec then collapses from $\mathcal{O}(nm)$ to $\mathcal{O}(r(n+m))$, removing $m$ from the inner loop entirely.
+
+| Region (reanalysis day, with SWOT) | Exact GP via PCG (Route A) — flops/day | Fully-RFF Woodbury (Route B+) — flops/day |
+|---|---|---|
+| Mediterranean ($m\!\sim\!4.5\text{k}$, $n\!\sim\!10^5$) | $\sim 2\times 10^{13}$ | $\sim 2\times 10^{11}$ |
+| North Atlantic ($m\!\sim\!7.5\text{k}\cdot 10^2$, $n\!\sim\!6.5\times 10^5$) | $\sim 6\times 10^{15}$ | $\sim 3\times 10^{12}$ |
+| Global ocean ($m\!\sim\!6\times 10^6$, $n\!\sim\!6.5\times 10^6$) | $\sim 4\times 10^{17}$ — **infeasible** | $\sim 2.5\times 10^{13}$ |
+
+Effective sustained throughput on common targets: a modern Xeon (32 cores, MKL) hits $\sim 200\,\text{GFLOPS}$ f64 on these matvec/scan kernels; an A100 GPU hits $\sim 5\,\text{TFLOPS}$ f64 (well below peak because the workload is bandwidth-bound). Per-day wall-clock follows directly:
+
+| Region | Route A — A100 / day | Route A — CPU / day | Fully-RFF — A100 / day | Fully-RFF — CPU / day |
+|---|---|---|---|---|
+| Mediterranean | $\sim 4\,\text{s}$ | $\sim 100\,\text{s}$ | $< 0.1\,\text{s}$ | $\sim 1\,\text{s}$ |
+| North Atlantic | $\sim 20\,\text{min}$ | $\sim 8\,\text{h}$ | $\sim 0.6\,\text{s}$ | $\sim 15\,\text{s}$ |
+| Global | $\sim 22\,\text{h}$ | weeks | $\sim 5\,\text{s}$ | $\sim 2\,\text{min}$ |
+
+Analysis day (2 time groups instead of 3) reduces $m$ by $\sim 1/3$, so per-day cost drops by $\sim 0.5\times$ for Route A (the $m^2$ term) and $\sim 0.6\times$ for Route B+. Numbers below take this into account.
+
+### Full-window wall-clock
+
+Multiply per-day by 30 / 90 / 180. Reanalysis with the full SWOT-era constellation, on a single A100:
+
+| Region | 1 month (30 d) | 3 months (90 d) | 6 months (180 d) |
+|---|---|---|---|
+| **Mediterranean** | Route A: $2\,\text{min}$ · RFF+: $3\,\text{s}$ | Route A: $6\,\text{min}$ · RFF+: $9\,\text{s}$ | Route A: $12\,\text{min}$ · RFF+: $18\,\text{s}$ |
+| **North Atlantic** | Route A: $10\,\text{h}$ · RFF+: $20\,\text{s}$ | Route A: $30\,\text{h}$ · RFF+: $1\,\text{min}$ | Route A: $60\,\text{h}$ · RFF+: $2\,\text{min}$ |
+| **Global** | Route A: **infeasible** · RFF+: $2.5\,\text{min}$ | RFF+: $7.5\,\text{min}$ | RFF+: $15\,\text{min}$ |
+
+Same totals on a 32-core CPU (Route A column for global is dropped — even with RFF+ it would take days at exact-GP scales):
+
+| Region | 1 month | 3 months | 6 months |
+|---|---|---|---|
+| **Mediterranean** | Route A: $50\,\text{min}$ · RFF+: $30\,\text{s}$ | Route A: $2.5\,\text{h}$ · RFF+: $90\,\text{s}$ | Route A: $5\,\text{h}$ · RFF+: $3\,\text{min}$ |
+| **North Atlantic** | Route A: $10\,\text{d}$ · RFF+: $7.5\,\text{min}$ | Route A: $30\,\text{d}$ · RFF+: $22\,\text{min}$ | Route A: $60\,\text{d}$ · RFF+: $45\,\text{min}$ |
+| **Global** | RFF+: $1\,\text{h}$ | RFF+: $3\,\text{h}$ | RFF+: $6\,\text{h}$ |
+
+Analysis day (operational, single $[t-\tau, t]$ window per run) is roughly half these per-day numbers — Mediterranean analysis is sub-second on any hardware; global analysis with RFF+ is a few seconds per A100 day.
+
+### Where things break
+
+- **Route A on global SWOT-era data is hopeless on a single node.** $m \sim 6\times 10^6$ pushes the per-CG-iter cost ($\mathcal{O}(m^2)$ via implicit-kernel scan) into the $10^{13}$-flop range, with $\sim 100$ iterations per solve and $\sim S$ solves per day. You end up at $\sim 10^{17}$ flops/day, which is days-per-day on an A100. Either drop SWOT (reverts to the nadir column where Route A is viable for NA but still tight for global), reduce resolution, switch to **inducing-point sparse GPs** (`gaussx.nystrom_operator` + `LowRankUpdate`), or move to a **state-space SPDE formulation** (which gets you sparse precision matrices and $\mathcal{O}(m)$ smoothing, at the cost of requiring an isotropic Matérn kernel and more setup work).
+- **RFF+ is the right default for North Atlantic and global.** The accuracy loss vs exact GP is $\mathcal{O}(1/\sqrt{r})$ in the kernel approximation; for SSH-mesoscale fields and $r=2000$ this is well below the altimeter noise floor.
+- **Hyperparameter learning is not in these numbers.** Estimating $(\sigma_\eta^2, L_s, L_t, \sigma_{obs}^2)$ via marginal-likelihood gradient descent multiplies the cost by $\sim 50$–$100$ optimiser steps. Do this once on a representative window, then freeze the hyperparameters for the full reanalysis pass.
+- **I/O is not in these numbers.** At $2\times 10^6$ obs/day SWOT-era, the *download* from CMEMS at typical link speeds (~$50\,\text{MB/s}$) is comparable to or larger than the compute on Mediterranean/NA. Pre-stage the data; do not re-fetch per day.
+- **Posterior variance maps via LOVE add $\sim 5$–$10\%$ to the per-day budget** — cheap when needed, skip when the empirical sample variance from $\{\eta^*_s\}$ suffices.

--- a/projects/interpolation/notebooks/02_physics_aware_ssh.md
+++ b/projects/interpolation/notebooks/02_physics_aware_ssh.md
@@ -1,0 +1,268 @@
+---
+title: "Physics-aware SSH reconstruction — where physics enters the pathwise GP"
+---
+
+# Physics-aware SSH reconstruction
+
+The pipeline in [00_ssh_pathwise_sampling.md](00_ssh_pathwise_sampling.md) and [01_efficient_machinery.md](01_efficient_machinery.md) is a **physics-agnostic** Gaussian process: a single Matérn × OU kernel encodes "the field is smoothly varying in space and time." That is a strong baseline — essentially what classical DUACS optimal interpolation does[^taburet2019] [^ballarotta2019] — but it leaves on the table a half-century of ocean-dynamics knowledge.
+
+This note organises *how* that knowledge gets injected. To frame it, recall the pathwise posterior formula from 00:
+
+$$
+\boxed{\;
+\underbrace{f(\mathcal{X}^*) \mid y}_{\text{posterior}}
+\;\overset{d}{=}\;
+\underbrace{\tilde f(\mathcal{X}^*)}_{\text{prior path}}
+\;+\;
+\underbrace{K_{\mathcal{X}^*\mathcal{X}}}_{\text{cross-cov}}
+\,\underbrace{\bigl(K_{\mathcal{X}\mathcal{X}} + \sigma_{obs}^2 I\bigr)^{-1}}_{\text{inversion}\,=\,C^{-1}}
+\,\bigl(\,
+\underbrace{y}_{\text{data}}
+\;-\;
+\underbrace{\tilde f(\mathcal{X})}_{\text{prior path at obs}}
+\bigr).
+\;}
+$$
+
+Every term in this expression is a knob:
+
+| Symbol | What it controls | Where physics enters | Treated in |
+|---|---|---|---|
+| $y,\, \sigma_{obs}^2$ | The observations and their noise | **DATA** — pre-process them, augment with new modalities (§2) | **§2 below** |
+| $K_{\mathcal{X}\mathcal{X}},\, K_{\mathcal{X}^*\mathcal{X}}$ | The prior covariance — the kernel | **KERNEL** — choose a physically motivated kernel; structure it as a sum of physically meaningful components (§3) | **§3 below** |
+| $C^{-1}$ | The linear inversion | **COMPUTE** — Woodbury, PCG, low-rank approximations | [01](01_efficient_machinery.md) |
+| $\tilde f$ | The prior sample (RFF) | **COMPUTE** — RFF basis, Bochner | [01](01_efficient_machinery.md) |
+| $\mathcal{X}^*$ | The prediction inputs (the grid) | **GEOMETRY** — patch decomposition, localisation | [03](03_global_scaling_patches.md) |
+
+This note is about the first two columns: **DATA** (§2) and **KERNEL** (§3). A final §4 places geostrophic-current diagnostics, which are post-hoc and touch nothing in the pathwise formula above.
+
+Two concrete axes summarise the menu:
+
+> 1. **Modify the data** — subtract physics that is already understood (tides, atmospheric loading, mean dynamic topography); add velocity observations from drifters / HF radar / Doppler altimetry as *gradient* constraints on $\eta$.
+> 2. **Modify the kernel** — pick a kernel whose spectral density encodes ocean dynamics (SQG); decompose the kernel as a sum of physically meaningful components on multiscale localised bases (MIOST/MASSH Gabor wavelets); keep low-rank structure so the gaussx Woodbury machinery from 01 still applies.
+
+The grouping is deliberate: **the GP machinery from 00/01/03 stays the same throughout** — only the inputs $y$ and the kernel $K$ change. Methods that abandon the static-prior GP framework — variational data assimilation with dynamical priors (3D-Var, 4D-Var, DYMOST, BFN-QG) and learned variational schemes (4DVarNet) — live in [04_variational_dynamical_priors.md](04_variational_dynamical_priors.md), since they swap out the entire $C^{-1}$ + $K$ block, not just the kernel.
+
+---
+
+## 2. The DATA knob — modify $y$ before the GP sees it
+
+The observation vector $y$ in the pathwise formula is a passive input — anything you do to $y$ before passing it to the solver is honoured exactly. Two physical interventions:
+
+### 2a. Subtract — pre-processing the obs
+
+The numbers in 01 quietly assume that the observations have already been corrected for the standard altimetry noise sources. They have not, by default — CMEMS L3 products are minimally corrected. The standard pipeline:
+
+| Correction | Source | Removes |
+|---|---|---|
+| Wet/dry tropospheric | Radiometer + ECMWF | Atmospheric refraction (~10 cm) |
+| Ionospheric | Dual-frequency altimeter | Plasma path delay (~5 cm at low latitudes) |
+| Sea-state bias | Empirical (SWH, U10 dependence) | EM bias from wave shape (~few cm) |
+| Solid Earth + pole tide | Cartwright–Tayler model | Earth-body tides (~30 cm) |
+| Ocean tides | FES2014 / FES2022[^lyard2021] | M2, S2, K1, O1, … (~1 m peak) |
+| Dynamic Atmospheric Correction (DAC) | MOG2D barotropic + IB[^carrere2003] | High-frequency wind/pressure response (~10 cm at mid-latitudes) |
+| Mean Dynamic Topography (MDT) | CNES-CLS-22[^jousset2025] | Time-mean SSH so you work with anomaly $\eta_a$ |
+
+After all corrections, what remains is the **sea-level anomaly** $\eta_a = \eta - \eta_{\text{MDT}}$ — the field the GP should be modelling. Three things to know:
+
+- **All corrections are pre-computed and provided in the L3 product.** Reading the right CMEMS variable (`sla_unfiltered` or `sla_filtered`) gets you the already-corrected anomaly.
+- **DAC is essential when pooling across short time windows.** The 5–10 cm barotropic response to a passing storm is *highly correlated across all observations within a few days* and will break the GP's stationarity assumption if not removed.
+- **Tide residuals at coastal points are the dominant error budget.** FES tidal models have ~3 cm RMS on the open ocean but degrade to >10 cm in narrow shelf seas (English Channel, Patagonian shelf). For coastal SSH work, expect to filter or down-weight these.
+
+In code: this is a one-shot upstream step. The GP machinery is unchanged.
+
+### 2b. Augment — derivative observations from velocities
+
+Lagrangian drifter trajectories give direct estimates of surface velocity (after removing Ekman, Stokes, and inertial-oscillation components)[^rio2014] [^mulet2021]. HF-radar gives the same on shelf seas. SKIM[^ardhuin2019] and the recently selected ESA Harmony / future Doppler-altimetry missions give it from space. **All of these constrain *gradients* of $\eta$ via geostrophic balance:**
+
+$$
+u_g(x, y) \;=\; -\frac{g}{f(y)}\,\frac{\partial \eta}{\partial y}, \qquad
+v_g(x, y) \;=\; \frac{g}{f(y)}\,\frac{\partial \eta}{\partial x},
+$$
+
+with $g \approx 9.81\,\text{m s}^{-2}$ and Coriolis $f = 2 \Omega \sin\phi$ at latitude $\phi$. These are *linear* functionals of $\eta$ — partial derivatives with a latitude-dependent multiplier. Gaussian processes are closed under linear operators, so derivative observations slot into the GP as additional rows of the Gram matrix:
+
+$$
+\mathrm{Cov}\bigl(\partial_y \eta(x),\, \eta(x')\bigr) = \partial_{y} k_\theta(x, x'), \qquad
+\mathrm{Cov}\bigl(\partial_y \eta(x),\, \partial_{y'} \eta(x')\bigr) = \partial_{y}\partial_{y'} k_\theta(x, x').
+$$
+
+For Matérn-3/2 these have closed form; in JAX, **`jax.grad` of the kernel function gives you all the entries automatically** — no analytical work needed. Recipe:
+
+1. Pre-process drifter velocities to remove Ekman + inertial + Stokes (standard CMEMS workflow).
+2. Multiply by $-f/g$ and $f/g$ to obtain "SSH-gradient observations."
+3. Stack them onto the SLA observation vector $y$.
+4. Define a kernel function that branches on observation type — `eta×eta`, `eta×∂η`, `∂η×∂η` — using `jax.grad(k)` for the differentiated entries.
+5. Pass the augmented kernel to `gx.ImplicitKernelOperator` and the augmented $y$ to `gx.solve`. Everything else from 00/01 is unchanged.
+
+This is mathematically identical to how the CMEMS Mean Dynamic Topography is constructed[^rio2014] [^mulet2021] [^jousset2025], where steady-state geostrophic balance jointly constrains altimetry residuals and drifter velocities.
+
+**Cyclostrophic / equatorial caveats.** Geostrophy degenerates as $f \to 0$ at the equator and inside tight eddy cores where centrifugal acceleration competes with Coriolis. Standard fixes are $\beta$-plane geostrophy near the equator[^bonjean2002] and gradient-wind balance for cyclostrophic eddies — both add a quadratic-in-$\nabla\eta$ correction term, and the GP is no longer linear. Skip unless you specifically care about the equatorial band or eddy-core diagnostics.
+
+---
+
+## 3. The KERNEL knob — physics-informed priors
+
+The kernel $k_\theta$ is the entire prior — it determines the smoothness, anisotropy, multi-scale content, and spectral slope of every reconstruction. The Matérn × OU baseline says only "smooth, isotropic, one length scale per axis." Two physical refinements, in increasing order of structural complexity:
+
+### 3a. Clever spectral density — the SQG kernel
+
+In a uniformly stratified ocean with zero interior potential vorticity, the dynamics reduce to a single equation for surface buoyancy[^held1995]:
+
+$$
+\partial_t b_s + J(\psi_s, b_s) \;=\; 0, \qquad b_s = -f \partial_z \psi |_{z=0},
+$$
+
+with surface streamfunction $\psi_s$ recovered from $b_s$ by a **half-Laplacian inversion**:
+
+$$
+\psi_s = (-\nabla^2)^{-1/2} \, b_s / N,
+$$
+
+where $N$ is the upper-ocean buoyancy frequency. Sea level $\eta = f \psi_s / g$ inherits the same spectral relation: $\hat\eta(k) \propto k^{-1} \hat b_s(k)$. Combined with the canonical SQG buoyancy spectrum $\widehat{|b_s|^2}(k) \propto k^{-5/3}$, this gives an **SSH spectral slope of $k^{-11/3}$** in the SQG regime, vs $k^{-5}$ for interior QG turbulence[^lapeyre2006] [^isern2008].
+
+**Use as a GP kernel.** The "SQG kernel" is a stationary kernel whose spectral density follows the $k^{-11/3}$ slope, with a low-wavenumber cutoff at the Rossby deformation radius and a high-wavenumber cutoff at the altimeter noise floor. From the GP point of view this is just a different choice of $S(\omega)$ in Bochner's theorem — feed it into [`pyrox._basis._rff._draw_spectral_frequencies`](file:///home/azureuser/localfiles/pyrox/src/pyrox/_basis/_rff.py) and the rest of the pathwise machinery from 01 stays unchanged. Physically, the prior says "fields with energy concentrated at wavelengths near the deformation radius and a known fall-off rate are *a priori* more plausible" — much sharper than the Matérn fall-off, and it concentrates statistical strength where the ocean actually has variance.
+
+**Where SQG is and isn't valid.** SQG works well[^isern2008] [^gonzalez2014] in the upper ocean of energetic mid-latitude regions, in winter when deep mixed layers maintain near-zero PV, and at mesoscale wavelengths (~50–300 km). It breaks at submesoscale (<50 km) where mixed-layer instabilities dominate[^callies2013], in summer when stratification is shallow, and below the surface mixed layer (use eSQG / interior + surface combinations instead). Pragmatically: use SQG as the *spatial* part of a multi-component kernel (next subsection) and let other components absorb what SQG misses.
+
+### 3b. Structured multi-scale kernels — MIOST / MASSH Gabor wavelets
+
+DUACS uses one global Matérn-like spatial covariance per region with hyperparameters tuned by latitude band[^taburet2019]. **MIOST** (Multiscale Inversion of Ocean Surface Topography, CNES/CLS) replaces this with a *sum of independent components*, each expanded on a redundant tight frame of localised wavelet atoms[^ubelmann2021] [^ballarotta2023]:
+
+$$
+\eta(x, t) \;=\; \sum_{c \in \text{components}} \sum_{i \in \text{atoms}_c} \alpha_i^{(c)} \, \psi_i^{(c)}(x, t).
+$$
+
+Components in operational MIOST: large-scale geostrophy, mesoscale geostrophy, equatorial waves, barotropic motion, internal tides[^ubelmann2021] [^dibarboure2025]. Each component carries its own covariance, diagonal in its wavelet basis (one variance per atom). The global covariance is then a *sum of structured operators* — one block per component.
+
+#### The wavelet atoms
+
+The reference open implementation is the Le Guillou **MASSH** code, mirrored locally at [`jej_vc_snippets/quasigeostrophic_model/massh/basis.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/massh/basis.py). Each atom is a Gaspari–Cohn windowed plane wave (Gabor / Morlet wavelet):
+
+$$
+\psi_i(x, y, t) \;=\; w\!\left(\tfrac{x - x_0}{\Delta_x}\right) w\!\left(\tfrac{y - y_0}{\Delta_x}\right) w\!\left(\tfrac{t - t_0}{\Delta_t}\right) \cdot \sqrt{2}\, \cos\bigl(k_x (x - x_0) + k_y (y - y_0) - \omega (t - t_0) + \varphi\bigr),
+$$
+
+with $w$ a Gaspari–Cohn compact-support window (so atoms genuinely vanish outside $\Delta_x$, unlike Gaussians). The atom is parameterised by
+
+| Symbol | Meaning |
+|---|---|
+| $(x_0, y_0, t_0)$ | atom centre — placed on a hierarchy of grids, one grid per scale octave |
+| $(k_x, k_y, \omega)$ | central wavenumbers (multiples of $2\pi / \lambda$ at the atom's scale) |
+| $\Delta_x, \Delta_t$ | spatial / temporal support radii — typically $\Delta_x = \lambda \cdot n_{\text{psp}} / 2$, with $n_{\text{psp}}=3$ wavelengths per atom |
+| $\varphi$ | $\{0, \pi/2\}$ — gives both cosine and sine atoms (real wavelet pair) |
+
+Each scale octave gets its own grid spacing and its own band of wavenumbers; the user picks the number of octaves to span the resolved range (e.g. $20\,\text{km}$ to $500\,\text{km}$, log-spaced).
+
+#### Why this fits naturally into the pathwise GP
+
+The wavelet expansion is *exactly* a finite-rank, structured prior on $\eta$. Stack the basis evaluations into a feature matrix $\Psi$ and the per-atom variances into a diagonal $\mathbf{D}$:
+
+$$
+\eta = \Psi \alpha, \qquad \alpha \sim \mathcal{N}(0, \mathbf{D}), \qquad \mathbf{D} = \mathrm{diag}(\sigma_i^2)
+\quad\Longrightarrow\quad K_{\mathcal{X}\mathcal{X}} \;=\; \Psi \mathbf{D} \Psi^\top.
+$$
+
+This is a **low-rank + diagonal** kernel — structurally identical to the RFF Woodbury route from [01](01_efficient_machinery.md#3.-route-b-rff-woodbury-approximate-but-very-cheap-when-r-m), with three concrete differences that make it strictly better as an SSH prior:
+
+- **Atoms are localised and bandpass**, not global plane waves. $\Psi$ is *sparse* in space and frequency: each pixel is touched by $\mathcal{O}(\log \lambda_{\max} / \lambda_{\min})$ atoms (one per octave that overlaps it), and each atom touches $\mathcal{O}(\Delta_x^2)$ pixels. Matrix-vector products with $\Psi$ are sparse and embarrassingly parallel — much cheaper than the dense $r(n+m)$ of RFF.
+- **The diagonal $\mathbf{D}$ encodes the energy spectrum directly.** Set $\sigma_i^2$ from a target spectral slope (e.g. $k^{-11/3}$ for SQG, $k^{-3}$ for QG, observed slope from in-region spectra). No kernel-fitting needed.
+- **Components are additive and independent.** $\Psi = [\Psi_{\text{geo}}, \Psi_{\text{eq}}, \Psi_{\text{bt}}, \Psi_{\text{IT}}]$ block-stacks per-component bases; $\mathbf{D}$ is block-diagonal. Each component lives in its own wavelet sub-frame with its own physical interpretation.
+
+In gaussx vocabulary: $\Psi \mathbf{D} \Psi^\top$ is a [`gaussx.LowRankUpdate`](https://github.com/jejjohnson/gaussx/blob/main/src/gaussx/_operators/_low_rank_update.py) with sparse $\Psi$. The noisy Gram $C = \Psi \mathbf{D} \Psi^\top + \sigma_{obs}^2 I$ goes through Woodbury *exactly* as in 01's Route B, but with $\Psi$ implemented as a sparse-matvec instead of a dense feature matrix. **You get the per-day cost numbers from 01's "fully-RFF" column with a physically motivated basis**, plus the multi-component decomposition that DUACS lacks.
+
+Resolution comparison (operational, mid-latitudes): DUACS recovers down to $\sim 150{-}200\,\text{km}$ wavelengths, MIOST down to $\sim 100{-}150\,\text{km}$[^ballarotta2019]. With SWOT KaRIn ingested, MIOST resolves $\sim 50{-}80\,\text{km}$[^dibarboure2025].
+
+#### MIOST vs inducing points — same family, different basis
+
+Both MIOST wavelets and Nyström-style inducing points (`gaussx.nystrom_operator` from [01](01_efficient_machinery.md#3.-route-b-rff-woodbury-approximate-but-very-cheap-when-r-m)) yield a low-rank approximation $K \approx \Psi \mathbf{D} \Psi^\top$. The difference is *what $\Psi$ contains*:
+
+| Method | $\Psi$ columns | $\mathbf{D}$ | Picks up... |
+|---|---|---|---|
+| RFF (01) | random plane waves at frequencies $\omega_j \sim S(\omega)$ | identity | matches the kernel spectral density on average |
+| Nyström inducing points | $K_{\mathcal{X}, \mathcal{Z}}$ with $\mathcal{Z}$ uniformly subsampled obs | $K_{\mathcal{Z}\mathcal{Z}}^{-1}$ | matches the kernel exactly at the inducing locations |
+| MIOST Gabor wavelets | localised bandpass atoms on per-octave grids | diagonal physical variances per scale | matches the *desired* energy spectrum at every scale |
+
+MIOST is the natural choice when (a) you want a per-scale interpretation and (b) you want to add or remove components without retraining. Nyström is the natural choice when you have a kernel you trust and want the cheapest possible approximation. RFF is the natural choice when neither structure helps.
+
+#### Code pointers
+
+- [`massh/basis.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/massh/basis.py) — `WaveletBasis`, `WaveletParameters`, `WaveletGrid` classes; the canonical reference.
+- [`massh/inversion.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/massh/inversion.py) — variational inversion for the wavelet coefficients.
+- [Ocean Data Challenges](https://github.com/ocean-data-challenges) — open MIOST baselines for the 2021/2023/2024 SWOT mapping benchmarks.
+
+---
+
+## 4. Diagnostics — geostrophic currents from $\hat\eta$ (post-hoc)
+
+This is *not* a physics-aware reconstruction step — it is a one-line post-processing of the GP mean using the geostrophic relation in §2b. Compute $\hat\eta$ from the GP, then take finite differences on the grid:
+
+$$
+\hat u_g = -\frac{g}{f}\,\partial_y \hat\eta, \qquad \hat v_g = \frac{g}{f}\,\partial_x \hat\eta.
+$$
+
+This is what DUACS, MIOST, and OSCAR[^bonjean2002] all publish as their L4 surface-current product. **Zero impact on the GP inversion.** Use the user's local [`derivatives/finite_difference_geo.py`](file:///home/azureuser/localfiles/jej_vc_snippets/derivatives/finite_difference_geo.py) — implements $\partial_x, \partial_y$ on a lat–lon grid with the spherical metric $\partial_y \to \partial_y / R$, $\partial_x \to \partial_x / (R \cos\phi)$ — drop the GP mean field through it and you have operational currents.
+
+If you want *uncertainty* on the currents, take finite differences of each posterior sample $\eta^*_s$ from the pathwise loop and compute the empirical std of the resulting $\{u_{g,s}, v_{g,s}\}$ — same pathwise machinery from 01, no extra cost.
+
+---
+
+## Recap — where each physics knob plugs in
+
+| Physics axis | Knob | Touches in the pathwise formula | Cost vs baseline | gaussx primitive |
+|---|---|---|---|---|
+| **DATA — subtract** | Pre-process: tides, DAC, MDT | $y$ (one-shot upstream) | Free | None — pure data step |
+| **DATA — augment** | Drifter / HF radar / Doppler-altimetry velocities as derivative obs | adds rows to $y$ and $K_{\mathcal{X}\mathcal{X}}$; uses `jax.grad(k)` for the derivative-row entries | Linear in number of velocity obs; usually $\ll m_{\text{altimetry}}$ | `ImplicitKernelOperator` with a typed kernel; `jax.grad` |
+| **KERNEL — clever choice** | SQG spectral prior | $S(\omega)$ inside RFF / Bochner | Free — same RFF cost | `pyrox._basis._rff._draw_spectral_frequencies` |
+| **KERNEL — multi-scale basis** | MIOST/MASSH Gabor wavelets | $K = \Psi \mathbf{D} \Psi^\top$ via sparse $\Psi$ | Cheaper — same as 01's "fully-RFF" column with sparse $\Psi$ | `gaussx.LowRankUpdate` + Woodbury solve |
+| **KERNEL — multi-component** | Block-stacked MIOST components (geostrophic + equatorial + barotropic + IT) | $\Psi$ becomes block-stacked, $\mathbf{D}$ block-diagonal | Linear in number of components (free) | `gaussx.LowRankUpdate` (one per component, summed) |
+| **KERNEL — inducing points** | Nyström approximation | $K \approx K_{\mathcal{X}\mathcal{Z}} K_{\mathcal{Z}\mathcal{Z}}^{-1} K_{\mathcal{Z}\mathcal{X}}$ | Same as 01 Route B | `gaussx.nystrom_operator` |
+| **DIAGNOSTIC** | Geostrophic currents from $\hat\eta$ | Finite-difference of GP output | Free (post-hoc) | `jej_vc_snippets/derivatives/finite_difference_geo.py` |
+| *(separate framework)* | 3D-Var / 4D-Var / DYMOST / BFN-QG / 4DVarNet | Replaces the GP prior with a dynamical or learned regulariser | Different framework — see [04](04_variational_dynamical_priors.md) | Outside the gaussx pathwise stack |
+
+### Recommended sequence
+
+For the next concrete step in this project, taking the menu in increasing order of effort and decreasing order of leverage:
+
+1. **DATA — subtract** (a half-day fix). Confirm that you read CMEMS `sla_filtered`, with DAC and MDT already removed. This is the lowest-effort, highest-impact change — running on uncorrected η will be all wrong regardless of what kernel you use.
+2. **KERNEL — multi-scale wavelet basis** on top of `gaussx.LowRankUpdate`. Highest-leverage extension that stays inside the pathwise framework — well-documented, locally-mirrored reference code (MASSH), gives a $\sim 2\times$ resolution improvement over a single-scale Matérn, costs the same as 01's fully-RFF column.
+3. **KERNEL — SQG spectral prior** as the spatial component of one of the wavelet sub-frames. One-line variation on (2); especially helpful in mid-latitude winter.
+4. **DATA — augment with drifter velocities**. Once the kernel is right, derivative obs add cheap, physically meaningful constraints. Plug into the same `gx.ImplicitKernelOperator` with a typed kernel.
+
+For variational baselines (3D-Var, 4D-Var, DYMOST, BFN-QG, 4DVarNet) that replace the GP prior with a dynamical or learned regulariser, see [04_variational_dynamical_priors.md](04_variational_dynamical_priors.md).
+
+---
+
+[^taburet2019]: Taburet, G., Sanchez-Roman, A., Ballarotta, M., Pujol, M.-I., Legeais, J.-F., Fournier, F., Faugere, Y., Dibarboure, G. (2019). "DUACS DT2018: 25 years of reprocessed sea level altimetry products." *Ocean Science* 15, 1207–1224.
+
+[^ballarotta2019]: Ballarotta, M., Ubelmann, C., Pujol, M.-I., Taburet, G., Fournier, F., Legeais, J.-F., Faugère, Y., Delepoulle, A., Chelton, D., Dibarboure, G., Picot, N. (2019). "On the resolutions of ocean altimetry maps." *Ocean Science* 15, 1091–1109.
+
+[^ubelmann2021]: Ubelmann, C., Carrere, L., Pascual, A., Le Guillou, F., Pujol, M.-I., Taburet, G., Picot, N. (2021). "Reconstructing ocean surface current combining altimetry and future spaceborne Doppler data." *J. Geophys. Res. Oceans* 126, e2020JC016560.
+
+[^ballarotta2023]: Ballarotta, M., et al. (2023). "Improved global sea surface height and current maps from remote sensing and in situ observations." *Earth Syst. Sci. Data* 15, 295–315.
+
+[^dibarboure2025]: Dibarboure, G., et al. (2025). "Integrating wide-swath altimetry data into Level-4 multi-mission maps." *Ocean Science* 21, 63–.
+
+[^held1995]: Held, I., Pierrehumbert, R., Garner, S., Swanson, K. (1995). "Surface quasi-geostrophic dynamics." *J. Fluid Mech.* 282, 1–20.
+
+[^lapeyre2006]: Lapeyre, G., Klein, P. (2006). "Dynamics of the upper oceanic layers in terms of surface quasigeostrophy theory." *J. Phys. Oceanogr.* 36, 165–176.
+
+[^isern2008]: Isern-Fontanet, J., Lapeyre, G., Klein, P., Chapron, B., Hecht, M. (2008). "Three-dimensional reconstruction of oceanic mesoscale currents from surface information." *J. Geophys. Res. Oceans* 113, C09005.
+
+[^gonzalez2014]: González-Haro, C., Isern-Fontanet, J. (2014). "Global ocean current reconstruction from altimetric and microwave SST measurements." *J. Geophys. Res. Oceans* 119, 3378–3391.
+
+[^callies2013]: Callies, J., Ferrari, R. (2013). "Interpreting energy and tracer spectra of upper-ocean turbulence in the submesoscale range (1–200 km)." *J. Phys. Oceanogr.* 43, 2456–2474.
+
+[^rio2014]: Rio, M.-H., Mulet, S., Picot, N. (2014). "Beyond GOCE for the ocean circulation estimate: synergetic use of altimetry, gravimetry, and in situ data provides new insight into geostrophic and Ekman currents." *Geophys. Res. Lett.* 41, 8918–8925.
+
+[^bonjean2002]: Bonjean, F., Lagerloef, G. (2002). "Diagnostic model and analysis of the surface currents in the tropical Pacific Ocean." *J. Phys. Oceanogr.* 32, 2938–2954.
+
+[^mulet2021]: Mulet, S., Rio, M.-H., et al. (2021). "The new CNES-CLS18 global mean dynamic topography." *Ocean Science* 17, 789–808.
+
+[^jousset2025]: Jousset, S., Mulet, S., Rio, M.-H., et al. (2025). "New global MDT CNES-CLS-22." *Earth Syst. Sci. Data* 18, 2285– (in press).
+
+[^ardhuin2019]: Ardhuin, F., et al. (2019). "SKIM, a candidate satellite mission exploring global ocean currents and waves." *Frontiers in Marine Science* 6, 209.
+
+[^lyard2021]: Lyard, F. H., Allain, D. J., Cancet, M., Carrère, L., Picot, N. (2021). "FES2014 global ocean tide atlas." *Ocean Science* 17, 615–649.
+
+[^carrere2003]: Carrère, L., Lyard, F. (2003). "Modeling the barotropic response of the global ocean to atmospheric wind and pressure forcing — comparisons with observations." *Geophys. Res. Lett.* 30, 1275.

--- a/projects/interpolation/notebooks/03_global_scaling_patches.md
+++ b/projects/interpolation/notebooks/03_global_scaling_patches.md
@@ -1,0 +1,342 @@
+---
+title: "Scaling SSH reconstruction to the globe — patch decomposition with xrpatcher + dask"
+---
+
+# Scaling to the globe — patch decomposition
+
+The cost numbers in [01_efficient_machinery.md](01_efficient_machinery.md) for the global ocean are uncomfortable. Even with the matrix-free / fully-RFF Route B+ machinery, a reanalysis day at SWOT-era data densities sits at $\sim 5\,\text{s}$ per day on an A100 — and that depends on a single $C \in \mathbb{R}^{m \times m}$ with $m \sim 6 \times 10^6$ fitting into memory, which it largely does not. Cholesky-route exact GP is infeasible past North Atlantic scales; even the implicit operators stop scaling once the per-CG-iter $\mathcal{O}(m^2)$ kernel scan blows past a few minutes.
+
+The standard fix is older than altimetry itself: **localise the inversion**. The SSH covariance has a finite spatial decorrelation length $L_s \sim 100\,\text{km}$, so observations more than $\sim 3 L_s$ from a target grid cell carry essentially no information about it. Cut the globe into overlapping patches, run a local GP on each patch, and stitch the patches back together with a partition-of-unity weighting. Compute scales linearly with the number of patches, memory drops to whatever fits per-patch, and the work is embarrassingly parallel.
+
+This is **exactly what DUACS does operationally**[^taburet2019] — it runs sub-domain optimal interpolation on overlapping $\sim 1000\,\text{km}$ tiles. MIOST relaxes the partition by working in a global wavelet basis instead, but at the cost of giving up some of the parallelism. The patch-wise approach trades a small accuracy degradation at patch edges for arbitrary horizontal scaling.
+
+This note maps the patch-decomposition recipe onto **xrpatcher**[^xrpatcher] (your patch extraction layer for xarray), **dask** (per-patch parallelism), **sklearn `BallTree`** (radius-neighbour queries), and the **Gaspari–Cohn weighted overlap-add** already implemented in your local [`quasigeostrophic_model/_tiling.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/_tiling.py). No new theory — just the assembly.
+
+---
+
+## 1. The localisation argument
+
+Recall the posterior mean from 00:
+
+$$
+\mu_{f|y}(x^*) \;=\; \sum_{j=1}^m k_\theta(x^*, x_j)\, \alpha_j, \qquad \alpha = C^{-1}y.
+$$
+
+For any kernel with finite spatial range $L_s$, the kernel weight $k_\theta(x^*, x_j)$ is below machine epsilon when $\|x^* - x_j\| \gtrsim 5 L_s$ (Matérn-3/2: $k(5L_s)/k(0) \approx e^{-\sqrt{3}\cdot 5} \approx 1.7 \times 10^{-4}$). Two consequences:
+
+- **The dual weight $\alpha_j$ is computed using the global $C^{-1}$**, but the *contribution* of $\alpha_j$ to a far-away $x^*$ is zero. So the long-range coupling in $C^{-1}$ does *not* propagate beyond $\sim 5 L_s$ in the *predicted field*.
+- **Conversely, $\alpha_j$ itself only depends on observations within $\sim 5 L_s$ of $x_j$** (this follows from the fact that the same kernel that suppresses long-range prediction also suppresses long-range entries of $C$).
+
+Together: solving the global $C^{-1} y$ and then evaluating at $x^*$ is, up to a small "boundary tail", equivalent to solving a *local* $C^{-1}_{\text{local}}\, y_{\text{local}}$ where "local" means "within a few $L_s$ of $x^*$". This is the **screening property** of local Gaussian inversions, formalised in the data-assimilation literature as covariance localisation[^houtekamer2005] [^bishop2017].
+
+The patch-wise recipe makes this explicit: each patch solves a small local GP using only nearby observations, the patches overlap by enough to absorb the boundary tail, and a smooth partition-of-unity blend stitches them back together.
+
+---
+
+## 2. Patch geometry with xrpatcher
+
+[`xrpatcher`](https://github.com/jejjohnson/xrpatcher) (your package, with Quentin Febvre) is the right primitive for the **prediction grid** decomposition. It is a single-class API:
+
+```python
+from xrpatcher import XRDAPatcher
+import xarray as xr
+
+# Empty grid DataArray defining the prediction lat/lon mesh.
+grid = xr.DataArray(
+    data=np.zeros((1801, 3601), dtype=np.float32),     # 0.1° global ocean
+    dims=("lat", "lon"),
+    coords={
+        "lat": np.linspace(-90, 90, 1801),
+        "lon": np.linspace(-180, 180, 3601),
+    },
+)
+
+patcher = XRDAPatcher(
+    da            = grid,
+    patches       = {"lat": 256, "lon": 256},          # 25.6° × 25.6° at 0.1°
+    strides       = {"lat": 192, "lon": 192},          # ⇒ 64-cell overlap on each axis
+    domain_limits = {"lat": slice(-80, 80)},           # skip pole rows
+    check_full_scan = False,
+)
+```
+
+Key parameters from the actual [`xrpatcher/_src/base.py`](https://github.com/jejjohnson/xrpatcher/blob/main/xrpatcher/_src/base.py):
+
+| Argument | Role |
+|---|---|
+| `patches` | Per-dim patch size, in cells |
+| `strides` | Per-dim stride. `stride < patch_size` ⇒ overlap; the overlap is the partition-of-unity buffer |
+| `domain_limits` | `da.sel(**domain_limits)` applied first — useful to mask land or skip polar rows |
+| `cache=True` | Materialise patches on first access (recommended for dask-backed `da`) |
+
+Each `patcher[i]` returns an `xr.DataArray` carrying the patch's coordinates, which you use to bound the per-patch observation query.
+
+**Overlap sizing rule.** The overlap on each axis must be at least $\sim 5 L_s$ in cells for the screening argument above to hold. At $0.1°$ resolution and $L_s \approx 100\,\text{km} \approx 1°$ at mid-latitudes, that is $\sim 50$ cells. A 64-cell overlap (12.8°) gives a comfortable margin and pushes patch-edge artefacts below the altimeter noise floor.
+
+---
+
+## 3. Selecting observations per patch — radius-neighbour queries
+
+Each patch needs the subset of observations within its halo. With $\sim 10^6$ obs per day globally and $\sim 200$ patches, naive distance computation is $200 \times 10^6 = 2 \times 10^8$ great-circle distance evaluations — fine, but a single `BallTree` does it faster and gives you the per-patch index lists in one shot.
+
+```python
+from sklearn.neighbors import BallTree
+
+# Build once per time window (NOT per patch).
+obs_lonlat_rad = np.deg2rad(obs_lonlat[:, [1, 0]])   # BallTree expects (lat, lon) in radians
+tree = BallTree(obs_lonlat_rad, metric="haversine")
+
+EARTH_R_KM = 6371.0
+HALO_KM = 5 * Ls_km                                  # 5 × spatial decorrelation length
+
+def obs_for_patch(patch_da):
+    centre_lat = float(patch_da.lat.mean())
+    centre_lon = float(patch_da.lon.mean())
+    # Effective patch radius = half-diagonal + halo
+    half_diag_km = EARTH_R_KM * np.deg2rad(
+        np.hypot(patch_da.lat.size, patch_da.lon.size) * 0.05  # 0.1° / 2
+    )
+    radius_km = half_diag_km + HALO_KM
+    ind = tree.query_radius(
+        np.deg2rad([[centre_lat, centre_lon]]),
+        r = radius_km / EARTH_R_KM,
+    )[0]
+    return ind                                        # indices into the global obs array
+```
+
+`BallTree.query_radius` is $\mathcal{O}(\log m_{\text{global}})$ per patch on the haversine metric. Per-patch obs counts at SWOT-era density and $25°\times 25°$ patches: $\sim 10^4{-}10^5$ — well inside the regime where the gaussx Route A (PCG against implicit kernel) from 01 is fastest.
+
+Time observations follow the same pattern with a 1-D temporal halo of $\sim 5 L_t$ days.
+
+---
+
+## 4. The per-patch GP
+
+This is where 00 / 01 plug in unchanged. Each patch is a small SSH reconstruction problem with $m_{\text{patch}} \sim 10^4{-}10^5$ obs and $n_{\text{patch}} \sim 256^2 = 6.5 \times 10^4$ grid cells:
+
+```python
+import gaussx as gx
+import lineax as lx
+
+def reconstruct_patch(patch_da, obs_idx, y_full, X_obs_full, key):
+    X_obs   = X_obs_full[obs_idx]                     # (m_patch, 3)  lon/lat/time
+    y_obs   = y_full[obs_idx]                         # (m_patch,)
+    X_grid  = grid_coords(patch_da)                   # (n_patch, 3)
+
+    C_op = gx.ImplicitKernelOperator(
+        kernel_fn = k_st_curried,
+        X         = X_obs,
+        noise_var = sigma_obs ** 2,
+        tags      = lx.positive_semidefinite_tag,
+    )
+    Kxs_op = gx.ImplicitCrossKernelOperator(
+        kernel_fn  = k_st_curried,
+        X_data     = X_grid,
+        X_inducing = X_obs,
+        batch_size = 4096,
+    )
+    solver = gx.PreconditionedCGSolver(
+        preconditioner_rank = 50,
+        shift               = sigma_obs ** 2,
+        rtol                = 1e-6,
+        max_steps           = 200,
+    )
+
+    alpha     = gx.solve(C_op, y_obs, solver=solver)
+    mean_field = Kxs_op.mv(alpha).reshape(patch_da.shape)
+
+    # Optional: posterior samples via Matheron — see 01 §3 for the loop.
+    return mean_field                                  # np.ndarray with patch's shape
+```
+
+Per-patch wall-clock at $m_{\text{patch}} = 5 \times 10^4$, $n_{\text{patch}} = 6.5 \times 10^4$ on an A100 (using 01's Route A column scaled down): $\sim 200\,\text{ms}/\text{patch}$. With $\sim 200$ patches covering the global ocean and full per-patch pathwise sampling ($S=100$): $\sim 1\,\text{min}/\text{day}$ at full GPU utilisation — almost an order of magnitude faster than the global RFF+ run from 01, and *exact* GP rather than RFF-approximated.
+
+---
+
+## 5. Stitching — Gaspari–Cohn weighted overlap-add
+
+Two reconstructions of the same grid cell from neighbouring patches are not identical (they used different obs subsets), so the stitching must use a smooth partition-of-unity weight to avoid visible patch boundaries. The right weight is **Gaspari–Cohn**[^gaspari1999]: a compactly-supported 5th-order polynomial that approximates a Gaussian on $[0, 1]$ with $w(0) = 1$, $w(1) = 0$, $w'(0) = w'(1) = 0$, and an exact zero outside $[0, 1]$. The advantage over a Gaussian is the compact support — no truncation, no overlap-tail bleed beyond the patch.
+
+You have an exact implementation in [`quasigeostrophic_model/_tiling.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/_tiling.py) — `_tile_gaspari_cohn_weights(tile_size, overlap)` builds a 2-D weight array peaked at the patch centre, decaying smoothly to zero at the patch edge. Reuse it directly:
+
+```python
+from quasigeostrophic_model._tiling import _tile_gaspari_cohn_weights
+
+w_patch = _tile_gaspari_cohn_weights(
+    tile_size = 256,
+    overlap   = 64,
+)                                                      # (256, 256), peaks at centre
+```
+
+xrpatcher's `XRDAPatcher.reconstruct(items, weight=...)` then does the weighted overlap-add for free:
+
+```python
+patch_results = [reconstruct_patch(patcher[i], ...) for i in range(len(patcher))]
+
+global_field = patcher.reconstruct(
+    items  = patch_results,
+    weight = w_patch,
+)                                                      # xr.DataArray on the full grid
+```
+
+Internally `reconstruct` accumulates `patch * w` into `rec_da` and `w` into `count_da` per patch position, then returns `rec_da / count_da` — i.e. a normalised partition of unity. With Gaspari–Cohn weights and 64-cell overlap, the resulting field is $C^2$-continuous across patch boundaries and free of visible seams.
+
+**Variance estimates compose the same way** — accumulate `var_patch * w**2` (because variances of weighted sums of *independent* draws scale as $\sum w^2 \sigma^2$). For posterior *samples*, blend at the sample level so the per-pixel correlations from each patch's pathwise draw survive.
+
+---
+
+## 6. Parallelism — dask for patches
+
+Each `reconstruct_patch` call is fully independent of the others; the only shared state is the global `BallTree` and the observation arrays (read-only). This is the textbook embarrassingly-parallel pattern. Two routes:
+
+### 6a. dask.delayed for cluster-wide parallelism
+
+```python
+import dask
+from dask.distributed import Client
+
+client = Client(n_workers=8, threads_per_worker=1)     # one worker per GPU/CPU socket
+
+# Scatter the read-only obs arrays once — workers reuse without re-shipping.
+y_full_remote     = client.scatter(y_full,     broadcast=True)
+X_obs_full_remote = client.scatter(X_obs_full, broadcast=True)
+tree_remote       = client.scatter(tree,       broadcast=True)
+
+futures = []
+for i in range(len(patcher)):
+    patch_da = patcher[i]                              # cheap — just slicing
+    obs_idx  = obs_for_patch(patch_da)                 # in-process — small lookup
+    fut = client.submit(
+        reconstruct_patch,
+        patch_da, obs_idx, y_full_remote, X_obs_full_remote,
+        key = jr.fold_in(master_key, i),
+    )
+    futures.append(fut)
+
+patch_results = client.gather(futures)
+global_field  = patcher.reconstruct(patch_results, weight=w_patch)
+```
+
+Throughput scales linearly until you saturate either GPU memory bandwidth or the inter-worker scatter — both happen comfortably past 100 workers.
+
+### 6b. jax.pmap over local devices
+
+For single-node multi-GPU (A100×8 / H100×8), `jax.pmap` over a stack of patches is faster because it avoids the dask serialization overhead. Pad patches to a uniform shape (constant $m_{\text{patch}}$ via dummy obs) so the JIT compiles once:
+
+```python
+@jax.jit
+def reconstruct_one_patch_jit(X_obs, y_obs, X_grid, key):
+    ...                                                # body of reconstruct_patch above
+
+batched = jax.pmap(reconstruct_one_patch_jit)
+patch_results = batched(X_obs_stack, y_obs_stack, X_grid_stack, key_stack)
+```
+
+Padding wastes some compute on the dummy obs but the JIT cache hit and the lack of inter-process communication usually wins. Use this when the global problem fits on one node; switch to dask.delayed when it does not.
+
+### 6c. dask-backed xarray observations
+
+If your raw observation NetCDFs are larger than memory (a year of SWOT L3 data is $\sim 1\,\text{TB}$), open them lazily with `xr.open_mfdataset` and let dask materialise the per-day slice when the BallTree is built. xrpatcher slices stay lazy until `reconstruct_patch` calls `.values`, so memory is bounded by per-patch working set + the dask graph.
+
+---
+
+## 7. Cost analysis — what scales how
+
+Let $P$ be the number of patches and $m_p, n_p$ the per-patch obs / grid sizes. Total cost decomposes as:
+
+| Stage | Cost | Comment |
+|---|---|---|
+| Build global `BallTree` | $\mathcal{O}(m \log m)$ | Once per time window |
+| `query_radius` for $P$ patches | $\mathcal{O}(P \log m + P\, m_p)$ | Cheap |
+| Per-patch GP (Route A) | $\mathcal{O}(\text{n\_iters} \cdot m_p^2 + S\, n_p m_p)$ | The dominant compute |
+| Total (sequential) | $P \cdot \mathcal{O}(\text{n\_iters} \cdot m_p^2 + S\, n_p m_p)$ | |
+| Total (parallel, $W$ workers) | $\frac{P}{W} \cdot \mathcal{O}(\text{n\_iters} \cdot m_p^2 + S\, n_p m_p)$ | Linear speed-up |
+| Stitching | $\mathcal{O}(P\, n_p) = \mathcal{O}(n \cdot \text{overlap-factor})$ | Free |
+
+### Concrete numbers, global ocean, SWOT-era reanalysis day, $L_s = 100\,\text{km}$
+
+- Patch size $25° \times 25° = 256 \times 256$ at $0.1°$ ⇒ $n_p = 6.5 \times 10^4$.
+- Stride $19° \times 19° \Rightarrow$ overlap $6° = 60\,\text{cells} \approx 5 L_s$ at mid-latitudes ✓.
+- Patch count $P \approx 200$ over the global ocean (after masking land — bookkeeping done by `domain_limits` + a land mask).
+- Daily obs $\sim 2 \times 10^6$ globally ⇒ $m_p \sim 2 \times 10^6 / 200 \times \text{(overlap factor 1.5)} \approx 1.5 \times 10^4$ per patch.
+
+Plug into 01's Route A per-day cost model with $S=100$:
+
+- Per-patch flops: $100 \times 100 \times (1.5\text{e}4)^2 + 100 \times 6.5\text{e}4 \times 1.5\text{e}4 \approx 2.3\text{e}{12} + 9.7\text{e}{10} \approx 2.4 \times 10^{12}$.
+- Total flops/day: $200 \times 2.4\text{e}{12} = 4.8 \times 10^{14}$ — vs $4 \times 10^{17}$ for monolithic Route A. **~800× faster.**
+- A100 wall-clock: $\sim 100\,\text{s}/\text{day}$ on a single GPU sequential; **~12 s/day on 8× A100**. For 30 days: $\sim 6\,\text{min}$. For 6 months: $\sim 70\,\text{min}$.
+
+This brings global SWOT-era reanalysis on a single 8-GPU node into the same time bracket as the *fully-RFF* numbers from 01, but with **exact per-patch GP** instead of the RFF approximation — better fidelity at finer scales, no $\mathcal{O}(1/\sqrt{r})$ kernel-approximation bias.
+
+---
+
+## 8. Failure modes and what to watch for
+
+- **Patches with too few observations.** Polar oceans in winter (sea-ice mask), continental shelves with bad QC. Guard each `reconstruct_patch` with an `if len(obs_idx) < min_obs: return prior_mean_only`, where `min_obs` ~ $\mathcal{O}(L_s^2 / \Delta x^2)$ — below this the GP is not constrained anywhere and you should just return the patch's prior mean (zero for SLA).
+- **Coastal patches** have observation distributions that are highly non-uniform (no obs over land); the GP variance in the land-shadow within a patch is large. Either mask land *before* the per-patch solve so it never sees those grid cells, or accept large variances on coastal land cells (they will be discarded downstream anyway).
+- **Patch-boundary discontinuities at long temporal wavelengths.** If you patch in space but treat time globally, no problem. If you also patch in time, the temporal halo must be at least $5 L_t \approx 25{-}50$ days — which forces large temporal patches and largely defeats the purpose. Recommendation: patch in space, run the time window monolithically per patch.
+- **Hyperparameter consistency across patches.** Every patch solves with the same $(\sigma_\eta^2, L_s, L_t, \sigma_{obs}^2)$ — fit hyperparameters once globally on a representative window. Letting each patch fit its own hyperparameters introduces patch-to-patch jumps that show up as visible seams even with Gaspari–Cohn blending.
+- **Land-bridge artefacts.** Two patches separated by a thin land barrier (e.g. Panama, Bering, Bosphorus) can both pull from the same observations on either side, propagating spurious correlations *through* the land. Either use a great-circle distance with a land penalty (route around), or post-process by setting all land-cell values to NaN and verifying patch boundaries do not cross narrow channels.
+- **xrpatcher's `reconstruct` is eager.** It allocates `np.zeros(global_shape)` so for the global $0.1°$ field at $1801 \times 3601 \times 4\,\text{bytes} = 26\,\text{MB}$ this is fine; for a global $0.05°$ output (4× more cells × 8 bytes for float64) you are at $\sim 800\,\text{MB}$ which is still fine but pushes the boundary. For ultra-high-resolution outputs, write each patch directly to a Zarr store at its target offset and skip `reconstruct` entirely.
+
+---
+
+## 9. End-to-end pseudocode
+
+```python
+import dask
+from dask.distributed import Client
+from sklearn.neighbors import BallTree
+from xrpatcher import XRDAPatcher
+from quasigeostrophic_model._tiling import _tile_gaspari_cohn_weights
+
+# --- One-time global setup ---
+grid     = build_global_prediction_grid(resolution_deg=0.1)
+patcher  = XRDAPatcher(grid, patches={"lat": 256, "lon": 256},
+                       strides={"lat": 192, "lon": 192},
+                       domain_limits={"lat": slice(-80, 80)})
+w_patch  = _tile_gaspari_cohn_weights(tile_size=256, overlap=64)
+client   = Client(n_workers=8, threads_per_worker=1)
+
+# --- Per reanalysis day ---
+def reconstruct_day(t_target):
+    obs_lonlat, obs_time, y_obs = load_obs_window(t_target, tau=5)        # CMEMS data
+    tree = BallTree(np.deg2rad(obs_lonlat[:, [1, 0]]), metric="haversine")
+
+    obs_lonlat_r = client.scatter(obs_lonlat, broadcast=True)
+    obs_time_r   = client.scatter(obs_time,   broadcast=True)
+    y_obs_r      = client.scatter(y_obs,      broadcast=True)
+    tree_r       = client.scatter(tree,       broadcast=True)
+
+    futures = []
+    for i, patch_da in enumerate(patcher):
+        obs_idx = obs_for_patch(patch_da, tree, halo_km=500)
+        fut = client.submit(
+            reconstruct_patch,
+            patch_da, obs_idx, y_obs_r, obs_lonlat_r, obs_time_r,
+            key=jr.fold_in(master_key, i * 10000 + day_index(t_target)),
+        )
+        futures.append(fut)
+
+    patch_results = client.gather(futures)
+    return patcher.reconstruct(patch_results, weight=w_patch)
+
+# --- Loop over the reanalysis window ---
+for t in pd.date_range(t_start, t_end, freq="D"):
+    eta_field = reconstruct_day(t)
+    eta_field.to_zarr(output_store, region={"time": slice_for_t(t)})
+```
+
+That is the global SSH pathwise pipeline at scale: `XRDAPatcher` for patch geometry, `BallTree` for obs lookup, the gaussx pathwise machinery from 01 inside each patch, `_tile_gaspari_cohn_weights` for the seam-free blend, dask for parallelism, Zarr for the output. No piece is novel — every component already lives in the user's local repos or established libraries — but the assembly is the answer to "how do I run my GP on the whole ocean without OOM-ing."
+
+---
+
+[^taburet2019]: Taburet, G., Sanchez-Roman, A., Ballarotta, M., Pujol, M.-I., Legeais, J.-F., Fournier, F., Faugere, Y., Dibarboure, G. (2019). "DUACS DT2018: 25 years of reprocessed sea level altimetry products." *Ocean Science* 15, 1207–1224.
+
+[^gaspari1999]: Gaspari, G., Cohn, S. E. (1999). "Construction of correlation functions in two and three dimensions." *Q. J. R. Meteorol. Soc.* 125, 723–757.
+
+[^houtekamer2005]: Houtekamer, P. L., Mitchell, H. L. (2005). "Ensemble Kalman filtering." *Q. J. R. Meteorol. Soc.* 131, 3269–3289. (Covariance localisation as the screening property in EnKF.)
+
+[^bishop2017]: Bishop, C. H., Whitaker, J. S., Lei, L. (2017). "Gain form of the ensemble transform Kalman filter and its relevance to satellite data assimilation with model space ensemble covariance localization." *Mon. Weather Rev.* 145, 4575–4592.
+
+[^xrpatcher]: Johnson, J. E., Febvre, Q. (2024). "xrpatcher: an xarray patch extractor for ML on geophysical fields." [github.com/jejjohnson/xrpatcher](https://github.com/jejjohnson/xrpatcher). Used as the data layer for OceanBench and the SSH-mapping ocean data challenges.

--- a/projects/interpolation/notebooks/04_variational_dynamical_priors.md
+++ b/projects/interpolation/notebooks/04_variational_dynamical_priors.md
@@ -1,0 +1,218 @@
+---
+title: "Variational SSH reconstruction — 3D-Var, 4D-Var, DYMOST, BFN-QG, 4DVarNet"
+---
+
+# Variational reconstruction with dynamical priors
+
+The pipeline in [00](00_ssh_pathwise_sampling.md)–[03](03_global_scaling_patches.md) is a **pathwise Gaussian process** with a static, isotropic prior covariance encoded by a kernel. That works because SSH variability has a known length scale and the inverse problem is mostly one of *interpolation* — fill in the gaps between satellite tracks under a smoothness assumption. It stops working when the dominant signal is *advection* by mesoscale eddies: the field at $t+\tau$ is not a smoothed version of the field at $t-\tau$, it is a *transported* version of it. A static kernel cannot represent that.
+
+This is where data assimilation (DA) takes over. The DA literature has spent fifty years on exactly this problem — combining sparse observations with a dynamical model to estimate an evolving state — and the SSH community has built a tower of methods on it: classical 3D-Var (≈ what we just did), 4D-Var (the time-evolving version), DYMOST (4D-Var with a quasi-geostrophic propagator), BFN-QG (a forward/backward nudging shortcut around the adjoint), and 4DVarNet (a learned variational scheme). All of these *replace* the GP prior with something that knows about ocean physics, so they live outside the gaussx pathwise stack — but they are the right comparison targets, and one of them is likely the operational successor.
+
+This note frames the math, situates each method in the same picture, and gives concrete pointers to the local code that implements them ([`jej_vc_snippets/quasigeostrophic_model/massh/`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/massh/), [`jej_vc_snippets/4dvar/`](file:///home/azureuser/localfiles/jej_vc_snippets/4dvar/)) and to the existing 3D-Var derivation in the plume-simulation project[^pl3dvar]. The aim is *navigational* — you should be able to read this side by side with the SSH-mapping data-challenge papers and see exactly which equation each algorithm is solving.
+
+[^pl3dvar]: A complementary 3D-Var derivation aimed at hyperspectral methane retrieval lives at [`projects/plume_simulation/notebooks/assimilation/00_3dvar_derivation.md`](../../plume_simulation/notebooks/assimilation/00_3dvar_derivation.md) — same math, different application. We borrow its preconditioning and dual-form discussion when relevant.
+
+---
+
+## 1. Variational data assimilation in one paragraph
+
+The *analysis* state $\hat x \in \mathbb{R}^N$ is the MAP estimate under a Gaussian prior $x \sim \mathcal{N}(x_b, B)$ and a Gaussian likelihood $y \mid x \sim \mathcal{N}(\mathcal{H}(x), R)$:
+
+$$
+\hat x \;=\; \arg\min_{x}\;
+\underbrace{\tfrac{1}{2}\,(x - x_b)^\top B^{-1} (x - x_b)}_{\mathcal{J}_{b}(x)\ \text{— background term}}
+\;+\;
+\underbrace{\tfrac{1}{2}\,\bigl(y - \mathcal{H}(x)\bigr)^\top R^{-1} \bigl(y - \mathcal{H}(x)\bigr)}_{\mathcal{J}_{o}(x)\ \text{— observation term}}.
+$$ (eq-3dvar)
+
+The *only* dependence on the analysis problem at hand is in the choice of $(x_b,\, B,\, \mathcal{H},\, R)$. Everything below is a pattern of choices.
+
+| Quantity | Static-GP / 3D-Var | 4D-Var | DYMOST | BFN-QG | 4DVarNet |
+|---|---|---|---|---|---|
+| State $x$ | SSH field at $t$ | SSH field at $t_0$, propagated by a model | SSH field along Lagrangian particles | Trajectory across window | SSH field across window |
+| Prior mean $x_b$ | 0 (anomaly) or DUACS | 0 or previous analysis | model trajectory | model trajectory | 0 or previous analysis |
+| Prior cov $B$ | Matérn × OU kernel | $B$ at $t_0$, propagated by model TLM | static, in propagated frame | implicit (nudging coefficient) | learned $\\Phi_\\theta$ |
+| Forward $\mathcal{H}$ | linear (sample at obs locations) | $\mathcal{H} \circ M^t$ — model-then-sample | $\mathcal{H} \circ M_{\text{QG}}$ | $\mathcal{H} \circ M_{\text{QG}}$ | $\mathcal{H}$ (sample) |
+| Solver | dense / CG / Woodbury | adjoint + LBFGS | adjoint + LBFGS | forward/backward nudging — no adjoint | learned ConvLSTM grad. modulator |
+| Code | gaussx 00/01/03 | massh `inversion.py` | massh `model.py` + `inversion.py` | massh `model.py` (BFN loop) | `fourdvarnet/` |
+
+The rest of the note works through each row.
+
+---
+
+## 2. 3D-Var ≡ static-GP optimal interpolation (sanity check)
+
+The pathwise-GP pipeline from 00–03 *is* 3D-Var. Setting
+
+- $x = \eta(\mathcal{X}^*)$ — the SSH field on the prediction grid,
+- $x_b = 0$ — anomaly convention,
+- $B = K_{\mathcal{X}^* \mathcal{X}^*}$ — the GP prior covariance on the grid,
+- $\mathcal{H}$ = linear interpolation from grid to observation locations,
+- $R = \sigma_{obs}^2 I$,
+
+the 3D-Var cost [eq-3dvar](#eq-3dvar) becomes
+
+$$
+\mathcal{J}(\eta) \;=\; \tfrac{1}{2}\,\eta^\top K_{\mathcal{X}^*\mathcal{X}^*}^{-1}\, \eta \;+\; \tfrac{1}{2\sigma_{obs}^2}\,\bigl(y - \mathcal{H}\eta\bigr)^\top \bigl(y - \mathcal{H}\eta\bigr).
+$$
+
+Setting $\nabla \mathcal{J} = 0$ yields, after the matrix-inversion lemma and a little reorganisation, the GP posterior mean from 00:
+
+$$
+\hat\eta \;=\; K_{\mathcal{X}^*\mathcal{X}}\,(K_{\mathcal{X}\mathcal{X}} + \sigma_{obs}^2 I)^{-1}\, y \;=\; \mu_{f|y}.
+$$
+
+This is the **dual** form of 3D-Var (PSAS) and matches the GP analytical posterior exactly — it is one of those "the same algorithm with two names" results that recurs in DA every five years[^bc1999] [^lorenc2000]. **The static-GP pipeline you already have is already 3D-Var.** Calling it "GP" or "OI" or "3D-Var" only changes which jargon you use to describe its components; the equations are identical.
+
+The reason the GP framing wins for the static case is that the kernel encodes $B$ implicitly via its closed-form covariance function — you never have to *store* $B \in \mathbb{R}^{n \times n}$, you just call `gx.ImplicitKernelOperator`. The DA literature spent decades wrestling with structured representations of $B$ (digital filters[^purser2003], NMC method[^parrish1992], wavelet $B$[^berre2010]); GP kernels solve it for free.
+
+---
+
+## 3. 4D-Var — propagating the analysis through time
+
+3D-Var assumes the field is approximately stationary over the analysis window. When $\tau \cdot u_{\text{eddy}}$ approaches a deformation radius — i.e. an eddy moves by its own diameter during the temporal window — that assumption fails. **4D-Var** fixes it by adding a deterministic dynamical model $M$ to the cost:
+
+$$
+\hat x_0 \;=\; \arg\min_{x_0}\;
+\tfrac{1}{2}\,(x_0 - x_b)^\top B^{-1} (x_0 - x_b)
+\;+\;
+\tfrac{1}{2}\sum_{i=0}^{T} \bigl(y_i - \mathcal{H}(M^i x_0)\bigr)^\top R_i^{-1} \bigl(y_i - \mathcal{H}(M^i x_0)\bigr).
+$$ (eq-4dvar)
+
+The control variable is the **initial state $x_0$**. The model $M$ propagates it through the window; observations at each time $t_i$ are compared to $\mathcal{H}(M^i x_0)$. Two things change vs. 3D-Var:
+
+- **The prior $B$ now propagates implicitly along $M$**: the effective prior at time $t_i$ is $M^i B (M^i)^\top$. So an isotropic Gaussian prior at $t_0$ becomes an anisotropic, eddy-stretched prior at $t_i$ — exactly what the static GP cannot represent.
+- **The cost gradient requires the adjoint $M^\top$**: backpropagating the obs misfit through the model. Hand-coded adjoints used to be a major engineering project (see ECMWF's IFS); JAX does it for you with `jax.grad` provided $M$ is differentiable.
+
+The minimisation is iterative — typically incremental 4D-Var: linearise $M$ and $\mathcal{H}$ around the current trajectory (the "outer loop"), solve the resulting quadratic problem (the "inner loop") with PCG-LBFGS, update the trajectory, repeat[^bc1999]. The control-variable transform from [`plume_simulation/.../00_3dvar_derivation.md` §2`](../../plume_simulation/notebooks/assimilation/00_3dvar_derivation.md) carries over directly: pre-conditioning by $U$ with $B = U U^\top$ collapses the prior to a sphere and makes LBFGS converge in ~10 iterations.
+
+> **In code.** [`jej_vc_snippets/4dvar/src/fourdvarnet/costs.py`](file:///home/azureuser/localfiles/jej_vc_snippets/4dvar/src/fourdvarnet/costs.py) builds [eq-4dvar](#eq-4dvar) for the `(B, T, H, W)` 2-D layout; the gradient is taken via `jax.grad` so the adjoint is implicit. `solver.py` runs the inner-loop LBFGS.
+
+The catch with 4D-Var is the model $M$. For SSH, the relevant model is some flavour of **quasi-geostrophic** dynamics — the natural mid-latitude approximation when the Rossby number is small.
+
+---
+
+## 4. The 1.5-layer QG model — the workhorse propagator for SSH
+
+The simplest model that captures mesoscale eddy advection is the **1.5-layer quasi-geostrophic** equation: an active surface layer over a deep, motionless layer. The SSH $\eta$ acts as a streamfunction (up to the Coriolis factor $g/f$); potential vorticity $q$ is materially conserved:
+
+$$
+q \;=\; \nabla^2 \psi \;-\; \frac{1}{L_R^2}\,\psi, \qquad \psi = g \eta / f,
+$$ (eq-pv)
+
+$$
+\partial_t q \;+\; J(\psi, q) \;=\; 0, \qquad J(\psi, q) = \partial_x \psi \cdot \partial_y q - \partial_y \psi \cdot \partial_x q.
+$$ (eq-qg)
+
+$L_R$ is the first baroclinic Rossby radius (~50 km mid-latitude, ~10 km at high latitudes). The Jacobian $J(\psi, q)$ is the **eddy advection** operator — this is what the static GP cannot express. Numerically: solve the elliptic [eq-pv](#eq-pv) with a Helmholtz solver to get $\psi$ from $q$, advect $q$ along the velocity $(-\partial_y \psi, \partial_x \psi)$ with an upwind or Arakawa scheme.
+
+> **In code.** The user's local [`jej_vc_snippets/quasigeostrophic_model/mqg/qgm.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/mqg/qgm.py) and [`mqg/helmholtz.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/mqg/helmholtz.py) implement the elliptic solve and Arakawa-Jacobian advection in JAX (differentiable). [`mqg/example_natl.py`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/mqg/example_natl.py) runs it on a North Atlantic configuration. This is the same numerical core as the MASSH propagator, just packaged separately.
+
+---
+
+## 5. DYMOST — 4D-Var in particle-following coordinates
+
+DYMOST (Ubelmann, Klein, Fu)[^ubelmann2015] [^ubelmann2020] is a **4D-Var with the 1.5-layer QG model as $M$**, but with a clever simplification: instead of running a full incremental-4D-Var loop, propagate the analysed SSH backward and forward along [eq-qg](#eq-qg) and perform OI in a Lagrangian, *particle-following* frame. In that frame the field looks closer to stationary — the QG flow has done most of the work of "straightening out" the eddies — so a single 3D-Var step on the propagated residual gives a near-optimal answer.
+
+Schematically:
+
+```
+For each obs time t_i in the window:
+  η_propagated_i  =  M^{i - t_target}  η_target            # propagate analysis to obs time
+  innovation_i    =  y_i - H(η_propagated_i)               # residual in observation space
+Combine innovations with a static OI to update η_target.
+```
+
+The whole window thus collapses to one 3D-Var solve (the static-GP machinery from 00/01) on the QG-propagated residuals. **Cost: ~1× a QG forward + 1× backward integration over the window, plus one GP solve.** No adjoint, because the OI step is linear and the QG propagation only enters as a forward operator.
+
+Performance: 30–60% more SSH variance recovered in the western boundary currents (Gulf Stream, Kuroshio) over static OI[^ubelmann2020] — exactly where eddy advection dominates.
+
+---
+
+## 6. BFN-QG — the adjoint-free 4D-Var
+
+Even DYMOST simplifies the adjoint problem; full 4D-Var still needs $M^\top$. Le Guillou et al.[^leguillou2021] [^leguillou2023] propose **back-and-forth nudging**: integrate the QG model forward over the window with a Newtonian relaxation toward observations, then integrate backward with the same relaxation, iterate until both passes agree. The relaxation replaces the gradient descent on the cost — no adjoint, no covariance, no LBFGS.
+
+Forward pass:
+$$
+\partial_t \psi \;=\; -J(\psi, q) \;-\; \kappa \cdot \mathbb{1}_{\text{obs}} \cdot (\mathcal{H}\psi - y),
+$$
+where $\kappa$ is the nudging coefficient (the only hyperparameter) and $\mathbb{1}_{\text{obs}}$ is the indicator at observation locations + times. Backward pass: same equation integrated from $t_0 + T$ down to $t_0$ with reversed time-derivative sign.
+
+Iterate the forward/backward pair $\sim 5$–$10$ times. The final analysis is the forward trajectory at the iteration where forward/backward states agree to within a tolerance.
+
+Pros: **no adjoint, no $B^{-1}$, embarrassingly simple to code** (three loops). Cons: the implicit error covariance is whatever fixed point the nudging settles to — no posterior uncertainty out of the box, no principled way to tune $\kappa$ except by cross-validation. Despite that, BFN-QG matches incremental 4D-Var on the SWOT data challenges[^leguillou2023] in energetic regions, making it the highest-bang-per-buck dynamical method on the menu.
+
+> **In code.** [`jej_vc_snippets/quasigeostrophic_model/massh/`](file:///home/azureuser/localfiles/jej_vc_snippets/quasigeostrophic_model/massh/) is the reference open implementation by Le Guillou. `massh/model.py` runs the QG dynamics; `massh/4dvar.py` and `massh/inversion.py` provide both the BFN loop and a true incremental 4D-Var path. Upstream is [github.com/leguillf/MASSH](https://github.com/leguillf/MASSH).
+
+---
+
+## 7. 4DVarNet — learn the prior, learn the solver
+
+The catch with all of §3–§6 is that the QG model is *only* a model — it captures geostrophic eddy advection, but misses internal tides, ageostrophic motions, submesoscale frontogenesis, and a long tail of finer physics. Hand-extending QG with each missing piece is open-ended. **4DVarNet** (Fablet, Beauchamp et al.)[^beauchamp2023] [^febvre2024] takes a different route: keep the variational *form* of the cost, but replace the hand-crafted prior with a learned regulariser, and replace the gradient solver itself with a learned one.
+
+Cost:
+$$
+\hat x \;=\; \arg\min_{x}\;
+\underbrace{\bigl\|\mathcal{H} x - y\bigr\|^2_{R^{-1}}}_{\mathcal{J}_o\,\text{— observation}}
+\;+\;
+\underbrace{\bigl\|x - \Phi_\theta(x)\bigr\|^2}_{\mathcal{J}_p\,\text{— learned prior}}.
+$$ (eq-4dvarnet-cost)
+
+$\Phi_\theta$ is a neural autoencoder (typically a bilinear convolutional AE on the spatiotemporal patch) trained as a fixed point on plausible SSH fields: $\Phi_\theta(x_{\text{plausible}}) \approx x_{\text{plausible}}$. The prior cost $\|x - \Phi_\theta(x)\|^2$ is then small whenever $x$ is in-distribution and large otherwise — a *learned* characterisation of "plausible SSH."
+
+Learned solver:
+$$
+x_{k+1} \;=\; x_k \;-\; \alpha_k \cdot \Psi_\omega\bigl(\nabla \mathcal{J}(x_k)\bigr) \;-\; \beta_k \cdot \nabla \mathcal{J}(x_k),
+$$ (eq-4dvarnet-solver)
+
+with $\Psi_\omega$ a ConvLSTM "gradient modulator" that learns a state-dependent preconditioner from training data. Training is end-to-end: backpropagate through $K$ unrolled solver iterations to update $(\theta, \omega)$, with implicit differentiation for memory efficiency.
+
+> **In code.** [`jej_vc_snippets/4dvar/src/fourdvarnet/`](file:///home/azureuser/localfiles/jej_vc_snippets/4dvar/src/fourdvarnet/): `priors.py` (autoencoder $\Phi_\theta$), `grad_mod.py` (ConvLSTM $\Psi_\omega$), `solver.py` (the unrolled solver [eq-4dvarnet-solver](#eq-4dvarnet-solver)), `model.py` (`FourDVarNet1D`/`2D` putting it all together), `training.py` (end-to-end fit). The full math reference is in `jej_vc_snippets/4dvar/docs/`.
+
+Performance: 4DVarNet trained on simulation (NATL60, eNATL60) and applied to real SWOT observations beats DUACS / MIOST / BFN-QG by another 5–15% RMSE on the open ocean[^febvre2024], with no further tuning. The price is a training stage that requires a high-resolution simulation ground truth — which is fine for SSH (multiple GCMs available) but expensive to repeat for each new region.
+
+---
+
+## 8. Where this leaves the GP pathwise pipeline
+
+These methods don't *replace* the GP pipeline so much as **sit alongside it at different points on the cost-vs-physics curve**:
+
+| Method | Captures eddy advection? | Cost vs static GP | Posterior uncertainty? | Code |
+|---|---|---|---|---|
+| Static-GP 3D-Var (00/01/03) | No | 1× | Yes (pathwise samples) | gaussx pathwise stack |
+| DYMOST | Yes (linearised) | 3–5× | Yes (around the QG trajectory) | `mqg/`, `massh/` |
+| BFN-QG | Yes | 5–10× | No (nudging fixed point) | `massh/` |
+| Incremental 4D-Var (full QG) | Yes | 10–20× | Yes (Hessian-based) | `massh/`, `4dvar/` |
+| 4DVarNet | Yes (learned) | 1–2× *after training* (training is one-shot) | No (point estimate) | `4dvar/` |
+
+Two practical hybrid recipes:
+
+- **GP residual after a dynamical first guess.** Run BFN-QG or DYMOST to get a $\hat\eta_{\text{dyn}}$; subtract it from the observations; feed the residual through the static GP from 00/01 to model whatever physics the QG missed (internal tides, ageostrophic motions, submesoscale fronts). Final analysis = $\hat\eta_{\text{dyn}} + \hat\eta_{\text{GP residual}}$. This is the cleanest split and keeps both stacks intact.
+- **GP warm-start for 4DVarNet.** Initialise the unrolled solver iteration $x_0$ with the GP posterior mean from 00/01 instead of a zero / climatology. Has been shown to roughly halve the iteration count[^febvre2024]; the GP solve is essentially free relative to the 4DVarNet inference cost.
+
+For the SSH-mapping benchmarks (Ocean Data Challenges, MEOM/IGE), the operational hierarchy as of 2025 is roughly: **DUACS < static GP ≈ MIOST < DYMOST < BFN-QG ≈ incremental-4D-Var < 4DVarNet**, with each step ~5–15% RMSE improvement and ~3–5× compute. The right choice for your project depends on which end of that curve you are willing to live on.
+
+---
+
+[^bc1999]: Bouttier, F., Courtier, P. (1999). *Data assimilation concepts and methods*. Meteorological Training Course Lecture Series, ECMWF.
+
+[^lorenc2000]: Lorenc, A. C., Ballard, S. P., Bell, R. S., Ingleby, N. B., Andrews, P. L. F., Barker, D. M., Bray, J. R., Clayton, A. M., Dalby, T., Li, D., Payne, T. J., Saunders, F. W. (2000). "The Met. Office global three-dimensional variational data assimilation scheme." *Q. J. R. Meteorol. Soc.* 126, 2991–3012.
+
+[^purser2003]: Purser, R. J., Wu, W.-S., Parrish, D. F., Roberts, N. M. (2003). "Numerical aspects of the application of recursive filters to variational statistical analysis. Part I: Spatially homogeneous and isotropic Gaussian covariances." *Mon. Weather Rev.* 131, 1524–1535.
+
+[^parrish1992]: Parrish, D. F., Derber, J. C. (1992). "The National Meteorological Center's spectral statistical-interpolation analysis system." *Mon. Weather Rev.* 120, 1747–1763.
+
+[^berre2010]: Berre, L., Pannekoucke, O., Desroziers, G., Stefanescu, S. E., Chapnik, B., Raynaud, L. (2010). "A variational assimilation ensemble and the spatial filtering of its error covariances: increase of sample size by local spatial averaging." *ECMWF Workshop on Diagnostics of Data Assimilation System Performance*.
+
+[^ubelmann2015]: Ubelmann, C., Klein, P., Fu, L.-L. (2015). "Dynamic interpolation of sea surface height and potential applications for future high-resolution altimetry mapping." *J. Atmos. Ocean. Technol.* 32, 177–184.
+
+[^ubelmann2020]: Ubelmann, C., Cornuelle, B., Fu, L.-L. (2020). "Dynamic mapping of along-track ocean altimetry: performance from real observations." *J. Atmos. Ocean. Technol.* 37, 1691–1707.
+
+[^leguillou2021]: Le Guillou, F., Metref, S., Cosme, E., Ubelmann, C., Ballarotta, M., Le Sommer, J., Verron, J. (2021). "Mapping altimetry in the forthcoming SWOT era by back-and-forth nudging a one-layer quasi-geostrophic model." *J. Atmos. Ocean. Technol.* 38, 697–710.
+
+[^leguillou2023]: Le Guillou, F., Metref, S., Cosme, E., Le Sommer, J., Ubelmann, C., Verron, J., Ballarotta, M. (2023). "Regional mapping of energetic short mesoscale ocean dynamics from altimetry." *Ocean Science* 19, 1517–1530.
+
+[^beauchamp2023]: Beauchamp, M., Febvre, Q., Georgenthum, H., Fablet, R. (2023). "4DVarNet-SSH: end-to-end learning of variational interpolation schemes for nadir and wide-swath satellite altimetry." *Geosci. Model Dev.* 16, 2119–2147.
+
+[^febvre2024]: Febvre, Q., Le Sommer, J., Ubelmann, C., Fablet, R. (2024). "Training neural mapping schemes for satellite altimetry with simulation data." *J. Adv. Model. Earth Syst.* 16, e2023MS003959.


### PR DESCRIPTION
## Summary

New `projects/interpolation/` chapter — five derivation-first notes anchored on SSH reconstruction from satellite altimetry, plus a project README and MyST TOC entry.

| # | Note | Layer |
|---|---|---|
| 00 | [GP pathwise sampling for SSH](../tree/docs/interpolation-ssh-notes/projects/interpolation/notebooks/00_ssh_pathwise_sampling.md) | Math — Matheron's rule from scratch on a Mediterranean SSH problem |
| 01 | [Efficient machinery from gaussx + pyrox](../tree/docs/interpolation-ssh-notes/projects/interpolation/notebooks/01_efficient_machinery.md) | Compute — matrix-free kernels, PCG, Woodbury, LOVE, `PathwiseSampler`; wall-clock budgets |
| 02 | [Physics-aware SSH reconstruction](../tree/docs/interpolation-ssh-notes/projects/interpolation/notebooks/02_physics_aware_ssh.md) | Prior — DATA + KERNEL axes, organised by which term of the pathwise formula they touch |
| 03 | [Scaling to the globe with patch decomposition](../tree/docs/interpolation-ssh-notes/projects/interpolation/notebooks/03_global_scaling_patches.md) | Geometry — `xrpatcher` + `BallTree` + Gaspari–Cohn overlap-add + dask |
| 04 | [Variational SSH reconstruction with dynamical priors](../tree/docs/interpolation-ssh-notes/projects/interpolation/notebooks/04_variational_dynamical_priors.md) | Outside framework — 3DVar / 4DVar / DYMOST / BFN-QG / 4DVarNet |

Notes deliberately kept derivation-first; no `src/` package yet. A future iteration would add a `plume_simulation`-style port implementing the patch-decomposition pipeline from 03 against real CMEMS data.

## Test plan

- [ ] `make docs-serve` and confirm the new "Interpolation (SSH reconstruction)" project appears in the MyST sidebar between Gaussianization and Gaussian processes
- [ ] Spot-check that math renders correctly in 00 (pathwise formula box) and 04 (variational cost equations)
- [ ] Verify cross-doc links work (00 ↔ 01 ↔ 02 ↔ 03 ↔ 04, plus the cross-project link from 04 to `plume_simulation/.../00_3dvar_derivation.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)