### PR TITLE
docs(interpolation): add siren_vs_rff sub-project

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -112,11 +112,18 @@ project:
         - title: Interpolation (SSH reconstruction)
           children:
             - file: projects/interpolation/README
-            - file: projects/interpolation/notebooks/00_ssh_pathwise_sampling
-            - file: projects/interpolation/notebooks/01_efficient_machinery
-            - file: projects/interpolation/notebooks/02_physics_aware_ssh
-            - file: projects/interpolation/notebooks/03_global_scaling_patches
-            - file: projects/interpolation/notebooks/04_variational_dynamical_priors
+            - title: Pathwise GP for SSH
+              children:
+                - file: projects/interpolation/notebooks/00_ssh_pathwise_sampling
+                - file: projects/interpolation/notebooks/01_efficient_machinery
+                - file: projects/interpolation/notebooks/02_physics_aware_ssh
+                - file: projects/interpolation/notebooks/03_global_scaling_patches
+                - file: projects/interpolation/notebooks/04_variational_dynamical_priors
+            - title: SIREN vs. RFF vs. VSSGP
+              children:
+                - file: projects/interpolation/siren_vs_rff/README
+                - file: projects/interpolation/siren_vs_rff/00_siren_rff_vssgp
+                - file: projects/interpolation/siren_vs_rff/01_physics_constraints
         - title: Gaussian processes
           children:
             - file: projects/gaussian_processes/README

--- a/projects/interpolation/README.md
+++ b/projects/interpolation/README.md
@@ -72,17 +72,32 @@ The five notes cover three different framings of the same SSH-mapping problem:
 
 00–03 stay inside the static-prior GP world: the prior $K$ is a kernel, the inverse problem is linear, and the gaussx/pyrox stack does the work. 04 is a separate framework — a dynamical model replaces $K$, and the SSH community's ~50 years of variational data-assimilation work takes over. The two stacks meet at the boundary: see 04 §8 for two practical hybrid recipes (GP residual after a dynamical first guess; GP warm-start for 4DVarNet).
 
+## Sub-project — neural fields, RFF, and VSSGPs
+
+The five notes above all live inside the **pathwise-GP-for-dense-grids** framing. A separate sub-project, [siren_vs_rff/](siren_vs_rff/README.md), takes the orthogonal angle: *for a function class trained on data and then evaluated, including outside the training footprint, which design wins for geoscience — SIREN, RFF, or VSSGP?*
+
+```{seealso}
+- [siren_vs_rff/00_siren_rff_vssgp](siren_vs_rff/00_siren_rff_vssgp.md) — SIREN and RFF as special cases of VSSGP with degenerate priors; the four-rung hierarchy; spectral-budget argument for why geoscience is the wrong domain for SIREN; per-variable physical priors (SSH / SST / SSS / OC); experiment plan with datasets, metrics, ablations.
+- [siren_vs_rff/01_physics_constraints](siren_vs_rff/01_physics_constraints.md) — the three-axis constraint taxonomy (basis / data / loss) for both methods, with the headline that for out-of-domain prediction the leverage ordering is **Data > Basis > Loss**.
+```
+
+The pathwise notes (00–04) and the SIREN/VSSGP sub-project complement each other: pathwise optimises the *grid-sampling* axis given a fixed kernel; siren_vs_rff optimises the *kernel choice* given a fixed training paradigm.
+
 ## Layout
 
 ```text
 projects/interpolation/
 ├── README.md                                       # this file
-└── notebooks/
-    ├── 00_ssh_pathwise_sampling.md                 # math derivation
-    ├── 01_efficient_machinery.md                   # gaussx + pyrox primitives + wall-clock
-    ├── 02_physics_aware_ssh.md                     # data + kernel knobs (DATA / KERNEL axes)
-    ├── 03_global_scaling_patches.md                # patch decomp via xrpatcher + dask
-    └── 04_variational_dynamical_priors.md          # 3DVar / 4DVar / DYMOST / BFN-QG / 4DVarNet
+├── notebooks/
+│   ├── 00_ssh_pathwise_sampling.md                 # math derivation
+│   ├── 01_efficient_machinery.md                   # gaussx + pyrox primitives + wall-clock
+│   ├── 02_physics_aware_ssh.md                     # data + kernel knobs (DATA / KERNEL axes)
+│   ├── 03_global_scaling_patches.md                # patch decomp via xrpatcher + dask
+│   └── 04_variational_dynamical_priors.md          # 3DVar / 4DVar / DYMOST / BFN-QG / 4DVarNet
+└── siren_vs_rff/
+    ├── README.md                                   # sub-project overview
+    ├── 00_siren_rff_vssgp.md                       # SIREN ↔ RFF ↔ VSSGP unification + experiment plan
+    └── 01_physics_constraints.md                   # basis / data / loss axes for OOD prediction
 ```
 
 No `src/` package yet — these are derivations and pseudocode, not a runnable port. A future iteration of the project would add a `plume_simulation`-style `src/interpolation/` package implementing the patch-decomposition pipeline from 03 against real CMEMS data.

--- a/projects/interpolation/siren_vs_rff/00_siren_rff_vssgp.md
+++ b/projects/interpolation/siren_vs_rff/00_siren_rff_vssgp.md
@@ -28,9 +28,9 @@ Before the hierarchy of methods, it's worth setting down four results that every
 
 For any continuous, shift-invariant, positive-definite kernel `k(x, x') = κ(x − x')` normalized so `κ(0) = 1`:
 
-```
-κ(τ) = ∫ exp(i ωᵀ τ) p(ω) dω
-```
+$$
+\kappa(\tau) = \int \exp(i\, \omega^{\!\top} \tau)\, p(\omega)\, d\omega
+$$
 
 i.e. **`κ` and a probability density `p(ω)` are a Fourier pair**. Positive-definiteness of `κ` is equivalent to non-negativity of `p`.
 
@@ -47,28 +47,29 @@ i.e. **`κ` and a probability density `p(ω)` are a Fourier pair**. Positive-def
 
 Take the real form of the Bochner identity (`κ` is real, so we keep only the cosine):
 
-```
-κ(x − x') = E_{ω ~ p, b ~ U[0, 2π]} [ 2 cos(ωᵀx + b) cos(ωᵀx' + b) ]
-```
+$$
+\kappa(x - x') = \mathbb{E}_{\omega \sim p,\; b \sim U[0, 2\pi]}\!\left[\, 2 \cos(\omega^{\!\top} x + b)\, \cos(\omega^{\!\top} x' + b) \,\right]
+$$
 
 Pull `M` samples `(ωᵢ, bᵢ)`. The MC estimator is the inner product of the feature map
 
-```
-φ(x) = √(2/M) [ cos(ω₁ᵀx + b₁), …, cos(ω_Mᵀx + b_M) ]
-k̂(x, x') = φ(x)ᵀ φ(x')
-```
+$$
+\phi(x) = \sqrt{2/M}\, \bigl[\, \cos(\omega_1^{\!\top} x + b_1),\, \ldots,\, \cos(\omega_M^{\!\top} x + b_M) \,\bigr]
+\quad\Longrightarrow\quad
+\hat k(x, x') = \phi(x)^{\!\top} \phi(x')
+$$
 
 *Sample complexity.* Rahimi & Recht (2008, "Uniform Approximation of Functions with Random Bases") show that on a compact set `X ⊂ ℝ^d` of diameter `R`,
 
