### PR TITLE
docs(interpolation): fix anisotropy scaling and Var[f*] labelling (post-merge fix-ups for #35)

### DIFF
--- a/projects/interpolation/siren_vs_rff/00_siren_rff_vssgp.md
+++ b/projects/interpolation/siren_vs_rff/00_siren_rff_vssgp.md
@@ -105,9 +105,12 @@ $$
 \Sigma_{\text{post}} &= \bigl(\Phi^{\!\top} \Phi / \sigma_n^2 + \Sigma_w^{-1}\bigr)^{-1} \quad &(M \times M) \\
 \mu_{\text{post}}    &= \Sigma_{\text{post}}\, \Phi^{\!\top} y / \sigma_n^2 \quad &(M,) \\
 \mathbb{E}[f^*]      &= \phi(x^*)^{\!\top} \mu_{\text{post}} \\
-\mathrm{Var}[f^*]    &= \phi(x^*)^{\!\top} \Sigma_{\text{post}}\, \phi(x^*) + \sigma_n^2
+\mathrm{Var}[f^*]    &= \phi(x^*)^{\!\top} \Sigma_{\text{post}}\, \phi(x^*) \\
+\mathrm{Var}[y^*]    &= \mathrm{Var}[f^*] + \sigma_n^2
 \end{aligned}
 $$
+
+(`Var[f*]` is the latent function variance — what you use for CRPS / NLPD on the underlying field; `Var[y*]` adds the observation-noise term and is what you use when comparing predictions to noisy held-out measurements.)
 
 *Engineering consequence.* This is one Cholesky on an `M × M` matrix. You get not just a point prediction, but a full predictive distribution at every test point — gap-filling uncertainty for free. SIREN replaces this entire block with `argmin_w ‖y − Φw‖² + λ‖w‖²` (i.e. ridge regression with a single tuned scalar `λ`), losing the per-point variance and the principled regularization-from-the-prior.
 
@@ -366,8 +369,11 @@ def patch_prior(x_patch):
     weights = jnp.array([0.35, 0.45, 0.20])  # variance shares
 
     # DYMOST-style anisotropy
+    # Spectral covariance scales like (2π/L)², and r_patch = L_∥/L_⊥ ≥ 1, so
+    # the parallel axis carries 1/r² *less* wavenumber variance than the
+    # perpendicular axis (the field varies more rapidly across-stream).
     R = rotation(θ_patch)
-    Σ_ω = R.T @ jnp.diag([1.0, r_patch**2]) @ R
+    Σ_ω = R.T @ jnp.diag([1.0, 1.0 / r_patch**2]) @ R   # [⊥, ∥]
 
     return centres, weights, Σ_ω, σ_patch
 


### PR DESCRIPTION
## Summary

Two post-merge review issues from PR #35 (Codex P1 + P2), addressed against `main`:

| Issue | File | Fix |
|---|---|---|
| **P1 — DYMOST anisotropy scaling inverted** | `00_siren_rff_vssgp.md` (in the §3.0.4 `patch_prior` pseudocode) | With `r = L_∥/L_⊥` and spectral covariance scaling like `(2π/L)²`, the diag should be `[1, 1/r²]` (factoring out `(2π/L_⊥)²`). Previous `[1, r²]` put more wavenumber variance on the larger-lengthscale axis, inverting the intended flow alignment. |
| **P2 — `Var[f*]` mislabelled** | `00_siren_rff_vssgp.md` §0.4 closed-form posterior block | The `+ σ_n²` term belongs to `Var[y*]` (noisy observation), not the latent variance `Var[f*]`. Split the line in two and add a clarifying note: `Var[f*]` is for CRPS/NLPD on the underlying field; `Var[y*] = Var[f*] + σ_n²` is for noisy held-out comparison. |

Both were caught by automated review on the original PR after merge; would have biased downstream implementation/calibration if copied as written.

## Test plan

- [ ] Verify `Var[f*]` and `Var[y*]` are both shown and the comment about which to use for which metric is correct.
- [ ] Verify the corrected `patch_prior` produces stronger wavenumber variance on the perpendicular-to-flow axis (which is the DYMOST-intended behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)