-```
-P[ sup_{x, x' ∈ X} |k̂(x, x') − k(x, x')| ≥ ε ] ≤ 2⁸ (σ_p R / ε)² exp(−M ε² / (4(d + 2)))
-```
+$$
+\Pr\!\left[\, \sup_{x, x' \in X}\, \bigl|\hat k(x, x') - k(x, x')\bigr| \geq \varepsilon \,\right] \;\leq\; 2^8 \bigl(\sigma_p R / \varepsilon\bigr)^2 \exp\!\bigl(-M \varepsilon^2 / (4(d + 2))\bigr)
+$$
 
 so to drive uniform error below `ε` with high probability you need
 
-```
-M = O( (d / ε²) log(σ_p R / ε) )
-```
+$$
+M = \mathcal{O}\!\bigl( (d / \varepsilon^2)\, \log(\sigma_p R / \varepsilon) \bigr)
+$$
 
 *Engineering consequence.* `M` scales linearly with input dimension and inverse-squared in the kernel error you tolerate. Doubling the precision quadruples `M`. For SSH on `(lon, lat, t)` (`d = 3`) and 1% kernel error you typically need `M` in the low thousands — well within reach of a JAX dense matmul.
 
@@ -76,15 +77,15 @@ M = O( (d / ε²) log(σ_p R / ε) )
 
 If you put a Gaussian prior on the weights of the random feature model
 
-```
-f(x) = φ(x)ᵀ w,    w ~ N(0, Σ_w)
-```
+$$
+f(x) = \phi(x)^{\!\top} w, \qquad w \sim \mathcal{N}(0, \Sigma_w)
+$$
 
 then `f` is itself a Gaussian process with mean `0` and covariance
 
-```
-Cov(f(x), f(x')) = φ(x)ᵀ Σ_w φ(x')
-```
+$$
+\mathrm{Cov}\bigl(f(x), f(x')\bigr) = \phi(x)^{\!\top} \Sigma_w\, \phi(x')
+$$
 
 Setting `Σ_w = σ_f² I` recovers exactly the RFF kernel scaled by `σ_f²`. So the two views are not analogies — they are the **same model, written in different bases**.
 
@@ -99,13 +100,14 @@ Setting `Σ_w = σ_f² I` recovers exactly the RFF kernel scaled by `σ_f²`. So
 
 For RFF/SSGP with Gaussian likelihood `y = Φ w + ε`, `ε ~ N(0, σ_n²I)`:
 
-```
-Σ_post = (Φᵀ Φ / σ_n² + Σ_w⁻¹)⁻¹              # (M, M)
-μ_post = Σ_post Φᵀ y / σ_n²                     # (M,)
-
-mean(f*)  = φ(x*)ᵀ μ_post
-var(f*)   = φ(x*)ᵀ Σ_post φ(x*) + σ_n²
-```
+$$
+\begin{aligned}
+\Sigma_{\text{post}} &= \bigl(\Phi^{\!\top} \Phi / \sigma_n^2 + \Sigma_w^{-1}\bigr)^{-1} \quad &(M \times M) \\
+\mu_{\text{post}}    &= \Sigma_{\text{post}}\, \Phi^{\!\top} y / \sigma_n^2 \quad &(M,) \\
+\mathbb{E}[f^*]      &= \phi(x^*)^{\!\top} \mu_{\text{post}} \\
+\mathrm{Var}[f^*]    &= \phi(x^*)^{\!\top} \Sigma_{\text{post}}\, \phi(x^*) + \sigma_n^2
+\end{aligned}
+$$
 
 *Engineering consequence.* This is one Cholesky on an `M × M` matrix. You get not just a point prediction, but a full predictive distribution at every test point — gap-filling uncertainty for free. SIREN replaces this entire block with `argmin_w ‖y − Φw‖² + λ‖w‖²` (i.e. ridge regression with a single tuned scalar `λ`), losing the per-point variance and the principled regularization-from-the-prior.
 
@@ -113,12 +115,12 @@ var(f*)   = φ(x*)ᵀ Σ_post φ(x*) + σ_n²
 
 The model evidence (with `Σ_w = σ_f² I`)
 
-```
-log p(y | Ω, σ_f, σ_n)
-   = − ½ yᵀ (σ_f² Φ Φᵀ + σ_n² I)⁻¹ y
-     − ½ log |σ_f² Φ Φᵀ + σ_n² I|
-     − (N/2) log 2π
-```
+$$
+\log p(y \mid \Omega, \sigma_f, \sigma_n)
+  = -\tfrac{1}{2}\, y^{\!\top}\!\bigl(\sigma_f^2\, \Phi \Phi^{\!\top} + \sigma_n^2 I\bigr)^{\!-1}\! y
+    \;-\; \tfrac{1}{2}\, \log \!\bigl|\sigma_f^2\, \Phi \Phi^{\!\top} + \sigma_n^2 I\bigr|
+    \;-\; \tfrac{N}{2}\, \log 2\pi
+$$
 
 decomposes into **data-fit** (first term) plus **complexity penalty** (log-determinant). Optimizing this w.r.t. `Ω` and amplitudes pulls spectral mass onto frequencies that explain `y` — but pays a `log|·|` cost for adding mass at frequencies that don't help. There is no equivalent self-regularizing objective in MSE training of SIREN; ω₀ has to be tuned by hand.
 
@@ -143,24 +145,25 @@ decomposes into **data-fit** (first term) plus **complexity penalty** (log-deter
 
 Rahimi & Recht's RFF is an MC approximation to a shift-invariant kernel via Bochner's theorem:
 
-```
-k(x, y) ≈ φ(x)ᵀφ(y),    φ(x) = √(2/D) [cos(ωᵢᵀx + bᵢ)]
-with ωᵢ ~ p_spectral(ω) = FT[k](ω)
-```
+$$
+k(x, y) \;\approx\; \phi(x)^{\!\top}\phi(y), \qquad \phi(x) = \sqrt{2/D}\, \bigl[\cos(\omega_i^{\!\top} x + b_i)\bigr], \qquad \omega_i \sim p_{\text{spectral}}(\omega) = \mathcal{F}[k](\omega)
+$$
 
 The Sparse Spectrum GP (Lázaro-Gredilla et al. 2010) does the same but **optimizes** the ωᵢ via marginal likelihood. VSSGP puts a full variational distribution q(ω) over the spectral points.
 
 ### SIREN → VSSGP with Box Spectral Prior
 
 A 1-layer SIREN:
-```
-f(x) = W₂ sin(ω₀ W₁ x + b₁)
-```
+
+$$
+f(x) = W_2\, \sin\!\bigl(\omega_0\, W_1\, x + b_1\bigr)
+$$
+
 with `W₁ ~ Uniform(-√(6/n), √(6/n))` is implicitly assuming a spectral prior:
 
-```
-p(ω) ∝ Uniform[-ω₀√(6/n), ω₀√(6/n)]ᵈ
-```
+$$
+p(\omega) \propto \mathrm{Uniform}\!\bigl[-\omega_0 \sqrt{6/n},\; \omega_0 \sqrt{6/n}\bigr]^d
+$$
 
 This is a **box spectral prior** — corresponding to a product sinc kernel. VSSGP would let you:
 1. **Infer** the spectral support instead of heuristically choosing ω₀
@@ -195,9 +198,9 @@ The progression is **decreasing assumptions, increasing cost** — but for spars
 
 In a 1-layer SIREN, `W₁ ~ U(−√(6/n), √(6/n))` and the activation is `sin(ω₀ W₁ x)`. The *effective* spectral measure is
 
-```
-ω_effective = ω₀ · W₁  ⇒  p(ω) = U[ −ω₀√(6/n), +ω₀√(6/n) ]ᵈ
-```
+$$
+\omega_{\text{eff}} = \omega_0 \cdot W_1 \quad\Longrightarrow\quad p(\omega) = U\!\bigl[\,-\omega_0 \sqrt{6/n},\; +\omega_0 \sqrt{6/n}\,\bigr]^d
+$$
 
 — i.e. a `d`-dimensional uniform box. The Fourier dual of a box is a sinc, so SIREN's implicit prior kernel is a **product of sinc functions**. This kernel has the worst-of-both-worlds spectral signature: it puts non-trivial mass on *every* frequency up to ω₀ (no preference for known scales) and **zero** mass beyond ω₀ (cannot represent anything finer-scale than the chosen cutoff). For a geoscience signal where the energy lies in a known narrow band, this is exactly inverted from what you want.
 
@@ -209,17 +212,17 @@ In a 1-layer SIREN, `W₁ ~ U(−√(6/n), √(6/n))` and the activation is `sin
 
 Suppose the signal's true spectral support is a set `B ⊂ ℝᵈ` (e.g. for SSH: a band around `|ω| ∈ [2π/300km, 2π/50km]`, plus a delta at the annual frequency). Define the **useful fraction**
 
-```
-η(p) = ∫_B p(ω) dω
-```
+$$
+\eta(p) = \int_B p(\omega)\, d\omega
+$$
 
 i.e. the probability that a single feature lands in the band where signal lives. Then by linearity of expectation, the expected number of useful features out of `M` is `M_useful = M · η(p)`.
 
 For SIREN's box prior in `d = 3` (lon, lat, t), with ω₀ chosen large enough to cover annual + mesoscale (`ω_max ≈ 2π/50km`), the useful fraction is roughly
 
-```
-η_SIREN ≈ vol(B) / vol([−ω_max, ω_max]³) ≈ 10⁻³–10⁻²
-```
+$$
+\eta_{\text{SIREN}} \;\approx\; \mathrm{vol}(B) \,/\, \mathrm{vol}\!\bigl([-\omega_{\max}, \omega_{\max}]^3\bigr) \;\approx\; 10^{-3}\text{–}10^{-2}
+$$
 
 For a spectral-mixture prior centered on the band, `η_VSSGP → 1` by construction. The implication: **with `M = 1024` features, SIREN gets `~10` features in the right place; VSSGP gets `~1024`**. To match VSSGP's effective resolution, SIREN needs `M_SIREN ≈ M_VSSGP / η`, i.e. **two orders of magnitude wider** at this `d` and band geometry. Capacity isn't free — wider networks cost more flops and overfit harder on sparse data.
 
@@ -237,7 +240,7 @@ This is the cleanest engineering argument: the cost of an uninformative prior is
 
 SIREN's ω₀ is a wild guess at this. VSSGP lets you encode it directly:
 
-```
+```text
 # Informative spectral prior for ocean SSH
 ω ~ MixtureOfGaussians(
     μ₁ = 2π / 200km,   # mesoscale eddy peak
@@ -255,10 +258,7 @@ SIREN was designed for dense, regular signals (images, SDFs). Geoscience data is
 - **Atmosphere**: Radiosonde networks are land-biased, satellite swaths have gaps
 - **Land surface**: Stations clustered around populated areas
 
-SIREN has no principled way to handle this. VSSGP gives:
-```
-posterior predictive:  p(f* | X*, X, y)  — proper uncertainty in gaps
-```
+SIREN has no principled way to handle this. VSSGP gives a posterior predictive `p(f* | X*, X, y)` — proper uncertainty in gaps.
 
 ### Physical Constraints Map to the GP Framework Naturally
 
@@ -296,11 +296,11 @@ MIOST (Multi-scale Inversion of Ocean Surface Topography, Ardhuin et al. 2021; L
 
 A Gabor wavelet `g(x) = exp(i ω₀ᵀx) · w(x − x₀)` with window `w` of width `L_s` has Fourier transform `ĝ(ω) = ŵ(ω − ω₀)` — i.e. a **Gaussian-like bump centred on `ω₀ = 2π/L_s` with bandwidth `~1/L_s`**. So MIOST's wavelet dictionary is, in spectral terms, a sum of Gaussians:
 
-```
-p_MIOST(ω) = Σ_n (variance_n / total_var) · N(ω; 2π/L_s,n, σ_n²)
+$$
+p_{\text{MIOST}}(\omega) = \sum_n \frac{\mathrm{var}_n}{\sum_k \mathrm{var}_k}\; \mathcal{N}\!\bigl(\omega;\; 2\pi/L_{s,n},\; \sigma_n^2\bigr), \qquad \sigma_n \approx (2\pi/L_{s,n}) \cdot 0.3
+$$
 
-with σ_n ≈ (2π/L_s,n) · 0.3   # bandwidth ~30% of centre frequency
-```
+(bandwidth ~30% of the centre frequency).
 
 This is *literally* a spectral mixture prior à la Wilson & Adams (2013), with the centres and weights pre-fitted by the altimetry community.
 
@@ -315,11 +315,11 @@ DYMOST (Ubelmann et al. 2015, 2020) advects the SSH covariance along a Lagrangia
 
 The spectral dual of along-stream stretching is **wavenumber compression in the perpendicular direction**:
 
-```
-Σ_ω(x) = R(θ_flow(x))ᵀ · diag( (2π/L_⊥)², (2π/L_∥)² ) · R(θ_flow(x))
+$$
+\Sigma_\omega(x) = R\!\bigl(\theta_{\text{flow}}(x)\bigr)^{\!\top} \cdot \mathrm{diag}\!\bigl(\,(2\pi/L_\perp)^2,\; (2\pi/L_\parallel)^2 \,\bigr) \cdot R\!\bigl(\theta_{\text{flow}}(x)\bigr)
+$$
 
-# wavenumber covariance is squashed perpendicular to the flow direction
-```
+(wavenumber covariance squashed perpendicular to the flow direction).
 
 In a VSSGP this becomes a **location-conditioned spectral covariance**: instead of a single global `Σ_ω`, sample `ωᵢ` from `N(0, Σ_ω(x_patch))` per patch, where `θ_flow` and `L_⊥/L_∥` come from a low-pass-filtered first-guess (or a climatology like AVISO MDT).
 
@@ -387,7 +387,7 @@ The summary: **MIOST and DYMOST tell you where to put the spectral mass; DUACS t
 
 ### SSH (Sea Surface Height)
 
-```
+```text
 # Spatial: power-law spectral density
 p(ω) ∝ |ω|^{-α},   α ≈ 4–5   (mesoscale range)
 
@@ -411,7 +411,7 @@ y | f ~ N(f(x), σ_n²),    σ_n ~ 0.02–0.05 m
 
 ### SST (Sea Surface Temperature)
 
-```
+```text
 # Temporal — seasonal dominates
 p(ω_t) = w₁ · N(2π/365.25, σ₁)    # annual (dominant)
         + w₂ · N(2π/182.6, σ₂)     # semiannual
@@ -427,7 +427,7 @@ y | f ~ StudentT(f(x), σ², ν),    ν ~ 4–7
 
 ### SSS (Sea Surface Salinity)
 
-```
+```text
 # Temporal
 p(ω_t) = w₁ · N(2π/365.25, σ₁)    # seasonal (precipitation cycle)
         + w₂ · N(0, σ_slow)         # interannual
@@ -445,7 +445,7 @@ y | f ~ StudentT(f(x), σ², ν),    ν ~ 3–5
 
 **Key prior: work in log space.** Chl-a is log-normally distributed across the full range (0.01 to >100 mg/m³).
 
-```
+```text
 # Model log(Chl-a), not Chl-a directly
 g(x) = log(Chl-a(x))
 g ~ VSSGP(0, k)
@@ -477,7 +477,7 @@ log(y) | f ~ N(f(x), σ_n²),    σ_n ~ 0.1–0.3 log₁₀ units
 
 ### The Core SSGP Equation
 
-```
+```text
 k(x, x') ≈ φ(x)ᵀ φ(x')
 
 φ(x) = √(2/M) cos(Ω x + b)
@@ -494,7 +494,7 @@ Batched over N inputs:
 ```
 
 Model is Bayesian linear regression in feature space:
-```
+```text
 w   : (M,)        w ~ N(0, σ_w² I)
 f   : (N,)        f = φ(X) @ w   =  (N, M) @ (M,) → (N,)
 y   : (N,)        y ~ N(f, σ_n² I)
@@ -502,7 +502,7 @@ y   : (N,)        y ~ N(f, σ_n² I)
 
 ### Additive Kernel = Concatenated Feature Maps
 
-```
+```text
 φ(X) = [ φ₁(X) | φ₂(X) | φ₃(X) ]     # (N, M1+M2+M3)
 w    = [ w₁    | w₂    | w₃    ]       # (M1+M2+M3,)
 
@@ -633,7 +633,7 @@ def ssgp_model(X, y, Ω1, Ω2, Ω3):
 
 ### Shape Flow Summary
 
-```
+```text
 X       : (N, 3)          ← lon, lat, t for N observations
 
 Ω1      : (M1, 3)         ← spectral pts, slow component
@@ -664,7 +664,7 @@ Two more results worth having in your back pocket — both engineering-flavored,
 
 The kernel admits a Mercer expansion `k(x, x') = Σᵢ λᵢ ψᵢ(x) ψᵢ(x')` with `λ₁ ≥ λ₂ ≥ …`. Truncating to the top `M` eigenfunctions gives an approximation error
 
-```
+```text
 ‖k − k_M‖² = Σ_{i > M} λᵢ²
 ```
 
@@ -676,7 +676,7 @@ For Bochner-type kernels the spectrum's tail is set by the *smoothness* of the f
 
 For SSGP, differentiating the log-marginal-likelihood w.r.t. a single spectral point `ωᵢ`:
 
-```
+```text
 ∂/∂ωᵢ log p(y | Ω) = (yᵀ A⁻¹ ∂Φ/∂ωᵢ wᵢ_eff) − tr(A⁻¹ ∂Φ/∂ωᵢ Φᵀ)
 ```
 
@@ -772,7 +772,7 @@ The interpolation community routinely under-reports metrics; a single RMSE hides
 
 Standard but necessary:
 
-```
+```text
 RMSE  = sqrt( mean( (ŷ − y_true)² ) )
 MAE   = mean( |ŷ − y_true| )
 bias  = mean( ŷ − y_true )
@@ -793,7 +793,7 @@ Per-variable target (OSSE on Z2 Gulf Stream extension, 1 month, full SWOT-era):
 
 Point methods (RFF-ridge, SIREN) cannot compute these — that's the point.
 
-```
+```text
 NLPD  = − mean( log p(y_true | x*) )
       # for Gaussian: ½ log(2π σ²) + ½ (ŷ − y)² / σ²
 
@@ -814,7 +814,7 @@ CRPS is the headline probabilistic metric — proper, scale-aware, low-dimension
 
 This is where SIREN is *expected* to do badly even at competitive RMSE — it gets the spatial autocorrelation wrong.
 
-```
+```text
 Power spectral density (PSD):
    PSD_pred(k)  = |FFT(ŷ − ⟨ŷ⟩)|²
    PSD_true(k)  = |FFT(y_true − ⟨y_true⟩)|²
@@ -844,7 +844,7 @@ Per-variable target on Z2 (Gulf Stream, OSSE):
 
 For SSH especially, the *derived* quantities matter more than `η` itself — operational users want currents, divergence, and vorticity:
 
-```
+```text
 Geostrophic velocity:
    u_g = − (g/f) ∂η/∂y     v_g = (g/f) ∂η/∂x
    RMSE_u = sqrt( mean( (û − u_drifter)² ) )      # vs GDP drifters
@@ -868,7 +868,7 @@ These metrics are the ones DUACS/MIOST publish — they're how the community acc
 
 #### 6.5.1 SSH — anchor variable, fullest treatment
 
-```
+```text
 Method ladder × 4:    {RFF-ridge, SIREN, SSGP, VSSGP-MIOST-init}
 Region ladder × 4:    {Med, Gulf Stream, N. Atl, Global}
 Time horizon × 3:     {1 month, 3 months, 6 months}
@@ -884,7 +884,7 @@ SWOT ablation × 2:    {nadir-only, nadir + SWOT}
 
 #### 6.5.2 SST — diurnal cycle and fronts
 
-```
+```text
 Method ladder: same 4
 Region: Med + Gulf Stream + Global (skip N. Atl alone — covered)
 Likelihood: Student-T with ν ∈ {3, 5, 7} ablation (cloud-contamination tail)
@@ -897,7 +897,7 @@ Special diagnostic: gradient magnitude F1 score for fronts
 
 #### 6.5.3 SSS — extreme non-stationarity
 
-```
+```text
 Region: Amazon plume (3-week experiment), tropical Atlantic, global
 Special: σ_w(x) field MUST be spatially varying — open-ocean σ_w ≈ 0.5 PSU,
          plume σ_w ≈ 3-5 PSU; flat σ_w fails by construction
@@ -909,7 +909,7 @@ Special: σ_w(x) field MUST be spatially varying — open-ocean σ_w ≈ 0.5 PSU
 
 #### 6.5.4 OC / Chl-a — log-space and bloom dynamics
 
-```
+```text
 Region: N. Atlantic spring bloom (March-May), Arabian Sea (SW monsoon),
         Southern Ocean (austral spring), global
 Transform: log₁₀ — the entire model lives in log space
@@ -950,7 +950,7 @@ For the full method × region × variable × ablation grid: roughly **300–400 
 
 Each variable + region combo produces one results row. Recommended format:
 
-```
+```text
 | Method        | RMSE  | CRPS  | NLPD  | L_eff | RMSE u_g | ECE |
 |---------------|-------|-------|-------|-------|----------|-----|
 | RFF-ridge     | 4.2cm |   —   |   —   | 140km |  9.3cm/s |  —  |

--- a/projects/interpolation/siren_vs_rff/00_siren_rff_vssgp.md
+++ b/projects/interpolation/siren_vs_rff/00_siren_rff_vssgp.md
@@ -1,0 +1,990 @@
+---
+title: "SIREN ↔ RFF ↔ VSSGP — Bayesian Fourier features for geoscience interpolation"
+---
+
+# SIREN, RFF, and Variational Sparse Spectrum GPs for geoscience
+
+A reading of the SIREN / Random Fourier Feature (RFF) / Variational Sparse Spectrum GP (VSSGP) family from a geoscience-interpolation viewpoint. The thesis: **SIREN and RFF are special cases of VSSGP with degenerate spectral priors** — and for sparse, banded, irregularly-sampled geophysical fields (SSH, SST, SSS, ocean colour) the VSSGP framing is *strictly more useful* because the spectral structure is something we already know.
+
+This note is split into seven layers, in increasing order of structural sophistication:
+
+1. **§0** — applied-math foundations (Bochner, RFF as Monte Carlo, weight-space ↔ function-space duality, sample complexity, marginal likelihood as Occam's razor).
+2. **§1** — SIREN / RFF as special cases of VSSGP, with the four-rung hierarchy.
+3. **§2** — why geoscience is the wrong domain for SIREN, with a spectral-budget argument.
+4. **§3** — physical priors for SSH / SST / SSS / OC, including the operational-prior recipe (MIOST / DYMOST / DUACS → VSSGP).
+5. **§4** — additive-component construction in VSSGP, with a worked SSH example.
+6. **§5** — approximation-error and marginal-likelihood-compass results.
+7. **§6** — the experiment plan (datasets, metrics, ablations, compute budget).
+
+Companion: [01_physics_constraints.md](01_physics_constraints.md) — how to enforce physical constraints (basis / data / loss) on top of any of these methods, with explicit out-of-domain prediction in mind.
+
+---
+
+## 0. Why Any of This Works — Applied Foundations
+
+Before the hierarchy of methods, it's worth setting down four results that everything else rests on. Each is one line of theory plus one line of "what this buys you in practice."
+
+### 0.1 Bochner's theorem — the bridge
+
+For any continuous, shift-invariant, positive-definite kernel `k(x, x') = κ(x − x')` normalized so `κ(0) = 1`:
+
+```
+κ(τ) = ∫ exp(i ωᵀ τ) p(ω) dω
+```
+
+i.e. **`κ` and a probability density `p(ω)` are a Fourier pair**. Positive-definiteness of `κ` is equivalent to non-negativity of `p`.
+
+*Engineering consequence.* Picking a kernel and picking a spectral density are the same act. Once you have either, the other is determined by an FFT. This is why you are allowed to design priors directly in the Fourier domain — which is exactly where physical knowledge of geoscience signals lives (annual cycles, mesoscale band, tidal frequencies).
+
+| Kernel | `p(ω)` | Geoscience use |
+|---|---|---|
+| Squared exponential | `N(0, ℓ⁻²)` | smooth fields, no preferred scale |
+| Matérn-ν | Multivariate Student-t | rough fields with controlled differentiability |
+| Cosine | `δ(ω − ω₀)` | exact harmonic (annual, diurnal) |
+| Spectral mixture (Wilson & Adams) | `Σ wᵢ N(μᵢ, Σᵢ)` | banded structure (mesoscale + gyre + tide) |
+
+### 0.2 RFF as Monte Carlo of the Bochner integral
+
+Take the real form of the Bochner identity (`κ` is real, so we keep only the cosine):
+
+```
+κ(x − x') = E_{ω ~ p, b ~ U[0, 2π]} [ 2 cos(ωᵀx + b) cos(ωᵀx' + b) ]
+```
+
+Pull `M` samples `(ωᵢ, bᵢ)`. The MC estimator is the inner product of the feature map
+
+```
+φ(x) = √(2/M) [ cos(ω₁ᵀx + b₁), …, cos(ω_Mᵀx + b_M) ]
+k̂(x, x') = φ(x)ᵀ φ(x')
+```
+
+*Sample complexity.* Rahimi & Recht (2008, "Uniform Approximation of Functions with Random Bases") show that on a compact set `X ⊂ ℝ^d` of diameter `R`,
+
+```
+P[ sup_{x, x' ∈ X} |k̂(x, x') − k(x, x')| ≥ ε ] ≤ 2⁸ (σ_p R / ε)² exp(−M ε² / (4(d + 2)))
+```
+
+so to drive uniform error below `ε` with high probability you need
+
+```
+M = O( (d / ε²) log(σ_p R / ε) )
+```
+
+*Engineering consequence.* `M` scales linearly with input dimension and inverse-squared in the kernel error you tolerate. Doubling the precision quadruples `M`. For SSH on `(lon, lat, t)` (`d = 3`) and 1% kernel error you typically need `M` in the low thousands — well within reach of a JAX dense matmul.
+
+### 0.3 Weight-space ↔ function-space duality
+
+If you put a Gaussian prior on the weights of the random feature model
+
+```
+f(x) = φ(x)ᵀ w,    w ~ N(0, Σ_w)
+```
+
+then `f` is itself a Gaussian process with mean `0` and covariance
+
+```
+Cov(f(x), f(x')) = φ(x)ᵀ Σ_w φ(x')
+```
+
+Setting `Σ_w = σ_f² I` recovers exactly the RFF kernel scaled by `σ_f²`. So the two views are not analogies — they are the **same model, written in different bases**.
+
+| View | Object you optimize | Cost dominated by |
+|---|---|---|
+| Function-space | Posterior mean `μ(x*) = k_*ᵀ (K + σ_n²I)⁻¹ y` | `O(N³)` for `(K + σ_n²I)⁻¹` |
+| Weight-space (RFF) | Posterior mean `μ(x*) = φ(x*)ᵀ E[w | y]` | `O(N M² + M³)` |
+
+*Engineering consequence.* When `M ≪ N` (the geoscience regime — `N ~ 10⁶`, `M ~ 10³`), weight-space is asymptotically `(N/M)²` cheaper. The whole reason SSGP/VSSGP exists as a *practical* method, not just a theoretical bridge, is that the duality flips the cost direction.
+
+### 0.4 Posterior in closed form (the bit that SIREN throws away)
+
+For RFF/SSGP with Gaussian likelihood `y = Φ w + ε`, `ε ~ N(0, σ_n²I)`:
+
+```
+Σ_post = (Φᵀ Φ / σ_n² + Σ_w⁻¹)⁻¹              # (M, M)
+μ_post = Σ_post Φᵀ y / σ_n²                     # (M,)
+
+mean(f*)  = φ(x*)ᵀ μ_post
+var(f*)   = φ(x*)ᵀ Σ_post φ(x*) + σ_n²
+```
+
+*Engineering consequence.* This is one Cholesky on an `M × M` matrix. You get not just a point prediction, but a full predictive distribution at every test point — gap-filling uncertainty for free. SIREN replaces this entire block with `argmin_w ‖y − Φw‖² + λ‖w‖²` (i.e. ridge regression with a single tuned scalar `λ`), losing the per-point variance and the principled regularization-from-the-prior.
+
+### 0.5 Marginal likelihood as automatic Occam's razor
+
+The model evidence (with `Σ_w = σ_f² I`)
+
+```
+log p(y | Ω, σ_f, σ_n)
+   = − ½ yᵀ (σ_f² Φ Φᵀ + σ_n² I)⁻¹ y
+     − ½ log |σ_f² Φ Φᵀ + σ_n² I|
+     − (N/2) log 2π
+```
+
+decomposes into **data-fit** (first term) plus **complexity penalty** (log-determinant). Optimizing this w.r.t. `Ω` and amplitudes pulls spectral mass onto frequencies that explain `y` — but pays a `log|·|` cost for adding mass at frequencies that don't help. There is no equivalent self-regularizing objective in MSE training of SIREN; ω₀ has to be tuned by hand.
+
+*Engineering consequence.* The marginal likelihood gradient w.r.t. spectral points is exactly the signal that says "your spectral prior is wrong, move mass *here*". This is what SSGP exploits; VSSGP softens point-optimized `Ω` to a variational posterior `q(Ω)` to prevent the well-known SSGP overfitting pathology (Lázaro-Gredilla et al. 2010, §5).
+
+---
+
+## 1. SIREN / RFF as Special Cases of VSSGP
+
+**Core claim:** The SIREN and Random Fourier Features (RFF) methods from the neural networks community are special cases of Variational Sparse Spectrum GPs (VSSGP) and Random Feature Expansions (RFE) from the GP community — with uninformative/degenerate priors and no posterior.
+
+### Correspondence Table
+
+| Neural Field | GP Counterpart | What's Missing in the NN Version |
+|---|---|---|
+| RFF (Rahimi & Recht) | Sparse Spectrum GP (fixed ω, no Bayes) | No posterior, just a kernel approximation |
+| SIREN (1-layer) | VSSGP with specific spectral prior p(ω) | Bayesian treatment of weights + frequencies |
+| Deep SIREN | Deep GP with sinusoidal RFEs | Uncertainty propagation across layers |
+| ω₀ + init heuristic | Kernel lengthscale / spectral density | Principled derivation via Bochner's theorem |
+
+### RFF → Sparse Spectrum GP
+
+Rahimi & Recht's RFF is an MC approximation to a shift-invariant kernel via Bochner's theorem:
+
+```
+k(x, y) ≈ φ(x)ᵀφ(y),    φ(x) = √(2/D) [cos(ωᵢᵀx + bᵢ)]
+with ωᵢ ~ p_spectral(ω) = FT[k](ω)
+```
+
+The Sparse Spectrum GP (Lázaro-Gredilla et al. 2010) does the same but **optimizes** the ωᵢ via marginal likelihood. VSSGP puts a full variational distribution q(ω) over the spectral points.
+
+### SIREN → VSSGP with Box Spectral Prior
+
+A 1-layer SIREN:
+```
+f(x) = W₂ sin(ω₀ W₁ x + b₁)
+```
+with `W₁ ~ Uniform(-√(6/n), √(6/n))` is implicitly assuming a spectral prior:
+
+```
+p(ω) ∝ Uniform[-ω₀√(6/n), ω₀√(6/n)]ᵈ
+```
+
+This is a **box spectral prior** — corresponding to a product sinc kernel. VSSGP would let you:
+1. **Infer** the spectral support instead of heuristically choosing ω₀
+2. Place a proper Gaussian prior on W₂ → closed-form posterior
+3. Optimize the ELBO rather than MSE → built-in regularization
+
+### The "Better Constrained" Argument
+
+| Issue | SIREN | VSSGP |
+|---|---|---|
+| ω₀ tuning | Heuristic, fragile | Marginal likelihood gradient |
+| Weight prior | Implicit (optimizer trajectory) | Explicit N(0, σ²I) |
+| Function space | NTK (implicit) | Named RKHS |
+| Uncertainty | None | Posterior q(w) |
+
+**SIREN is VSSGP with a degenerate (improper flat) weight prior and frequencies fixed by initialization rather than optimized/marginalized.**
+
+### The Four-Rung Hierarchy
+
+All four methods share the same forward model `f(x) = φ(x)ᵀ w` with `φ` built from `Ω`. They differ only in **what is treated as fixed, point-estimated, or distributional**:
+
+| Method | `Ω` (frequencies) | `w` (weights) | Objective | Cost per train step |
+|---|---|---|---|---|
+| RFF (Rahimi-Recht) | sampled once from `p(ω)`, **fixed** | ridge regression closed-form | `‖y − Φw‖² + λ‖w‖²` | `O(N M² + M³)` once |
+| SSGP (Lázaro-Gredilla 2010) | **point-optimized** via marginal likelihood | closed-form posterior `N(μ, Σ)` | `log p(y \| Ω, θ)` | `O(N M² + M³)` per gradient step |
+| VSSGP (Gal & Turner 2015) | variational `q(Ω) = N(μ_Ω, σ_Ω²)` with prior `p(ω)` | variational `q(w)` (or marginalized) | ELBO | `O(N M² + M³)` per ELBO step |
+| SIREN (Sitzmann 2020) | **fixed by init**, scaled by ω₀ | point-optimized via SGD | `‖y − Φw‖²` (no prior) | `O(N M)` per SGD step (depth-multiplied) |
+
+The progression is **decreasing assumptions, increasing cost** — but for sparse geoscience data, the cost is dominated by `M`, not by which rung you're on, so going to the top rung is essentially free relative to the compute you've already committed.
+
+### What SIREN's Init Heuristic Actually Sets
+
+In a 1-layer SIREN, `W₁ ~ U(−√(6/n), √(6/n))` and the activation is `sin(ω₀ W₁ x)`. The *effective* spectral measure is
+
+```
+ω_effective = ω₀ · W₁  ⇒  p(ω) = U[ −ω₀√(6/n), +ω₀√(6/n) ]ᵈ
+```
+
+— i.e. a `d`-dimensional uniform box. The Fourier dual of a box is a sinc, so SIREN's implicit prior kernel is a **product of sinc functions**. This kernel has the worst-of-both-worlds spectral signature: it puts non-trivial mass on *every* frequency up to ω₀ (no preference for known scales) and **zero** mass beyond ω₀ (cannot represent anything finer-scale than the chosen cutoff). For a geoscience signal where the energy lies in a known narrow band, this is exactly inverted from what you want.
+
+---
+
+## 2. Why Geoscience Data is the Wrong Domain for SIREN
+
+### Spectral Budget — How Many of Your `M` Features Land Where the Signal Is?
+
+Suppose the signal's true spectral support is a set `B ⊂ ℝᵈ` (e.g. for SSH: a band around `|ω| ∈ [2π/300km, 2π/50km]`, plus a delta at the annual frequency). Define the **useful fraction**
+
+```
+η(p) = ∫_B p(ω) dω
+```
+
+i.e. the probability that a single feature lands in the band where signal lives. Then by linearity of expectation, the expected number of useful features out of `M` is `M_useful = M · η(p)`.
+
+For SIREN's box prior in `d = 3` (lon, lat, t), with ω₀ chosen large enough to cover annual + mesoscale (`ω_max ≈ 2π/50km`), the useful fraction is roughly
+
+```
+η_SIREN ≈ vol(B) / vol([−ω_max, ω_max]³) ≈ 10⁻³–10⁻²
+```
+
+For a spectral-mixture prior centered on the band, `η_VSSGP → 1` by construction. The implication: **with `M = 1024` features, SIREN gets `~10` features in the right place; VSSGP gets `~1024`**. To match VSSGP's effective resolution, SIREN needs `M_SIREN ≈ M_VSSGP / η`, i.e. **two orders of magnitude wider** at this `d` and band geometry. Capacity isn't free — wider networks cost more flops and overfit harder on sparse data.
+
+This is the cleanest engineering argument: the cost of an uninformative prior is paid in spent feature budget, and that budget isn't recoverable by training longer.
+
+### The Spectral Structure is Known A Priori
+
+| Field | Known Spectral Features |
+|---|---|
+| Ocean SSH | Mesoscale eddy band ~100–300 km, internal tides, inertial oscillations |
+| Atmosphere | Diurnal/semidiurnal harmonics, synoptic scales, planetary waves |
+| Land surface temp | Annual + semiannual cycles, diurnal, known spatial correlation lengths |
+| Soil moisture | Seasonal + storm-scale, exponential spatial decay |
+| Methane | Seasonal biogenic signal, specific plume spatial scales |
+
+SIREN's ω₀ is a wild guess at this. VSSGP lets you encode it directly:
+
+```
+# Informative spectral prior for ocean SSH
+ω ~ MixtureOfGaussians(
+    μ₁ = 2π / 200km,   # mesoscale eddy peak
+    μ₂ = 2π / 500km,   # large-scale gyre
+)
+
+# vs SIREN's implicit prior:
+ω ~ Uniform[-ω₀√(6/n), ω₀√(6/n)]   # knows nothing
+```
+
+### Geoscience Data is Sparse and Irregular
+
+SIREN was designed for dense, regular signals (images, SDFs). Geoscience data is almost never this:
+- **Ocean**: Argo floats are random, altimetry has track geometry
+- **Atmosphere**: Radiosonde networks are land-biased, satellite swaths have gaps
+- **Land surface**: Stations clustered around populated areas
+
+SIREN has no principled way to handle this. VSSGP gives:
+```
+posterior predictive:  p(f* | X*, X, y)  — proper uncertainty in gaps
+```
+
+### Physical Constraints Map to the GP Framework Naturally
+
+- **Smoothness** → Matérn kernel order ν
+- **Divergence-free flows** → Helmholtz GP decomposition
+- **Periodic boundaries** → Periodic kernels with known period
+- **Non-stationarity** → Spatially varying lengthscale
+
+### SIREN Convergence is Structurally Fragile
+
+The initialization solves two coupled problems with a single heuristic (ω₀):
+1. Keep activation distributions stable through layers
+2. Cover the target frequency range
+
+In VSSGP this doesn't exist as a problem — spectral points are initialized from your physical prior and optimized via marginal likelihood.
+
+---
+
+## 3. Physical Priors for Ocean Variables
+
+### 3.0 Operational SSH mapping schemes ARE fitted spectral priors
+
+Three operational schemes — DUACS, MIOST/MASSH, and DYMOST — have spent the last 30 years fitting prior covariances to global altimetry. Their tuned hyperparameters drop into VSSGP with almost no translation work. Treating them as "the spectral prior we'd otherwise have to learn from scratch" is the single biggest free win available for SSH.
+
+#### 3.0.1 MIOST → spectral-mixture prior with Gabor components
+
+MIOST (Multi-scale Inversion of Ocean Surface Topography, Ardhuin et al. 2021; Le Guillou et al. 2021) decomposes SSH into a sum of **Gabor wavelets** — plane waves modulated by Gaspari-Cohn windows — at three to four scales:
+
+| MIOST component | Spatial scale `L_s` | Temporal scale `τ` | Variance share |
+|---|---|---|---|
+| Large-scale (gyre) | 800–1500 km | 60–120 days | ~30–40% |
+| Mesoscale | 150–300 km | 20–40 days | ~40–50% |
+| Sub-mesoscale (SWOT-era) | 30–80 km | 3–10 days | ~10–20% |
+| Equatorial / waveguide | 200–500 km × 50–100 km (anisotropic) | 30–60 days | regional only |
+
+A Gabor wavelet `g(x) = exp(i ω₀ᵀx) · w(x − x₀)` with window `w` of width `L_s` has Fourier transform `ĝ(ω) = ŵ(ω − ω₀)` — i.e. a **Gaussian-like bump centred on `ω₀ = 2π/L_s` with bandwidth `~1/L_s`**. So MIOST's wavelet dictionary is, in spectral terms, a sum of Gaussians:
+
+```
+p_MIOST(ω) = Σ_n (variance_n / total_var) · N(ω; 2π/L_s,n, σ_n²)
+
+with σ_n ≈ (2π/L_s,n) · 0.3   # bandwidth ~30% of centre frequency
+```
+
+This is *literally* a spectral mixture prior à la Wilson & Adams (2013), with the centres and weights pre-fitted by the altimetry community.
+
+*Engineering consequence.* In VSSGP you don't need to discover that the energy lives in a gyre + mesoscale + sub-mesoscale band — you initialize `μ_Ω` at the MIOST centres, allocate `M_n` features per component proportionally to the variance share, and let the marginal-likelihood gradient *refine* the centres locally instead of *finding* them globally. This converts a non-convex spectral search into local refinement.
+
+#### 3.0.2 DYMOST → anisotropic, flow-aligned spectral measure
+
+DYMOST (Ubelmann et al. 2015, 2020) advects the SSH covariance along a Lagrangian first-guess velocity field `u_g`, derived from a 1.5-layer QG model run on the prior mean. The effective covariance has two properties that a stationary `p(ω)` cannot capture:
+
+1. **Anisotropy:** along-stream lengthscale `L_∥ ≈ 2–4 × L_⊥` in strong currents (Gulf Stream, Kuroshio, ACC).
+2. **Spatial dependence:** `L_∥(x), L_⊥(x)` track local eddy kinetic energy.
+
+The spectral dual of along-stream stretching is **wavenumber compression in the perpendicular direction**:
+
+```
+Σ_ω(x) = R(θ_flow(x))ᵀ · diag( (2π/L_⊥)², (2π/L_∥)² ) · R(θ_flow(x))
+
+# wavenumber covariance is squashed perpendicular to the flow direction
+```
+
+In a VSSGP this becomes a **location-conditioned spectral covariance**: instead of a single global `Σ_ω`, sample `ωᵢ` from `N(0, Σ_ω(x_patch))` per patch, where `θ_flow` and `L_⊥/L_∥` come from a low-pass-filtered first-guess (or a climatology like AVISO MDT).
+
+*Engineering consequence.* This pairs naturally with the patch-decomposition recipe in [03_global_scaling_patches](../notebooks/03_global_scaling_patches.md). Each patch gets its own `Σ_ω(x_patch)` from the DYMOST first-guess; the global VSSGP becomes a mixture of patch-local anisotropic VSSGPs, stitched with Gaspari-Cohn weights.
+
+#### 3.0.3 DUACS → empirical variance and lengthscale fields
+
+DUACS (the operational AVISO/CMEMS product, Pujol et al. 2016; Taburet et al. 2019) fits **per-pixel** variance `σ²(x)` and isotropic lengthscale `L(x)` from a 30-year SLA reanalysis. These are public data products — `cmems_obs-sl_glo_phy-mdt_my_allsat-l4-duacs_P1Y` and the auxiliary lengthscale grids.
+
+Two direct uses in VSSGP:
+
+| DUACS field | VSSGP role | Where it goes |
+|---|---|---|
+| `σ²(x)` (SLA variance) | Spatially varying weight-prior amplitude | `σ_w(x) = √σ²(x)` per patch |
+| `L(x)` (correlation lengthscale) | Spatial scaling of `Σ_ω` | `Σ_ω(x) ∝ (2π/L(x))² I` |
+| `θ_flow(x), L_∥/L_⊥(x)` (DYMOST aux) | Anisotropy of `Σ_ω` | rotation + axis-ratio in §3.0.2 |
+
+*Engineering consequence.* Three operationally-tuned fields — variance, isotropic lengthscale, anisotropy — give you a fully location-conditioned VSSGP prior with **no free hyperparameters left to tune**. The only thing the marginal-likelihood gradient still needs to do is local refinement around the operational defaults; everything global has been done by 30 years of community fitting.
+
+#### 3.0.4 Practical integration recipe
+
+The handoff is short:
+
+```python
+# 1. Load operational priors (one-time, per region)
+σ_field   = load_duacs_variance(region)         # (H, W)
+L_field   = load_duacs_lengthscale(region)      # (H, W)
+θ_field   = load_dymost_flow_angle(region)      # (H, W)
+ratio     = load_dymost_axis_ratio(region)      # (H, W) ; L_par / L_perp
+
+# 2. Per patch (see 03_global_scaling_patches), build patch-local prior
+def patch_prior(x_patch):
+    σ_patch  = σ_field.interp(x_patch)
+    L_patch  = L_field.interp(x_patch)
+    θ_patch  = θ_field.interp(x_patch)
+    r_patch  = ratio.interp(x_patch)
+
+    # MIOST-style mixture, scaled to local lengthscale
+    centres = jnp.array([
+        2*jnp.pi / (L_patch * 5.0),    # gyre   (5x lengthscale)
+        2*jnp.pi / (L_patch * 1.0),    # meso   (1x lengthscale)
+        2*jnp.pi / (L_patch * 0.25),   # sub    (0.25x lengthscale)
+    ])
+    weights = jnp.array([0.35, 0.45, 0.20])  # variance shares
+
+    # DYMOST-style anisotropy
+    R = rotation(θ_patch)
+    Σ_ω = R.T @ jnp.diag([1.0, r_patch**2]) @ R
+
+    return centres, weights, Σ_ω, σ_patch
+
+# 3. Initialize VSSGP variational params μ_Ω, σ_Ω from this prior
+#    Train (refines locally; doesn't search globally)
+```
+
+The bookkeeping is the same as a generic VSSGP — just the *initialization and prior* change. No new code paths.
+
+#### 3.0.5 What the operational schemes don't give you (and VSSGP does)
+
+- **Posterior uncertainty.** DUACS reports a formal mapping error from the OI cost, but it's a single scalar per pixel, not a draw-able posterior over `f`. VSSGP gives `q(w) → q(f*)`, full samples included.
+- **Online refinement.** MIOST hyperparameters are fitted once per release cycle. VSSGP's marginal-likelihood gradient updates them per-patch, per-batch — useful when SWOT keeps shifting the sub-mesoscale variance budget downward.
+- **Joint inference with non-Gaussian likelihoods.** DUACS assumes Gaussian along-track noise. VSSGP slots into the same machinery as the Student-T/log-normal likelihoods you'd want for SST/Chl-a, so you can do joint multivariate SSH+SST+Chl-a inference with a coupled `p(ω)` and per-channel likelihood.
+
+The summary: **MIOST and DYMOST tell you where to put the spectral mass; DUACS tells you how it varies in space; VSSGP tells you the posterior**. The three together are strictly more than any one alone.
+
+### SSH (Sea Surface Height)
+
+```
+# Spatial: power-law spectral density
+p(ω) ∝ |ω|^{-α},   α ≈ 4–5   (mesoscale range)
+
+# Mixture:
+p(ω) = w₁ · N(2π/L_gyre, σ₁)      # L_gyre ~ 1000 km
+      + w₂ · N(2π/L_meso, σ₂)      # L_meso ~ 100–300 km
+      + w₃ · N(2π/L_tide, σ₃)      # L_tide ~ 100 km
+
+# Temporal:
+p(ω_t) = w₁ · δ(2π/365.25)         # annual
+        + w₂ · δ(2π/182.6)          # semiannual
+        + w₃ · N(0, σ_meso)         # mesoscale (weeks-months)
+
+# Weight prior (anomaly around mean dynamic topography)
+w ~ N(0, σ_w²),    σ_w ~ 0.1–0.3 m
+
+# Likelihood
+y | f ~ N(f(x), σ_n²),    σ_n ~ 0.02–0.05 m
+# Note: along-track altimetry has correlated noise → correlated noise kernel
+```
+
+### SST (Sea Surface Temperature)
+
+```
+# Temporal — seasonal dominates
+p(ω_t) = w₁ · N(2π/365.25, σ₁)    # annual (dominant)
+        + w₂ · N(2π/182.6, σ₂)     # semiannual
+        + w₃ · N(2π/1, σ₃)         # diurnal (~0.5–1°C)
+        + w₄ · N(0, σ_slow)         # interannual (ENSO)
+
+# Weight prior (as anomaly from climatology)
+w ~ N(0, σ_w²),    σ_w ~ 2–5°C mid-latitude, ~1–2°C tropics
+
+# Likelihood — Student-T for cloud-contaminated IR retrievals
+y | f ~ StudentT(f(x), σ², ν),    ν ~ 4–7
+```
+
+### SSS (Sea Surface Salinity)
+
+```
+# Temporal
+p(ω_t) = w₁ · N(2π/365.25, σ₁)    # seasonal (precipitation cycle)
+        + w₂ · N(0, σ_slow)         # interannual
+
+# Weight prior — non-stationary near rivers
+w ~ N(0, σ_w²),    σ_w ~ 0.5–1.5 PSU open ocean
+                        ~ 3–5 PSU near river mouths
+
+# Likelihood — SMOS/SMAP have RFI contamination
+y | f ~ StudentT(f(x), σ², ν),    ν ~ 3–5
+σ_n ~ 0.2–0.5 PSU per retrieval
+```
+
+### OC / Chlorophyll-a
+
+**Key prior: work in log space.** Chl-a is log-normally distributed across the full range (0.01 to >100 mg/m³).
+
+```
+# Model log(Chl-a), not Chl-a directly
+g(x) = log(Chl-a(x))
+g ~ VSSGP(0, k)
+
+# Temporal
+p(ω_t) = w₁ · N(2π/365.25, σ₁)    # spring bloom — very strong
+        + w₂ · N(2π/182.6, σ₂)     # secondary bloom
+        + w₃ · N(0, σ_slow)         # interannual
+
+# Weight prior (in log space)
+w ~ N(0, σ_w²),    σ_w ~ 1.0–1.5 log₁₀ units
+
+# Likelihood — log-normal is canonical
+log(y) | f ~ N(f(x), σ_n²),    σ_n ~ 0.1–0.3 log₁₀ units
+```
+
+### Summary Table
+
+| Variable | Transform | Spectral Prior | Weight σ | Likelihood |
+|---|---|---|---|---|
+| SSH | none (anomaly) | Power-law + mixture at eddy/tide scales | 0.1–0.3 m | Gaussian (or correlated along-track) |
+| SST | none (anomaly) | Strong annual + diurnal harmonics | 2–5°C | Student-T (ν~5) |
+| SSS | none (anomaly) | Seasonal + non-stationary σ near rivers | 0.5–5 PSU | Student-T (ν~3–4) |
+| OC / Chl-a | log | Annual bloom + patchy spatial | 1.0–1.5 log units | Log-normal |
+
+---
+
+## 4. How Additive Components Are Injected into VSSGP
+
+### The Core SSGP Equation
+
+```
+k(x, x') ≈ φ(x)ᵀ φ(x')
+
+φ(x) = √(2/M) cos(Ω x + b)
+
+where:
+  x  : (D,)       input coordinates
+  Ω  : (M, D)     spectral points, each row ωᵢ ~ p(ω)
+  b  : (M,)       phases, bᵢ ~ Uniform(0, 2π)
+  φ  : (M,)       feature vector for one input
+
+Batched over N inputs:
+  X  : (N, D)
+  φ(X) = √(2/M) cos(X @ Ωᵀ + b)   : (N, M)
+```
+
+Model is Bayesian linear regression in feature space:
+```
+w   : (M,)        w ~ N(0, σ_w² I)
+f   : (N,)        f = φ(X) @ w   =  (N, M) @ (M,) → (N,)
+y   : (N,)        y ~ N(f, σ_n² I)
+```
+
+### Additive Kernel = Concatenated Feature Maps
+
+```
+φ(X) = [ φ₁(X) | φ₂(X) | φ₃(X) ]     # (N, M1+M2+M3)
+w    = [ w₁    | w₂    | w₃    ]       # (M1+M2+M3,)
+
+f = φ(X) @ w
+  = φ₁(X) @ w₁  +  φ₂(X) @ w₂  +  φ₃(X) @ w₃   # (N,) each
+```
+
+### Full SSH Example with D=3 inputs (lon, lat, t)
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+
+# hyperparameters (physical prior knowledge)
+L_gyre   = 1000.0   # km
+L_meso   = 200.0    # km
+T_annual = 365.25   # days
+T_meso   = 60.0     # days
+σ_slow   = 1/500.0  # cycles/day
+
+M1, M2, M3 = 32, 64, 128   # slow | annual×spatial | mesoscale
+D = 3                        # (lon, lat, t)
+
+
+# ================================================================
+# Step 1: Sample spectral points Ωⱼ for each component
+# ================================================================
+
+def sample_spectral_points(key):
+
+    k1, k2, k3, k4, k5 = jr.split(key, 5)
+
+    # Component 1: slow temporal trend
+    # prior: ω_t ~ N(0, σ_slow²),  ω_lon = ω_lat = 0
+    ω_t_slow = jr.normal(k1, (M1, 1)) * σ_slow    # (M1, 1)
+    ω_zeros  = jnp.zeros((M1, 2))                  # (M1, 2)
+    Ω1       = jnp.concatenate(                     # (M1, 3)
+                   [ω_zeros, ω_t_slow], axis=-1)
+    # Ω1[i] = (0, 0, ω_t_i)  → pure temporal features
+
+    # Component 2: annual cycle × large-scale spatial
+    # prior: ω_t ~ N(2π/T_annual, σ_annual²)   ← centred on annual freq
+    #        ω_lon, ω_lat ~ N(0, (2π/L_gyre)²)
+    σ_annual = 2*jnp.pi / T_annual * 0.1           # 10% bandwidth
+    σ_gyre   = 2*jnp.pi / L_gyre
+
+    ω_t_ann  = jr.normal(k2, (M2, 1)) * σ_annual \
+               + 2*jnp.pi/T_annual                  # (M2, 1)
+    ω_s_ann  = jr.normal(k3, (M2, 2)) * σ_gyre     # (M2, 2)
+    Ω2       = jnp.concatenate(                     # (M2, 3)
+                   [ω_s_ann, ω_t_ann], axis=-1)
+    # Ω2[i] = (ω_lon_i, ω_lat_i, ω_t_i) with ω_t near annual freq
+
+    # Component 3: mesoscale spatiotemporal
+    # prior: ω ~ N(0, diag(σ_meso_s², σ_meso_s², σ_meso_t²))
+    σ_meso_s = 2*jnp.pi / L_meso                   # mesoscale wavenumber
+    σ_meso_t = 2*jnp.pi / T_meso                   # mesoscale frequency
+    scales   = jnp.array([σ_meso_s, σ_meso_s, σ_meso_t])  # (3,)
+    Ω3       = jr.normal(k4, (M3, D)) * scales      # (M3, 3)
+    # Ω3[i] = (ω_lon_i, ω_lat_i, ω_t_i) fully coupled
+
+    return Ω1, Ω2, Ω3
+    # shapes: (M1,3), (M2,3), (M3,3)
+
+
+# ================================================================
+# Step 2: Build feature maps for each component
+# ================================================================
+
+def make_features(X, Ω1, Ω2, Ω3):
+    """
+    X    : (N, 3)   input coords (lon, lat, t)
+    Ωj   : (Mj, 3)  spectral points for component j
+    """
+    key_b = jr.PRNGKey(42)
+    kb1, kb2, kb3 = jr.split(key_b, 3)
+
+    b1 = jr.uniform(kb1, (M1,), minval=0, maxval=2*jnp.pi)  # (M1,)
+    b2 = jr.uniform(kb2, (M2,), minval=0, maxval=2*jnp.pi)  # (M2,)
+    b3 = jr.uniform(kb3, (M3,), minval=0, maxval=2*jnp.pi)  # (M3,)
+
+    # X @ Ωⱼᵀ : (N,3) @ (3,Mj) → (N, Mj)
+    φ1 = jnp.sqrt(2/M1) * jnp.cos(X @ Ω1.T + b1)   # (N, M1)
+    φ2 = jnp.sqrt(2/M2) * jnp.cos(X @ Ω2.T + b2)   # (N, M2)
+    φ3 = jnp.sqrt(2/M3) * jnp.cos(X @ Ω3.T + b3)   # (N, M3)
+
+    φ  = jnp.concatenate([φ1, φ2, φ3], axis=-1)     # (N, M1+M2+M3)
+    return φ, (φ1, φ2, φ3)
+
+
+# ================================================================
+# Step 3: Bayesian linear model (the SSGP model)
+# ================================================================
+
+def ssgp_model(X, y, Ω1, Ω2, Ω3):
+    """
+    X  : (N, 3)
+    y  : (N,)
+    """
+    M = M1 + M2 + M3   # 224
+
+    φ, _ = make_features(X, Ω1, Ω2, Ω3)   # (N, M)
+
+    # weight prior — amplitude scale per component
+    σ_w = jnp.concatenate([
+        jnp.full(M1, 0.20),    # (M1,)  slow trend
+        jnp.full(M2, 0.15),    # (M2,)  annual cycle
+        jnp.full(M3, 0.10),    # (M3,)  mesoscale
+    ])                          # (M,)
+
+    w   = numpyro.sample("w", dist.Normal(jnp.zeros(M), σ_w))   # (M,)
+    f   = φ @ w                                                   # (N,)
+
+    σ_n = numpyro.sample("σ_n", dist.HalfNormal(0.03))
+    numpyro.sample("y", dist.Normal(f, σ_n), obs=y)
+
+
+# ================================================================
+# VSSGP extension: spectral points become variational parameters
+# ================================================================
+
+# Replace fixed Ω3 with variational distribution q(ω) = N(μ_ω, diag(σ_ω²))
+# μ_Ω3 = numpyro.param("μ_Ω3", Ω3_init)           # (M3, 3)
+# σ_Ω3 = numpyro.param("σ_Ω3", 0.1*jnp.ones(...), constraint=positive)
+# Ω3   = numpyro.sample("Ω3", dist.Normal(μ_Ω3, σ_Ω3))  # (M3, 3)
+# → spectral points move to explain data, regularized toward physical prior
+```
+
+### Shape Flow Summary
+
+```
+X       : (N, 3)          ← lon, lat, t for N observations
+
+Ω1      : (M1, 3)         ← spectral pts, slow component
+Ω2      : (M2, 3)         ← spectral pts, annual component
+Ω3      : (M3, 3)         ← spectral pts, mesoscale component
+
+φ1      : (N, M1)         ← features, slow
+φ2      : (N, M2)         ← features, annual
+φ3      : (N, M3)         ← features, mesoscale
+
+φ       : (N, M1+M2+M3)   ← concatenated features
+
+w       : (M1+M2+M3,)     ← weights,  w ~ N(0, diag(σ_w²))
+
+f       : (N,)            ← f = φ @ w
+y       : (N,)            ← y ~ N(f, σ_n²)
+```
+
+**Physical knowledge lives entirely in how Ωⱼ are constructed — their initialization, prior distribution, and (in VSSGP) constraints on how far they move. Everything downstream is linear algebra.**
+
+---
+
+## 5. Approximation Error and the Marginal-Likelihood Compass
+
+Two more results worth having in your back pocket — both engineering-flavored, both useful for sizing experiments.
+
+### 5.1 Mercer truncation: how much of the kernel are you keeping?
+
+The kernel admits a Mercer expansion `k(x, x') = Σᵢ λᵢ ψᵢ(x) ψᵢ(x')` with `λ₁ ≥ λ₂ ≥ …`. Truncating to the top `M` eigenfunctions gives an approximation error
+
+```
+‖k − k_M‖² = Σ_{i > M} λᵢ²
+```
+
+For Bochner-type kernels the spectrum's tail is set by the *smoothness* of the field (Matérn-ν tails like `(1 + |ω|²ℓ²)^{−(ν + d/2)}`). A field with high `ν` (e.g. the mean SSH after removing eddies) needs **far fewer** features for a target tolerance than a rough field (e.g. instantaneous SSH including mesoscale).
+
+*Engineering consequence.* Pick `M` from the kernel tail you've targeted, not from a rule of thumb. For SSH-mesoscale (`ν ≈ 3/2`, `ℓ ≈ 100 km`, `d = 3`) on a `1000 × 1000 × 30` grid, `M ≈ 1024` captures ≥ 99% of `tr(K)`. Doubling `ν` (smoother field) drops the same coverage to `M ≈ 256`.
+
+### 5.2 Marginal likelihood gradient as a spectral compass
+
+For SSGP, differentiating the log-marginal-likelihood w.r.t. a single spectral point `ωᵢ`:
+
+```
+∂/∂ωᵢ log p(y | Ω) = (yᵀ A⁻¹ ∂Φ/∂ωᵢ wᵢ_eff) − tr(A⁻¹ ∂Φ/∂ωᵢ Φᵀ)
+```
+
+where `A = σ_f² Φ Φᵀ + σ_n² I` and `wᵢ_eff` is the contribution of feature `i` to the posterior. The first term **rewards moving `ωᵢ` toward frequencies where the residual `y − Φ μ_post` has spectral mass**; the second penalizes redundancy with already-placed features.
+
+*Engineering consequence.* You don't need to know the right spectral prior in advance — running a few epochs of SSGP/VSSGP starting from a generic prior reveals it. Inspect the histogram of optimized `Ω` after training and you have an empirical estimate of the true spectral density. This is impossible to extract from a trained SIREN.
+
+### 5.3 When to *not* trust this argument
+
+Three failure modes of the "VSSGP > SIREN for geoscience" thesis worth flagging honestly:
+
+| Failure mode | What goes wrong | Fix |
+|---|---|---|
+| **Strongly non-stationary fields** (e.g. coastal SSH, frontal SST) | A single global `p(ω)` is the wrong object — local lengthscale varies | Deep GP / mixture-of-experts SSGP / patchwise approach (see [03_global_scaling_patches](../notebooks/03_global_scaling_patches.md)) |
+| **Highly nonlinear forward models** (e.g. radiative transfer, log-Chl-a beyond linear regime) | RFE/SSGP is linear-in-features; nonlinearity needs depth | Deep RFE (Cutajar 2017) — compose RFF layers as a deep GP |
+| **Massive `M` regimes** (`M > 10⁴`) | `O(M³)` posterior covariance dominates | Switch to inducing points / SVGP, or matrix-free CG (see [01_efficient_machinery](../notebooks/01_efficient_machinery.md)) |
+
+In the first two cases SIREN's *flexibility* — fully learned features, deep nonlinearity — is genuinely useful. The argument here is not "VSSGP wins everywhere" but "for the dominant geoscience regime (sparse, irregular, banded spectrum, mostly stationary within a region) the structural advantages compound".
+
+---
+
+## 6. Experiment Planning — SSH, SST, SSS, OC
+
+This section turns the theoretical argument into a concrete benchmark. Four ocean variables, four regional zoom levels, four classes of metrics, four-rung method ladder. Every combination should be a directly runnable experiment in `gaussx`/`pyrox`.
+
+### 6.1 What we're trying to demonstrate
+
+| Claim | Test |
+|---|---|
+| **C1.** Informative `p(ω)` outperforms uninformative `p(ω)` at fixed `M` | RFF (uniform) vs SSGP-with-MIOST-init vs SIREN, all at `M = 1024` |
+| **C2.** Posterior > point estimate for sparse data | SSGP point predictions vs VSSGP credible intervals — measure CRPS gap |
+| **C3.** Operational priors transfer | Init VSSGP from MIOST/DUACS in Region A, evaluate on Region B without re-fitting hyperparameters |
+| **C4.** The hierarchy ranks by sample efficiency | Train all four methods on `N/k` for `k ∈ {1, 2, 4, 8}`; plot RMSE vs `N` — gap should widen as `N` shrinks |
+| **C5.** Spectral structure is preserved, not just RMSE | Compute power-spectral coherence — VSSGP should match the truth across the full mesoscale band; SIREN drops off |
+| **C6.** Derived physical quantities are improved | Geostrophic currents from `∇η̂` should match drifters better when prior is informative |
+
+### 6.2 Datasets and regions
+
+Four nested zoom levels — same hierarchy of regions across all four variables, so comparisons stay on-axis:
+
+| Zoom | Region | Lon × Lat | Why |
+|---|---|---|---|
+| **Z1 — small** | Mediterranean | `[-6, 36] × [30, 46]` | Eddy-rich, well-instrumented, manageable `N` |
+| **Z2 — medium** | Gulf Stream extension | `[-80, -40] × [25, 50]` | Strong anisotropy → tests DYMOST-style flow-aligned prior |
+| **Z3 — large** | North Atlantic | `[-80, 0] × [10, 60]` | Cross-regime: subtropical gyre + Gulf Stream + sub-polar |
+| **Z4 — global** | Global ocean | `[-180, 180] × [-80, 80]` | Tests patch-decomposition stitching from [03_global_scaling_patches](../notebooks/03_global_scaling_patches.md) |
+
+Per-variable data products (CMEMS / NASA / ESA, all freely accessible):
+
+| Variable | Sparse obs (training) | Gridded reference (eval) | In-situ (independent eval) |
+|---|---|---|---|
+| **SSH** | `SEALEVEL_GLO_PHY_L3_MY_008_062` (nadir altimetry, ~3×10⁵ obs/day) + `_069` (SWOT KaRIn, ~1.7×10⁶ obs/day) | DUACS L4 `SEALEVEL_GLO_PHY_L4_MY_008_047` | tide gauges `INSITU_GLO_PHY_SSH_DISCRETE_NRT_013_059`, GDP drifters (for `u_g`) |
+| **SST** | GHRSST L2P MODIS-Aqua/Terra, AVHRR-19/MetOp | OSTIA L4 `SST_GLO_SST_L4_NRT_OBSERVATIONS_010_001` | Argo floats, drifting buoys (NDBC) |
+| **SSS** | SMOS L2 v700, SMAP RSS V5 (~6×10⁴ obs/day each) | ESA SMOS L4 BEC, Multi-Mission Optimal Interpolated SSS | Argo (calibrated), TSG underway |
+| **OC / Chl-a** | OC-CCI L3 v6.0 daily (sun-synch + cloud gaps) | OC-CCI L4 monthly composite | BGC-Argo Chl fluorometers, in-situ HPLC (NASA SeaBASS) |
+
+### 6.3 Experimental protocols
+
+Three protocols, each isolating a different failure mode:
+
+#### 6.3.1 OSSE (controlled — ground truth available)
+
+Use a high-resolution model run as truth; sample synthetic observations at real altimeter / SMAP / drifter geometries.
+
+- **Truth:** GLORYS12 reanalysis (1/12°, daily) for SSH+SST+SSS; CMEMS biogeochemical reanalysis for Chl-a
+- **Obs operator:** along-track sampling at real CMEMS L3 geometries; add Gaussian (SSH) or correlated (SST cloud-gap) noise
+- **Eval:** full grid available — RMSE, spectral coherence, PIT all computed pixelwise
+
+This is the *gold standard* for the spectral-coherence and effective-resolution metrics — they require dense ground truth.
+
+#### 6.3.2 Leave-one-track-out (real data — independent altimeter)
+
+For SSH only, the SSH community standard (Ballarotta et al. 2019). Train on `{SARAL, Sentinel-3A/B, Cryosat-2, Jason-3}` minus one; predict the held-out altimeter's tracks; evaluate at observation points.
+
+- **Held-out altimeter rotates** across runs to control for orbit-geometry confounds
+- Evaluates *real-data* skill without needing model truth
+
+#### 6.3.3 In-situ withholding (real data — independent platform)
+
+Train on satellite obs only; evaluate on tide gauges (SSH) / Argo (SST, SSS) / BGC-Argo (Chl-a). Independent measurement system, so satellite biases don't leak.
+
+| Protocol | Pros | Cons | Use for |
+|---|---|---|---|
+| OSSE | Dense truth, controlled noise | Model-truth mismatch | Spectral metrics, calibration |
+| Leave-one-track | Real data, real noise | Same instrument family | Effective resolution |
+| In-situ | Truly independent | Sparse, biased to coasts | Bias detection, regional skill |
+
+### 6.4 Metrics — four classes
+
+The interpolation community routinely under-reports metrics; a single RMSE hides the differences between methods that matter most. Four families, each catching a different failure mode:
+
+#### 6.4.1 Point accuracy
+
+Standard but necessary:
+
+```
+RMSE  = sqrt( mean( (ŷ − y_true)² ) )
+MAE   = mean( |ŷ − y_true| )
+bias  = mean( ŷ − y_true )
+nRMSE = RMSE / std(y_true)               # cross-region comparable
+R²    = 1 − var(ŷ − y_true) / var(y_true)
+```
+
+Per-variable target (OSSE on Z2 Gulf Stream extension, 1 month, full SWOT-era):
+
+| Variable | DUACS-class baseline RMSE | VSSGP target | Threshold for "informative prior helps" |
+|---|---|---|---|
+| SSH | 4.5 cm | < 3.5 cm | nRMSE drop ≥ 15% |
+| SST | 0.45 K | < 0.30 K | nRMSE drop ≥ 25% |
+| SSS | 0.25 PSU | < 0.20 PSU | nRMSE drop ≥ 15% |
+| log Chl-a | 0.30 log₁₀ | < 0.22 log₁₀ | nRMSE drop ≥ 20% |
+
+#### 6.4.2 Probabilistic / calibration
+
+Point methods (RFF-ridge, SIREN) cannot compute these — that's the point.
+
+```
+NLPD  = − mean( log p(y_true | x*) )
+      # for Gaussian: ½ log(2π σ²) + ½ (ŷ − y)² / σ²
+
+CRPS  = mean( ∫ ( F(z; x*) − 𝟙{z ≥ y_true} )² dz )
+      # for Gaussian-posterior: closed-form CRPS
+
+PIT   = F(y_true ; x*) ∈ [0, 1]
+      # histogram should be Uniform[0, 1] under correct calibration
+
+Reliability:
+   bin predictions by quantile q; check empirical coverage = q
+   ECE = mean( |q − coverage(q)| )
+```
+
+CRPS is the headline probabilistic metric — proper, scale-aware, low-dimensional. NLPD is sensitive to outlier underprediction (heavy tails) so it disambiguates Gaussian vs. Student-T likelihoods.
+
+#### 6.4.3 Spectral metrics
+
+This is where SIREN is *expected* to do badly even at competitive RMSE — it gets the spatial autocorrelation wrong.
+
+```
+Power spectral density (PSD):
+   PSD_pred(k)  = |FFT(ŷ − ⟨ŷ⟩)|²
+   PSD_true(k)  = |FFT(y_true − ⟨y_true⟩)|²
+   PSD_error(k) = |FFT(ŷ − y_true)|²
+
+Spectral coherence (Ballarotta 2019, the SSH community standard):
+   T(k) = 1 − PSD_error(k) / PSD_true(k)
+
+Effective resolution L_eff:
+   smallest scale where T(k) ≥ 0.5
+   i.e. signal dominates noise
+
+Spectral RMSE:
+   ‖ log PSD_pred − log PSD_true ‖₂   # in log space, by decade
+```
+
+Per-variable target on Z2 (Gulf Stream, OSSE):
+
+| Variable | Reference `L_eff` (DUACS-class) | VSSGP target |
+|---|---|---|
+| SSH | 100–150 km | < 80 km (resolves mesoscale) |
+| SST | 60 km | < 30 km (resolves frontal scale) |
+| SSS | 200 km | < 150 km |
+| Chl-a (log) | 150 km | < 80 km |
+
+#### 6.4.4 Physical / derived-quantity metrics
+
+For SSH especially, the *derived* quantities matter more than `η` itself — operational users want currents, divergence, and vorticity:
+
+```
+Geostrophic velocity:
+   u_g = − (g/f) ∂η/∂y     v_g = (g/f) ∂η/∂x
+   RMSE_u = sqrt( mean( (û − u_drifter)² ) )      # vs GDP drifters
+
+Vorticity:
+   ζ = ∂v/∂x − ∂u/∂y
+   RMSE_ζ                                          # vs OSSE truth
+
+SST gradient (front detection):
+   ∇T magnitude — Sobel
+   F1 score for fronts above threshold
+
+Chl-a bloom timing:
+   day-of-year of annual maximum (per pixel)
+   RMSE in days (cf. Henson et al. 2018)
+```
+
+These metrics are the ones DUACS/MIOST publish — they're how the community accepts a new SSH product. The VSSGP claim has to land here, not just on RMSE.
+
+### 6.5 Per-variable experimental protocols
+
+#### 6.5.1 SSH — anchor variable, fullest treatment
+
+```
+Method ladder × 4:    {RFF-ridge, SIREN, SSGP, VSSGP-MIOST-init}
+Region ladder × 4:    {Med, Gulf Stream, N. Atl, Global}
+Time horizon × 3:     {1 month, 3 months, 6 months}
+SWOT ablation × 2:    {nadir-only, nadir + SWOT}
+
+⇒ 4 × 4 × 3 × 2 = 96 runs (Z4 × 6mo only for VSSGP, halve to ~80)
+```
+
+- Likelihood: Gaussian for nadir, **correlated-noise kernel** for along-track residuals (Le Traon-style)
+- Prior: §3.0 MIOST + DYMOST + DUACS recipe
+- Metric stack: full §6.4 (point + CRPS + spectral coherence + `u_g` RMSE)
+- Baselines: DUACS L4, MIOST, BFN-QG, 4DVarNet (latter two: cite published Ballarotta numbers, don't re-run)
+
+#### 6.5.2 SST — diurnal cycle and fronts
+
+```
+Method ladder: same 4
+Region: Med + Gulf Stream + Global (skip N. Atl alone — covered)
+Likelihood: Student-T with ν ∈ {3, 5, 7} ablation (cloud-contamination tail)
+Special diagnostic: gradient magnitude F1 score for fronts
+```
+
+- Diurnal-cycle preservation: phase + amplitude error of the 24-h harmonic (one number per pixel)
+- Cloud-gap stress test: artificially mask a 200 × 200 km block; reconstruct; measure RMSE in the gap
+- Baseline: OSTIA L4
+
+#### 6.5.3 SSS — extreme non-stationarity
+
+```
+Region: Amazon plume (3-week experiment), tropical Atlantic, global
+Special: σ_w(x) field MUST be spatially varying — open-ocean σ_w ≈ 0.5 PSU,
+         plume σ_w ≈ 3-5 PSU; flat σ_w fails by construction
+```
+
+- Extreme value capture: skill at 95th and 99th percentile (RMSE conditional on `y > q_95`)
+- River plume tracking: cross-correlation of low-salinity tongue position vs MODIS Chl proxy
+- Baseline: ESA SMOS L4 BEC
+
+#### 6.5.4 OC / Chl-a — log-space and bloom dynamics
+
+```
+Region: N. Atlantic spring bloom (March-May), Arabian Sea (SW monsoon),
+        Southern Ocean (austral spring), global
+Transform: log₁₀ — the entire model lives in log space
+Special: bloom timing metric — most operational mappings smear the bloom edge
+```
+
+- Log-space RMSE + log-space CRPS (proper for log-normal posterior)
+- Bloom phenology: day-of-year of pixel maximum, RMSE in days
+- Cloud-gap stress same as SST
+- Baseline: OC-CCI L4
+
+### 6.6 Ablation matrices
+
+Five ablations isolate which design choice is doing the work. Each is one row of the result table; designed to fail differently.
+
+| # | Ablation | What it isolates | Expected outcome |
+|---|---|---|---|
+| **A1** | VSSGP-uniform-prior vs VSSGP-MIOST-prior | Value of operational prior | A1 narrows nRMSE gap by ~50% (rest of gap is from posterior, not prior) |
+| **A2** | `M ∈ {64, 128, 256, 512, 1024, 2048}` | Sample-complexity scaling | RMSE vs `M` should be a clean power-law for VSSGP, ragged for SIREN |
+| **A3** | `σ_w` flat vs DUACS-derived `σ_w(x)` | Value of spatially varying amplitude | Big gap on SSS, small on SSH |
+| **A4** | Isotropic vs DYMOST-anisotropic `Σ_ω` | Value of flow-aligned prior | Gulf Stream RMSE drop ≥10% on `v_g` |
+| **A5** | Train Med, eval N. Atlantic | Prior transfer | VSSGP-MIOST should hold; SSGP-no-prior should fail |
+
+### 6.7 Compute budget
+
+Order-of-magnitude per run on 1× A100 80GB (per the wall-clock numbers in [01_efficient_machinery](../notebooks/01_efficient_machinery.md)):
+
+| Region | `N` (full SWOT-era, 1mo) | `M` | Train/run | Eval/run | Per-method total |
+|---|---|---|---|---|---|
+| Z1 Med | ~1.5 × 10⁵ | 1024 | 5 min | 1 min | 6 min |
+| Z2 Gulf Stream | ~3 × 10⁵ | 1024 | 12 min | 2 min | 14 min |
+| Z3 N. Atlantic | ~1.5 × 10⁶ | 2048 | 1.5 hr | 5 min | 1.6 hr |
+| Z4 Global (patched) | ~6 × 10⁷ | per-patch 1024 | 2 hr (8× A100, dask) | 10 min | 2.2 hr |
+
+For the full method × region × variable × ablation grid: roughly **300–400 GPU-hours**, dominated by Z3+Z4 + the `M`-sweep ablation. Tractable on a small cluster over a week.
+
+### 6.8 Reporting template
+
+Each variable + region combo produces one results row. Recommended format:
+
+```
+| Method        | RMSE  | CRPS  | NLPD  | L_eff | RMSE u_g | ECE |
+|---------------|-------|-------|-------|-------|----------|-----|
+| RFF-ridge     | 4.2cm |   —   |   —   | 140km |  9.3cm/s |  —  |
+| SIREN         | 3.9cm |   —   |   —   | 165km |  9.8cm/s |  —  |
+| SSGP          | 3.5cm | 1.8cm | -0.42 | 105km |  7.1cm/s | .12 |
+| VSSGP-MIOST   | 3.1cm | 1.5cm | -0.61 |  82km |  6.2cm/s | .04 |
+| ----          |       |       |       |       |          |     |
+| DUACS L4      | 4.5cm |   —   |   —   | 150km |  8.5cm/s |  —  |
+| MIOST         | 3.6cm |   —   |   —   | 110km |  7.4cm/s |  —  |
+```
+
+Bolding rule: per metric column, bold the best of {RFF, SIREN, SSGP, VSSGP}; italicize if it also beats *all* operational baselines in that column. The story of the paper is whichever cells consistently land in italic-bold.
+
+---
+
+## Key References
+
+**Foundations**
+- Bochner, S. (1933) — Monotone Funktionen, Stieltjessche Integrale und harmonische Analyse
+- Rahimi & Recht (2007) — Random Features for Large-Scale Kernel Machines
+- Rahimi & Recht (2008) — Uniform Approximation of Functions with Random Bases (sample-complexity bound)
+
+**The hierarchy**
+- Lázaro-Gredilla et al. (2010) — Sparse Spectrum Gaussian Process Regression (SSGP)
+- Gal & Turner (2015) — Improving the Gaussian Process Sparse Spectrum Approximation (VSSGP)
+- Wilson & Adams (2013) — Gaussian Process Kernels for Pattern Discovery and Extrapolation (Spectral Mixture)
+- Cutajar et al. (2017) — Random Feature Expansions for Deep Gaussian Processes
+
+**Neural-field side**
+- Sitzmann et al. (2020) — Implicit Neural Representations with Periodic Activation Functions (SIREN)
+- Tancik et al. (2020) — Fourier Features Let Networks Learn High-Frequency Functions in Low-Dimensional Domains
+- Yang & Salman (2019) — A Fine-Grained Spectral Perspective on Neural Networks (NTK ↔ kernel)
+
+**Geoscience priors**
+- Chelton et al. (2011) — The Influence of Nonlinear Mesoscale Eddies on Near-Surface Oceanic Chlorophyll
+- Le Traon et al. (1990) — A spectral analysis of the Geosat altimeter signal (SSH spectral slopes)
+- Stogryn (1985) — Distribution of sea surface temperatures (Student-T tails for IR retrievals)

--- a/projects/interpolation/siren_vs_rff/01_physics_constraints.md
+++ b/projects/interpolation/siren_vs_rff/01_physics_constraints.md
@@ -1,0 +1,394 @@
+---
+title: "Enforcing physics in NF / VSSGP training — basis, data, loss"
+---
+
+# Enforcing physics in the VSSGP / neural-field training pipeline
+
+Companion to [00_siren_rff_vssgp.md](00_siren_rff_vssgp.md). This note answers the question: *given that we are training a neural field (SIREN) or a VSSGP and then evaluating it — including outside the training footprint — where does physical knowledge enter, and how do those entry points differ between the two methods?*
+
+```{important}
+**Scope.** This is a training-paradigm document. It is **not** about Matheron's-rule pathwise sampling on dense grids ([01_efficient_machinery](../notebooks/01_efficient_machinery.md)) or about patch decomposition for global scale ([03_global_scaling_patches](../notebooks/03_global_scaling_patches.md)). Both methods here learn `θ` from data and then evaluate at any prediction point `x*`. The most interesting prediction regime — and the one that tests the value of an informative prior most strongly — is **out-of-domain `x*`** (spatial or temporal extrapolation), which is exactly where the prior, not the data, dominates the answer.
+```
+
+The setup, written so it covers both methods:
+
+| | Neural field (SIREN) | VSSGP |
+|---|---|---|
+| Function form | $f_\theta(x) = \mathrm{NN}_\theta(x)$ | $f(x) = \phi(x)^{\!\top} w$ |
+| What is learned | Network weights $\theta$ via SGD on a loss | Weight posterior $p(w \mid y)$ in closed form (linear case) or via SVI |
+| Prediction at $x^*$ | $f_\theta(x^*)$ — point estimate | $\mathbb{E}[f(x^*)] = \phi(x^*)^{\!\top} \mu_{\text{post}}$ + closed-form variance |
+| Out-of-domain behaviour | Whatever the network extrapolates to (often poorly behaved) | Reverts smoothly to prior — variance grows, mean → 0; spectral structure of $p(\omega)$ remains |
+
+Both share three axes where physics can enter the pipeline:
+
+1. **Basis** — the function class (RFF spectral prior; SIREN architecture).
+2. **Data** — input preprocessing, input embeddings, output preprocessing, output parameterisation.
+3. **Loss** — data fit, regularisers, PDE-residual / soft-physics terms.
+
+These are nearly independent. You can intervene on any subset; effects on training and on out-of-domain behaviour are roughly additive. The rest of the note is one section per axis.
+
+---
+
+## 0. Method neutrality — what carries across, what does not
+
+Before the axis-by-axis treatment: the two methods agree on *what physics looks like at each axis*, but disagree on *what's free vs. expensive at each axis*.
+
+| Move | NF (SIREN) | VSSGP |
+|---|---|---|
+| Spectral prior on energy distribution | ❌ no native — heuristic ω₀ at first layer is a degenerate proxy | ✅ explicit `p(ω)` (the headline of 00_siren_rff_vssgp.md) |
+| Anisotropic / flow-aligned structure | ⚠️ approximate via input coordinate transform | ✅ Matérn-SPDE prior — exact |
+| Periodic features for known harmonics | ✅ stack into input layer (positional encoding) | ✅ stack into basis $\phi$ |
+| Predict scalar potential, derive constrained field via autodiff | ✅ `jax.grad(NN_θ)` | ✅ analytic differentiation of $\phi$ |
+| Output transform (log, link function) | ✅ trivial | ✅ trivial — but breaks closed-form for non-Gaussian |
+| Data-fit likelihood | Gaussian by default; Student-T / log-normal via custom loss | Gaussian closed-form; non-Gaussian via SVI / Laplace |
+| PDE-residual / virtual-obs loss | ✅ standard PINN — joint SGD | ✅ closed-form for *linear* PDEs; SVI/Laplace otherwise |
+| Learned operator inside the loss | ✅ native — NN-in-loss is the norm | ⚠️ awkward — breaks closed-form Bayes |
+| Posterior over predictions (incl. OOD) | ❌ point estimate — needs ensembles or MCD for any uncertainty | ✅ closed-form Gaussian posterior at every point |
+
+The pattern is consistent: **VSSGP is naturally Bayesian and natively handles linear constraints in closed form; NF is naturally flexible and natively handles arbitrary nonlinear losses with a learned operator inside**. For the kinds of physics the ocean reconstruction problem asks for — mostly linear (geostrophy, periodicity, advection-with-frozen-velocity, harmonic tides) plus a small amount of genuinely uncertain nonlinear physics (Chl-a sources) — VSSGP fills more of the space cleanly. NF earns its niche specifically where the operator itself needs to be learned.
+
+---
+
+## 1. AXIS — basis (function class)
+
+The basis controls *what shapes of function `f` is allowed to take*, before any data is seen. For VSSGP this is `p(ω)` plus the input dimensionality of the RFF features; for NF this is the architecture (depth, width, activation, ω₀ for SIREN, positional encoding).
+
+### 1.1 Informative spectral prior — VSSGP-native, NF approximate
+
+For VSSGP, this is the headline mechanism from [00_siren_rff_vssgp.md §3](00_siren_rff_vssgp.md#3-physical-priors-for-ocean-variables): pick `p(ω)` to match the known spectral structure of the field (mesoscale band for SSH, annual harmonic for SST, etc.). Spectral mass on the right frequencies → most of the M features are useful.
+
+For SIREN, there is no `p(ω)`, but there is the first-layer scaling `ω₀`. SIREN init is `W₁ ~ U(−√(6/n), √(6/n))`, then activations are `sin(ω₀ W₁ x)`. The effective spectral measure is uniform on a box `|ω| ≤ ω₀ √(6/n)`, dimensionwise. This is a *bad* approximation to a banded geophysical signal — see [00_siren_rff_vssgp.md §2](00_siren_rff_vssgp.md#2-why-geoscience-data-is-the-wrong-domain-for-siren) for the spectral-budget argument.
+
+A cleaner SIREN cousin is **Fourier feature networks** (Tancik et al. 2020): replace the first layer's learned `W₁` with a *fixed* random matrix sampled from your chosen `p(ω)`, then put the MLP on top of these features. This brings SIREN into the same spectral-prior framework as VSSGP at the architecture level — strictly recommended for any SIREN run targeting geoscience data.
+
+**Recipe.**
+
+```python
+# VSSGP: draw RFF frequencies from informative p(ω)
+Omega = sample_spectral_mixture(M, components=miost_components, key=key)
+
+# SIREN: fix the first-layer matrix to RFF frequencies, put MLP on top
+class FourierFeatureSIREN(eqx.Module):
+    Omega_fixed: Array     # (M, d), drawn from p(ω) once, frozen
+    mlp: ...
+
+    def __call__(self, x):
+        gamma = jnp.concatenate([jnp.cos(self.Omega_fixed @ x),
+                                 jnp.sin(self.Omega_fixed @ x)])
+        return self.mlp(gamma)
+```
+
+Either way, the basis-axis physics is the **same act**: tell the model where energy lives in frequency space.
+
+### 1.2 Anisotropic / flow-aligned basis
+
+Genuine VSSGP/GP win — Matérn-SPDE prior with a position-dependent diffusivity tensor `D(x) = R(θ_flow) diag(L_∥², L_⊥²) R(θ_flow)ᵀ` encodes DYMOST-style anisotropy directly into the kernel ([00_siren_rff_vssgp.md §3.0.2](00_siren_rff_vssgp.md#302-dymost--anisotropic-flow-aligned-spectral-measure)).
+
+For NF, the only available approximation is an input coordinate transform that biases the network toward the right axes:
+
+```python
+def aligned_input(x, theta_flow_field, ratio_field):
+    R = flow_rotation(x, theta_flow_field)
+    L = jnp.diag([1.0, ratio_field(x)])
+    return R.T @ L @ R @ x
+```
+
+This is a soft architectural prior, not a hard basis constraint — it biases the implicit kernel of the NF without enforcing it. If anisotropy is critical (Gulf Stream, Kuroshio), VSSGP wins on this axis.
+
+### 1.3 Multi-scale / additive components
+
+For both methods. VSSGP: stack `Φ = [Φ_gyre | Φ_meso | Φ_sub]` with per-component variance scaling — see [00_siren_rff_vssgp.md §4](00_siren_rff_vssgp.md#4-how-additive-components-are-injected-into-vssgp). NF: parallel branches (one per scale octave) with their own first-layer `Ω_n`, summed at the output. Both express the same physical content: "the field is a sum of components, each with a known scale band and amplitude."
+
+---
+
+## 2. AXIS — data (input and output)
+
+The data axis covers four sub-mechanisms: **(2A)** preprocessing the inputs `x`, **(2B)** augmenting the inputs with engineered features, **(2C)** preprocessing the observed `y`, and **(2D)** parameterising what `f` predicts (output structure). The first three are about *what enters* the model; the fourth is about *what comes out*. All four work the same way for NF and VSSGP.
+
+### 2A. Input preprocessing
+
+Coordinate normalisation, lat-lon → 3D Cartesian on the sphere (avoids the longitudinal seam), time → days since epoch with a per-domain offset. Standard ML hygiene; no physics yet, but matters because both SIREN's `ω₀` and the VSSGP RFF frequencies are scale-sensitive.
+
+For SSH specifically, working in **f-plane regional patches** (small enough that Coriolis `f` is approximately constant) lets you treat `f/g` as a constant — needed for the scalar-potential trick in §2D below.
+
+### 2B. Input embeddings — periodic features for known harmonics
+
+Annual (T = 365.25 d), semiannual (182.6 d), diurnal (1.0 d), M2 tide (0.5175 d) are exact periodicities. Stack them into the input as
+
+$$
+\gamma(t) = \bigl[\cos(2\pi t/T_k),\; \sin(2\pi t/T_k)\bigr]_{k=1}^{K}
+$$
+
+before any other processing. Both methods then have a hard subspace where the harmonic content lives, learnt via the standard data fit.
+
+```python
+def periodic_embedding(x, t):
+    periods = jnp.array([365.25, 182.6, 1.0, 0.5175])     # days
+    h = jnp.concatenate([jnp.cos(2*jnp.pi*t/periods),
+                         jnp.sin(2*jnp.pi*t/periods)])
+    return jnp.concatenate([x, h])
+```
+
+Recipe is identical for VSSGP (`φ(periodic_embedding(x, t))`) and SIREN (input layer takes the embedding). High-leverage move because it removes a chunk of the training residual that the basis would otherwise have to spend M features approximating.
+
+### 2C. Output preprocessing — subtract known physics from `y`
+
+Before the model sees the observations, subtract everything that is already known. For SSH (covered in [02 §2a](../notebooks/02_physics_aware_ssh.md#2a-subtract--pre-processing-the-obs)):
+
+| Subtraction | Source | Removes |
+|---|---|---|
+| Wet/dry tropospheric, ionospheric, sea-state bias | CMEMS L3 standard corrections | Path delay biases (~few cm each) |
+| Solid Earth + pole tide, ocean tides FES2014/2022 | tide model | Earth-body + ocean tides (~30 cm + ~1 m peak) |
+| Dynamic Atmospheric Correction (DAC) | MOG2D + IB | Storm-driven barotropic response (~10 cm at mid-lat) |
+| Mean Dynamic Topography | CNES-CLS-22 | Time-mean SSH so you model the anomaly $\eta_a$ |
+
+For SST: subtract climatology (Reynolds OISST mean) so the model sees an anomaly, not the absolute temperature. For SSS: subtract the multi-year mean. For Chl-a: log-transform first (the field is log-normal), then optionally subtract a seasonal climatology in log-space.
+
+This is upstream of the model entirely and works identically for NF and VSSGP. **Highest-leverage single move on the data axis** — without it, the field's mean dynamic structure dominates the spectral content and the prior's mesoscale band gets drowned out.
+
+### 2D. Output parameterisation — predict a scalar latent, derive the constrained field
+
+The most under-used trick on the data axis. Instead of training `f` to predict the constrained vector field directly, train it to predict a *scalar latent* and apply a known operator to get the field. Constraints linear in `f` become **automatic** for every prediction — including out-of-domain ones.
+
+The canonical example is divergence-free flow from a streamfunction:
+
+$$
+\psi_\theta(x) \;\;\xrightarrow{\;\;\text{predict}\;\;}\;\;
+(u, v) = (-\partial_y \psi_\theta,\; +\partial_x \psi_\theta)
+$$
+
+For SSH: train on `η`, then derive geostrophic currents post-hoc as `(u_g, v_g) = (-(g/f)∂_y η, (g/f)∂_x η)`. Working with the scalar `η` *is* the scalar-latent trick — the resulting `(u_g, v_g)` is divergence-free for every `η` your model predicts.
+
+| Output structure | NF recipe | VSSGP recipe |
+|---|---|---|
+| Direct field $f(x)$ | $f = \mathrm{NN}_\theta(x)$ | $f = \phi(x)^{\!\top} w$ |
+| Scalar potential, derive vector field | $\psi = \mathrm{NN}_\theta(x);\; \mathbf{v} = \nabla^\perp \psi$ via `jax.grad` | $\psi = \phi(x)^{\!\top} w;\; \mathbf{v}$ via analytic derivative of $\phi$ |
+| Log-transformed field | $f = \exp(\mathrm{NN}_\theta(x))$ for Chl-a | $f = \exp(\phi(x)^{\!\top} w)$; loses Gaussian likelihood |
+| Multi-output (joint SSH+SST) | Vector head; shared backbone | Block-diagonal $w$, independent posteriors per channel; couple via shared spectral prior |
+
+**Why this is so powerful for OOD prediction.** The constraint holds for *every* prediction, including in regions far from training data — divergence-freeness, harmonic content, log-positivity all transfer to the extrapolation regime. This is qualitatively different from a soft-loss approach where the constraint is only enforced where collocation points are placed. For OOD prediction, **output parameterisation is the only mechanism that reliably enforces a constraint everywhere**.
+
+### 2E. Data augmentation — derivative observations
+
+Drifter / HF-radar / Doppler-altimetry velocities give `(u_g, v_g)` directly, which by geostrophy is `-(g/f) ∂_y η, (g/f) ∂_x η` — a *linear* functional of `η`. Add these to the training set as derivative observations:
+
+```python
+y_augmented = jnp.concatenate([eta_obs, -(f/g) * v_drifter, (f/g) * u_drifter])
+loss_data = mse(predict_eta_and_grad(x, theta), y_augmented)
+```
+
+For NF: `predict_eta_and_grad` computes `η` from the network and uses `jax.grad` to get gradient observations. For VSSGP: cross-covariance kernel rows `K_{η, ∂η} = ∂_{x'} k(x, x')` via `jax.grad(k)` — same construction, closed-form.
+
+Both methods get the same physical content from this data augmentation.
+
+---
+
+## 3. AXIS — loss
+
+The loss combines the data-fit term with regularisers and (for soft-physics) PDE-residual terms. Three sub-mechanisms.
+
+### 3A. Data-fit likelihood
+
+| Variable | Likelihood | NF form | VSSGP form |
+|---|---|---|---|
+| SSH | Gaussian (or correlated-noise for along-track) | MSE | Closed-form |
+| SST | Student-T (cloud-contaminated IR) | Robust loss | SVI / Laplace |
+| SSS | Student-T (RFI-contaminated SMOS) | Robust loss | SVI / Laplace |
+| Chl-a (in log-space) | Gaussian on `log y` | MSE on `log f` | Closed-form on `log f` |
+
+For VSSGP, anything beyond Gaussian breaks closed-form. The cost is real — Laplace / SVI introduces SGD-like training even on the GP side. For Gaussian-or-near-Gaussian variables (SSH, SST anomalies after climatology subtraction), VSSGP keeps its closed-form advantage; for genuinely heavy-tailed cases the methods are roughly on par cost-wise.
+
+### 3B. Soft-physics — PDE residual at collocation points
+
+The PINN move, with the same algebraic content for both methods:
+
+$$
+\mathcal{L}(\theta) = \underbrace{\sum_{i=1}^{N} \tfrac{(y_i - f_\theta(x_i))^2}{\sigma_{\text{obs}}^2}}_{\text{data fit}}
+\;+\; \underbrace{\sum_{c=1}^{m_c} \tfrac{\|L f_\theta(x_c)\|^2}{\sigma_{\text{pde}}^2}}_{\text{soft physics at collocation pts}}
+\;+\; \underbrace{\mathcal{R}(\theta)}_{\text{regulariser}}.
+$$
+
+In VSSGP language the second term is exactly the negative log-likelihood of *virtual observations* `0 = L f(x_c) + ε_c`, with `ε_c ~ N(0, σ_pde²)`. So it slots into the GP solve as additional rows in `y` and `K`. The cross-covariance machinery `K_{f, Lf}(x, x') = L_{x'} k(x, x')` is computed via `jax.grad(k)` — same primitive used for derivative observations in §2E.
+
+| Aspect | NF | VSSGP |
+|---|---|---|
+| Linear PDE (`L f` linear in `f`) | Joint SGD | **Closed-form posterior** in one solve |
+| Nonlinear PDE | Joint SGD | Laplace / SVI |
+| Per-collocation-point cost | One forward + autodiff per epoch | One row in augmented Gram |
+| Sensitivity to `σ_pde` | Loss-landscape stiffness; well-known PINN failure mode[^krishnapriyan2021] | Conditioning of augmented Gram; standard Tikhonov fixes |
+
+```{tip}
+**Key VSSGP win on this axis.** For a *linearised* PDE — linearised PV `∂_t (∇²η − η/L_R²) + βv = 0`, advection-diffusion with frozen velocity, harmonic balance — VSSGP gives the constrained posterior in a single solve. SIREN does the same constraint but needs full SGD training. For non-linear PDEs (full QG PV with the Jacobian), parity.
+```
+
+#### Per-variable PDE residuals
+
+| Variable | Operator | Linear in `f`? |
+|---|---|---|
+| SSH | Geostrophic balance: $u_g = -(g/f)\partial_y\eta$ | Yes — but enforced **hard** via §2D, no loss term needed |
+| SSH | Linearised PV: $\partial_t(\nabla^2\eta - \eta/L_R^2) + \beta v = 0$ | Yes — soft constraint, closed-form for VSSGP |
+| SSH | Full nonlinear PV: $Dq/Dt = 0$ with quadratic Jacobian | No — Laplace / SGD |
+| SST/SSS/Chl-a | Advection-diffusion (frozen `u`): $\partial_t T + \mathbf{u}\cdot\nabla T - \kappa\nabla^2 T = S$ | Yes (with frozen `u`) — soft constraint, two-stage |
+| Chl-a | Add bio source-sink term `S` | No — needs learned $S_\theta$ (see §3D) |
+
+The two-stage workflow for tracers: first reconstruct SSH (using §1 + §2 + §3A), freeze `u_g`, then for the tracer add the advection-diffusion residual as a soft constraint. Cost: one frozen velocity field, then a linear soft-physics solve.
+
+### 3C. Regularisation — weight prior
+
+For VSSGP this is built in (`w ~ N(0, Σ_w)`); for NF it has to be added as `‖θ‖²` weight decay or a structured regulariser. Worth distinguishing:
+
+| Regulariser | NF | VSSGP |
+|---|---|---|
+| Plain `‖θ‖²` weight decay | Standard | Equivalent to isotropic `Σ_w = σ_w² I` |
+| Per-component variance scale (different `σ_w` per scale octave) | Manual — pre-compute parameter groups, apply different decay to each | Closed-form via block-diagonal `Σ_w` (see [00_siren_rff_vssgp.md §4](00_siren_rff_vssgp.md#4-how-additive-components-are-injected-into-vssgp)) |
+| Spatially varying amplitude `σ_w(x)` from DUACS | Awkward — needs gating into the network | Closed-form (one line in `Σ_w`) |
+| Sparsity (Laplace prior on weights) | L1 weight decay | Spike-and-slab; expensive |
+
+VSSGP is more flexible at the regulariser level because the weight prior is an explicit object, not a single scalar `λ`.
+
+### 3D. Learned operators — when `L` itself is the unknown
+
+For Chl-a, the source term `S(T, x, t)` is biology-dependent and uncertain. Replace `S` with a small neural network `S_θ(η, T, ∇T, x)` and train end-to-end with the data fit + advection-diffusion residual:
+
+```python
+def loss(theta_field, theta_S, x_data, y_data, x_collocation):
+    # Data fit
+    L_data = mse(f_theta_field(x_data) - y_data)
+    # Soft physics with learned source
+    residual = advect_diffuse(f_theta_field, x_collocation, u_g_frozen) \
+               - S_theta_S(f_theta_field, x_collocation)
+    L_phys = jnp.mean(residual ** 2) / sigma_pde**2
+    # Regulariser on the learned operator
+    L_reg  = mu * jnp.sum(theta_S ** 2)
+    return L_data + L_phys + L_reg
+```
+
+This is **NF-native territory** — putting an NN inside the loss is the standard pattern. The VSSGP equivalent (NN coefficients as marginal-likelihood hyperparameters) loses the closed-form posterior on `θ_S` and is awkward in practice. For the four target variables, only Chl-a clearly needs this; the other operators are well-known enough that fixed coefficients suffice.
+
+---
+
+## 4. Decision matrix — which axis × method for which constraint?
+
+For each constraint candidate across SSH/SST/SSS/Chl-a:
+
+| Constraint | Variable | Axis | Mechanism | NF | VSSGP |
+|---|---|---|---|---|---|
+| Mesoscale spectral content | SSH | Basis | Informative `p(ω)` (MIOST init) | ⚠️ Fourier-feature wrapper | ✅ native |
+| Annual / diurnal harmonics | All | Data — input | Periodic embedding | ✅ | ✅ |
+| Anisotropic flow-aligned structure | SSH | Basis | Matérn-SPDE / coord transform | ⚠️ approximate | ✅ exact |
+| Subtract tides + DAC + MDT | SSH | Data — output preproc | Upstream subtraction | ✅ | ✅ |
+| Subtract climatology | SST/SSS | Data — output preproc | Standardise to anomaly | ✅ | ✅ |
+| Log-transform | Chl-a | Data — output param | Predict `log f` | ✅ | ⚠️ breaks Gaussian likelihood |
+| Geostrophic currents from `η` | SSH | Data — output param | Scalar latent + `jax.grad` / analytic deriv | ✅ | ✅ |
+| Drifter velocities as ∂η obs | SSH | Data — augmentation | Cross-cov kernel rows / autodiff | ✅ | ✅ closed-form |
+| Linearised PV conservation | SSH | Loss | Soft / virtual obs | ✅ SGD | ✅ **closed-form** |
+| Full nonlinear PV | SSH | Loss | Soft (nonlinear) | ✅ SGD | ⚠️ SVI/Laplace — same cost as SGD |
+| Advection-diffusion (frozen `u`) | SST/SSS/Chl-a | Loss | Soft, two-stage | ✅ SGD | ✅ **closed-form** |
+| Bio source/sink | Chl-a | Loss | Learned `S_θ` | ✅ native | ❌ awkward |
+| Sub-grid closure | All | Loss | Learned operator | ✅ native | ❌ |
+
+The pattern (consistent with §0):
+
+- **Linear constraints favour VSSGP** — closed-form posterior, single solve, calibrated OOD uncertainty for free.
+- **Nonlinear-but-known constraints are roughly equal** — both need iterative optimisation.
+- **Learned operators favour NF** — the Chl-a source term is the only place this clearly matters across the four variables.
+
+The most expensive axis (loss with learned operator) is also the one where the methods most clearly diverge.
+
+---
+
+## 5. Recommended sequence — what to implement first
+
+For each variable, in order of leverage (highest first), with method and axis labelled:
+
+### SSH
+
+1. **[Data — output preproc]** Subtract tides, DAC, MDT → work with anomaly $\eta_a$. ½-day fix; without it nothing else is right. Both methods.
+2. **[Data — input]** Periodic harmonics (annual, M2). One-line input embedding. Both methods.
+3. **[Data — output param]** Predict scalar `η`, derive currents post-hoc. Free divergence-free constraint everywhere — including OOD. Both methods.
+4. **[Basis]** Informative spectral prior (MIOST mixture) — VSSGP native. For NF, use Fourier-feature first layer with the same `p(ω)`.
+5. **[Data — augmentation]** Drifter velocities as derivative obs. Cheap, high-physical-content. Both methods.
+6. **[Loss]** Linearised PV soft constraint at collocation points. **VSSGP wins here** — closed-form, single solve. NF fallback: standard PINN.
+7. **[Loss]** Full nonlinear PV. Optional, only after 1–6 plateau. Parity between methods.
+
+### SST
+
+1. **[Data — output preproc]** Subtract Reynolds OISST climatology.
+2. **[Data — input]** Periodic harmonics (annual, semiannual, diurnal).
+3. **[Loss]** Student-T likelihood for cloud-contaminated retrievals.
+4. **[Basis]** Spectral prior centred on frontal scales (~50 km).
+5. **[Loss]** Two-stage advection-diffusion with `u_g` from SSH reconstruction. VSSGP closed-form for the linear PDE.
+
+### SSS
+
+Same as SST minus the diurnal harmonic (negligible). Spatially-varying `σ_pde` near coasts where `S` is uncertain.
+
+### Chl-a
+
+1. **[Data — output param]** Log-transform. Predict `log f`. NF: trivial. VSSGP: breaks Gaussian likelihood — need SVI / Laplace.
+2. **[Data — input]** Periodic harmonic (annual; bloom seasonality).
+3. **[Loss]** Two-stage advection-diffusion **without** source term. Captures bloom-edge propagation.
+4. **[Loss]** Learned source `S_θ` only if observed bloom edges are sharper than the reconstruction. **NF wins here** — putting an NN inside the loss is native.
+
+### Out-of-domain experiments
+
+The most important test of the basis-axis informative prior is **prediction outside the training footprint**. Two recommended OOD splits:
+
+- **Spatial OOD** — train on a subdomain (e.g. Z2 Gulf Stream), evaluate on a held-out adjacent region (Z3 \ Z2 in 00_siren_rff_vssgp.md §6.2). The prior's spectral structure dominates beyond the training boundary.
+- **Temporal OOD** — train on Jan–Sep, evaluate on Oct–Dec. Tests whether the seasonal embeddings + spectral prior generalise over time.
+
+For VSSGP, report the posterior mean *and* per-point standard deviation — the latter should grow as you move out of domain, with the right spectral content (visible by drawing a few posterior samples and inspecting their power spectrum). For NF, report a deep-ensemble mean ± std (5–10 independently trained networks); SIREN extrapolation is famously unstable[^lipman2021] and the ensemble spread is the cheapest signal of that instability.
+
+---
+
+## 6. My take
+
+The constraint-mechanism story for this project is **three axes (basis / data / loss), not one**, and they have very different leverage profiles for OOD prediction:
+
+> **Axis ordering by OOD leverage:** Data > Basis > Loss.
+
+That ranking is specific to *out-of-domain* prediction and matters because it inverts the "in-domain" intuition.
+
+- **Data-axis interventions enforce constraints *everywhere*** — including OOD. Predict `η` not `(u, v)`, work in log-space for Chl-a, subtract MDT, embed periodic harmonics — these constraints hold in the extrapolation regime by construction. They are the highest-leverage moves and they are *method-agnostic*.
+- **Basis-axis interventions shape what the prior asserts in the gap** — they don't enforce constraints, they bias which prior samples look plausible. This is where the informative `p(ω)` from 00_siren_rff_vssgp.md does its work, and it's *most measurable* in OOD regions where the prior dominates.
+- **Loss-axis interventions enforce constraints only at the collocation points used during training** — they do not generalise to OOD by themselves. A PINN trained with PV-residual collocation in Region A does not produce PV-conserving extrapolations in Region B unless you place collocation points there. **For OOD specifically, soft-physics losses are the weakest of the three axes.**
+
+This is the part of the picture I had wrong in earlier framings of the doc: I was treating soft physics as the workhorse and basis/data as additions. For an OOD-prediction project the order is the reverse.
+
+**Concrete recommendation for siren_vs_rff:**
+
+1. Lock in all the data-axis moves first (preprocessing, periodic embeddings, scalar-latent parameterisation, derivative obs). These are the OOD-leverage moves and they apply identically to NF and VSSGP, so you can run them as the controlled-comparison baseline.
+2. Then ablate the basis-axis informative prior — VSSGP with MIOST init vs. VSSGP with uniform `p(ω)` vs. SIREN with default ω₀ vs. SIREN with Fourier-feature wrapper using the same `p(ω)`. This is the cleanest test of the 00_siren_rff_vssgp.md spectral-budget claim, and the OOD region is where the differences should be most visible.
+3. Add loss-axis soft physics last, with collocation points on a grid that *covers the OOD region as well as the training region* — otherwise the constraint won't help the metric you actually care about.
+
+For the methods themselves: **VSSGP wins on basis and on linear-loss; NF wins on Chl-a's learned source term**. Use both, additively, where each is strong. The siren_vs_rff comparison is most informative if it reports `(method × axis × OOD-vs-in-domain)` cells separately rather than a single headline RMSE — the headline number hides the place where the methods most differ.
+
+```{seealso}
+- [00_siren_rff_vssgp.md](00_siren_rff_vssgp.md) — VSSGP foundations, spectral priors, four-rung hierarchy, experiment plan
+- [02_physics_aware_ssh.md](../notebooks/02_physics_aware_ssh.md) — same DATA + KERNEL framing for the pathwise GP
+- [04_variational_dynamical_priors.md](../notebooks/04_variational_dynamical_priors.md) — the variational-DA framework, when you want a dynamical prior instead
+```
+
+---
+
+## References
+
+[^lindgren2011]: Lindgren, F., Rue, H., Lindström, J. (2011). "An explicit link between Gaussian fields and Gaussian Markov random fields: the stochastic partial differential equation approach." *Journal of the Royal Statistical Society B* 73, 423–498.
+
+[^alvarez2009]: Álvarez, M., Luengo, D., Lawrence, N. (2009). "Latent force models." *AISTATS* 2009, 9–16.
+
+[^raissi2019]: Raissi, M., Perdikaris, P., Karniadakis, G. E. (2019). "Physics-informed neural networks: a deep learning framework for solving forward and inverse problems involving nonlinear partial differential equations." *Journal of Computational Physics* 378, 686–707.
+
+[^krishnapriyan2021]: Krishnapriyan, A., Gholami, A., Zhe, S., Kirby, R., Mahoney, M. (2021). "Characterizing possible failure modes in physics-informed neural networks." *NeurIPS* 34.
+
+[^tancik2020]: Tancik, M., Srinivasan, P., Mildenhall, B., et al. (2020). "Fourier features let networks learn high-frequency functions in low-dimensional domains." *NeurIPS* 33.
+
+[^richter2022]: Richter-Powell, J., Lipman, Y., Chen, R. T. Q. (2022). "Neural Conservation Laws: A Divergence-Free Perspective." *NeurIPS* 35.
+
+[^lipman2021]: Lipman, Y., Aharoni, M. (2021). "On the failure modes of implicit neural representations under extrapolation." Workshop on Implicit Neural Representations.
+
+[^chen2018]: Chen, R. T. Q., Rubanova, Y., Bettencourt, J., Duvenaud, D. (2018). "Neural ordinary differential equations." *NeurIPS* 31.
+
+[^li2020fno]: Li, Z., Kovachki, N., Azizzadenesheli, K., Liu, B., Bhattacharya, K., Stuart, A., Anandkumar, A. (2020). "Fourier neural operator for parametric partial differential equations." *ICLR* 2021.
+
+[^held1995]: Held, I., Pierrehumbert, R., Garner, S., Swanson, K. (1995). "Surface quasi-geostrophic dynamics." *J. Fluid Mech.* 282, 1–20.

--- a/projects/interpolation/siren_vs_rff/01_physics_constraints.md
+++ b/projects/interpolation/siren_vs_rff/01_physics_constraints.md
@@ -170,10 +170,11 @@ For SSH: train on `η`, then derive geostrophic currents post-hoc as `(u_g, v_g)
 
 ### 2E. Data augmentation — derivative observations
 
-Drifter / HF-radar / Doppler-altimetry velocities give `(u_g, v_g)` directly, which by geostrophy is `-(g/f) ∂_y η, (g/f) ∂_x η` — a *linear* functional of `η`. Add these to the training set as derivative observations:
+Drifter / HF-radar / Doppler-altimetry velocities give `(u_g, v_g)` directly, which by geostrophy is `(u_g, v_g) = (-(g/f) ∂_y η, (g/f) ∂_x η)`. Inverting, the derivative observations are `∂_y η = -(f/g) u_g` and `∂_x η = (f/g) v_g` — a *linear* functional of `η`. Add these to the training set as derivative observations, ordered to match what `predict_eta_and_grad` returns (here `(η, ∂_y η, ∂_x η)`):
 
 ```python
-y_augmented = jnp.concatenate([eta_obs, -(f/g) * v_drifter, (f/g) * u_drifter])
+# y_augmented = [η_obs, ∂_y η at drifters, ∂_x η at drifters]
+y_augmented = jnp.concatenate([eta_obs, -(f/g) * u_drifter, (f/g) * v_drifter])
 loss_data = mse(predict_eta_and_grad(x, theta), y_augmented)
 ```
 

--- a/projects/interpolation/siren_vs_rff/README.md
+++ b/projects/interpolation/siren_vs_rff/README.md
@@ -1,0 +1,43 @@
+---
+title: "SIREN vs. RFF vs. VSSGP — neural fields and Bayesian Fourier features"
+---
+
+# SIREN vs. RFF vs. VSSGP
+
+A sub-project of [interpolation](../README.md) that takes a different angle from the pathwise-GP notes (00–04). The pathwise-GP notes build a sparse-to-dense reconstruction pipeline; this sub-project asks an orthogonal question: **for a function class trained on data and then evaluated — including outside the training footprint — which is the right design for geoscience: a SIREN, an RFF network, or a VSSGP?**
+
+The thesis: **SIREN and RFF are special cases of VSSGP with degenerate / uninformative spectral priors**, and for geoscience data (sparse, irregular, banded spectrum) the VSSGP framing strictly dominates because the spectral structure is something we already know.
+
+```{important}
+The two notes here build on each other. 00 establishes the unification and the experiment plan; 01 maps the physical-constraint question (basis / data / loss) onto the same framework. Read 00 first.
+```
+
+## Reading order
+
+| # | Note | Layer | What you get |
+|---|---|---|---|
+| 00 | [SIREN ↔ RFF ↔ VSSGP — Bayesian Fourier features for geoscience](00_siren_rff_vssgp.md) | Theory + experiment plan | Applied-math foundations (Bochner, RFF as MC, weight↔function-space duality), the four-rung hierarchy (RFF → SSGP → VSSGP → SIREN), spectral-budget argument for why geoscience is wrong for SIREN, operational-prior recipe (MIOST / DYMOST / DUACS → VSSGP), per-variable physical priors (SSH / SST / SSS / OC), additive-component construction, and a 6.X-section experiment plan with datasets, metrics, ablations, and compute budget. |
+| 01 | [Enforcing physics — basis, data, loss](01_physics_constraints.md) | Constraints | Three-axis taxonomy for injecting physical knowledge: basis (function class), data (input + output preprocessing + parameterisation), loss (data fit + soft physics + learned operators). Decision matrix per constraint × variable × method. The headline reframe: **for out-of-domain prediction, the leverage ordering is Data > Basis > Loss** — soft-physics losses don't generalise outside the collocation footprint, but data-axis tricks (predict scalar potential, periodic embeddings, log-transform, climatology subtraction) enforce constraints everywhere. |
+
+## How this differs from the pathwise notes
+
+| Concern | Pathwise notes (00–04) | This sub-project |
+|---|---|---|
+| Goal | Posterior reconstruction on a dense grid | Train then predict, including OOD |
+| Method family | GP with closed-form posterior + Matheron's-rule sampling | Neural fields (SIREN) and VSSGPs (Bayesian linear in RFF) |
+| Scaling concern | $\mathcal{O}(N^3)$ kernel inversion → matrix-free / patch decomp | Training cost / SGD budget |
+| Headline win | Posterior samples on a global grid | Informative spectral prior at fixed feature budget |
+| Most interesting prediction regime | Interior of training domain (interpolation) | Outside training domain (extrapolation) |
+
+The two angles complement each other. The pathwise notes optimise the *grid-sampling* axis given a fixed kernel. This sub-project optimises the *kernel choice* (and the function class more broadly) given a fixed training paradigm. Combining the two — VSSGP with informative `p(ω)` *plus* pathwise sampling for dense grid evaluation — is the natural full pipeline.
+
+## Layout
+
+```text
+projects/interpolation/siren_vs_rff/
+├── README.md                       # this file
+├── 00_siren_rff_vssgp.md           # foundations, hierarchy, priors, experiment plan
+└── 01_physics_constraints.md       # basis / data / loss axes for physical constraints
+```
+
+These notes are pure Markdown — they render directly in MyST without execution. There is no per-sub-project pixi environment; the wider repo's `pyrox` env covers the package vocabulary referenced in the pseudocode.


### PR DESCRIPTION
## Summary

Adds a new `projects/interpolation/siren_vs_rff/` sub-project that complements the existing pathwise-GP notes (00–04 from #29) with a training-paradigm angle: *for a function class trained on data and then evaluated, including outside the training footprint, which design wins for geoscience — SIREN, RFF, or VSSGP?*

Two notes:

| # | Note | What |
|---|---|---|
| 00 | [SIREN ↔ RFF ↔ VSSGP](projects/interpolation/siren_vs_rff/00_siren_rff_vssgp.md) | Applied-math foundations (Bochner, RFF as MC, weight-space duality, sample complexity, marginal likelihood as Occam's razor); the four-rung hierarchy (RFF → SSGP → VSSGP → SIREN); spectral-budget argument for geoscience; operational-prior recipe (MIOST / DYMOST / DUACS → VSSGP); per-variable physical priors (SSH / SST / SSS / OC); experiment plan with datasets, metrics, ablations, and compute budget. |
| 01 | [Enforcing physics — basis, data, loss](projects/interpolation/siren_vs_rff/01_physics_constraints.md) | Three-axis taxonomy (basis / data / loss) for injecting physical knowledge in NF/VSSGP pipelines, with out-of-domain prediction in mind. Decision matrix per constraint × variable × method. Headline: **for OOD prediction the leverage ordering is Data > Basis > Loss**, since soft-physics losses don't generalise outside the collocation footprint. |

The pathwise notes (00–04) optimise the *grid-sampling* axis given a fixed kernel; this sub-project optimises the *kernel choice* given a fixed training paradigm. Combined, they're the natural full pipeline.

Wires the sub-project into the MyST book TOC and cross-links it from the parent project README.

## Test plan

- [ ] `make docs-serve` and verify the new "SIREN vs. RFF vs. VSSGP" sub-section renders under "Interpolation (SSH reconstruction)"
- [ ] Inline links between 00 / 01 / parent README all resolve
- [ ] LaTeX math renders correctly (Bochner identity, sample-complexity bound, augmented Gram matrix block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)