### PR TITLE
docs(geotoolz): add design plans and georeader tutorial

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -110,6 +110,38 @@ project:
               children:
                 - file: projects/plume_simulation/notebooks/radtran/04_srf_band_integration.ipynb
                 - file: projects/plume_simulation/notebooks/radtran/05_matched_filter_retrieval.ipynb
+        - title: geotoolz
+          children:
+            - title: Plans
+              children:
+                - file: projects/geotoolz/plans/geotoolz.md
+                - file: projects/geotoolz/plans/georeader.md
+                - file: projects/geotoolz/plans/geocatalog.md
+                - file: projects/geotoolz/plans/geoduckdb.md
+                - file: projects/geotoolz/plans/geostack.md
+                - file: projects/geotoolz/plans/geostationary.md
+                - file: projects/geotoolz/plans/modis.md
+            - title: georeader tutorial
+              children:
+                - file: projects/geotoolz/georeader_tutorial/00_index.md
+                - file: projects/geotoolz/georeader_tutorial/01_geotensor.md
+                - file: projects/geotoolz/georeader_tutorial/02_abstract_reader.md
+                - file: projects/geotoolz/georeader_tutorial/03_rasterio_reader.md
+                - file: projects/geotoolz/georeader_tutorial/04_window_utils.md
+                - file: projects/geotoolz/georeader_tutorial/05_read.md
+                - file: projects/geotoolz/georeader_tutorial/06_slices.md
+                - file: projects/geotoolz/georeader_tutorial/07_griddata.md
+                - file: projects/geotoolz/georeader_tutorial/08_mosaic.md
+                - file: projects/geotoolz/georeader_tutorial/09_rasterize.md
+                - file: projects/geotoolz/georeader_tutorial/10_vectorize.md
+                - file: projects/geotoolz/georeader_tutorial/11_reflectance.md
+                - file: projects/geotoolz/georeader_tutorial/12_save.md
+                - file: projects/geotoolz/georeader_tutorial/13_misc_io.md
+                - file: projects/geotoolz/georeader_tutorial/14_sentinel2.md
+                - file: projects/geotoolz/georeader_tutorial/15_hyperspectral.md
+                - file: projects/geotoolz/georeader_tutorial/16_earth_engine.md
+                - file: projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
+                - file: projects/geotoolz/georeader_tutorial/18_query_and_download.md
         - title: Gaussianization flows
           children:
             - file: projects/gaussianization/README.md

--- a/projects/geotoolz/georeader_tutorial/00_index.md
+++ b/projects/geotoolz/georeader_tutorial/00_index.md
@@ -1,7 +1,6 @@
-# georeader tutorial — module catalog
+# Module catalog
 
-> **Source:** `spaceml-org/georeader` @ branch `feature/geotensor_npapi`, commit `f0d92f0`
-> **Cloned to:** `/tmp/georeader_src` (re-clone if removed)
+> **Source:** [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader/tree/f0d92f0) @ branch `feature/geotensor_npapi`, commit [`f0d92f0`](https://github.com/spaceml-org/georeader/tree/f0d92f0)
 > **Goal:** a module-by-module tutorial that captures the package's capabilities **and preserves all ASCII diagrams** before they're cleaned up downstream.
 
 The package is ~20k LOC across 17 top-level files + 14 reader modules. ~1100 lines of box-drawing ASCII art are scattered across docstrings — this is the doc treasure we're rescuing.

--- a/projects/geotoolz/georeader_tutorial/00_index.md
+++ b/projects/geotoolz/georeader_tutorial/00_index.md
@@ -1,0 +1,104 @@
+# georeader tutorial — module catalog
+
+> **Source:** `spaceml-org/georeader` @ branch `feature/geotensor_npapi`, commit `f0d92f0`
+> **Cloned to:** `/tmp/georeader_src` (re-clone if removed)
+> **Goal:** a module-by-module tutorial that captures the package's capabilities **and preserves all ASCII diagrams** before they're cleaned up downstream.
+
+The package is ~20k LOC across 17 top-level files + 14 reader modules. ~1100 lines of box-drawing ASCII art are scattered across docstrings — this is the doc treasure we're rescuing.
+
+---
+
+## Recommended tutorial structure
+
+Each chapter = one file under `georeader_tutorial/`. We work through them one at a time. Diagrams are copied verbatim into the tutorial; surrounding prose explains the concept and adds runnable examples.
+
+### Part I — Core data model
+
+| # | File | Source module | LOC | Diagrams | What you learn |
+|---|------|---------------|-----|----------|----------------|
+| 1 | `01_geotensor.md` | `geotensor.py` | 2532 | 86 | The numpy-subclass `GeoTensor` — dim conventions, `__array_ufunc__`, `__array_finalize__`, transform/CRS round-trip, time as a first-class dim. **The centerpiece of this branch.** |
+| 2 | `02_abstract_reader.md` | `abstract_reader.py` | 257 | 46 | The `GeoData` / `GeoTensor` / Reader Protocol type hierarchy — what duck-types as a georeader source. |
+| 3 | `03_rasterio_reader.md` | `rasterio_reader.py` | 1630 | 66 | Lazy file-backed reader: `RasterioReader`, multi-file stacks, windowed reads, overviews, cloud-native VSI paths. |
+
+### Part II — Reading & windowing
+
+| # | File | Source module | LOC | Diagrams | What you learn |
+|---|------|---------------|-----|----------|----------------|
+| 4 | `04_window_utils.md` | `window_utils.py` | 1471 | 102 | Window anatomy, pixel↔geo transforms, padding, alignment, intersection. The math of "what region am I reading." |
+| 5 | `05_read.md` | `read.py` | 1967 | 123 | The high-level `read_from_*` family: bounds, polygon, center coords, bbox, with reprojection + resampling. **Most diagrams in the package.** |
+| 6 | `06_slices.md` | `slices.py` | 404 | 60 | Tiling strategies: overlap vs stride vs chunked, generating windows for tiled inference. |
+
+### Part III — Geometry & gridding
+
+| # | File | Source module | LOC | Diagrams | What you learn |
+|---|------|---------------|-----|----------|----------------|
+| 7 | `07_griddata.md` | `griddata.py` | 617 | 96 | Irregular→regular gridding, GLT (geolocation lookup tables), `read_to_crs` for swath sensors. |
+| 8 | `08_mosaic.md` | `mosaic.py` | 450 | 66 | Multi-raster mosaicking with reprojection + nodata fill — cloud-free composites. |
+| 9 | `09_rasterize.md` | `rasterize.py` | 438 | 58 | Burning vector geometries (polygons, lines) into raster grids aligned to a `GeoTensor`. |
+| 10 | `10_vectorize.md` | `vectorize.py` | 370 | 63 | Inverse: extracting polygons from binary masks (segmentation → GIS-ready vectors). |
+
+### Part IV — Radiometry & I/O
+
+| # | File | Source module | LOC | Diagrams | What you learn |
+|---|------|---------------|-----|----------|----------------|
+| 11 | `11_reflectance.md` | `reflectance.py` | 971 | 97 | Radiance↔ToA reflectance, spectral response functions (SRF), solar irradiance integrals (Thuillier). |
+| 12 | `12_save.md` | `save.py` + `save_cog.py` | 586 | 58 | Writing GeoTensors to disk; full COG anatomy with the IFD/overview/tile diagram. |
+| 13 | `13_misc_io.md` | `io.py`, `dataarray.py`, `plot.py` | 113+145+336 | 0 | Smaller utilities: fsspec wrappers, xarray bridge (`to_dataarray`/`from_dataarray`), `plot.show`. |
+
+### Part V — Sensor readers
+
+| # | File | Source module | LOC | Diagrams | What you learn |
+|---|------|---------------|-----|----------|----------------|
+| 14 | `14_sentinel2.md` | `readers/S2_SAFE_reader.py` | 1845 | 47 | S2 SAFE reader (L1C + L2A), band groups, GCS support, jp2 reads. |
+| 15 | `15_hyperspectral.md` | `readers/{emit,prisma,enmap}.py` | 1102+571+865 | 27+38+33 | Hyperspectral trio — EMIT (ISS, 285 bands), PRISMA (ASI, 239 bands), EnMAP (DLR, 224 bands). All curvilinear; common pattern. |
+| 16 | `16_earth_engine.md` | `readers/{ee_image,ee_query,ee_utils}.py` | 539+589+58 | 42 | GEE export with recursive tile splitting and parallel download. |
+| 17 | `17_legacy_sensors.md` | `readers/{spotvgt,probav}_image_operational.py` | 389+701 | 0 | SPOT VGT and Proba-V — operational legacy readers. |
+| 18 | `18_query_and_download.md` | `readers/{scihubcopernicus_query,download_pv_product,query_utils,tileserver,download_utils}.py` | small | 0 | Catalog/query helpers, downloaders, tile-server adapter. |
+
+---
+
+## Diagram inventory (count of box-drawing chars per file)
+
+```
+read.py                 123    ← reading workflow, AOI specification, reprojection
+window_utils.py         102    ← window anatomy, pixel↔geo, alignment
+reflectance.py           97    ← unit conventions, SRF, irradiance pipeline
+griddata.py              96    ← irregular vs regular grids, GLT
+geotensor.py             86    ← dim conventions, ufunc protocol, metadata flow
+rasterio_reader.py       66    ← lazy I/O architecture
+mosaic.py                66    ← spatial mosaic concept
+vectorize.py             63    ← raster→vector pipeline
+slices.py                60    ← tiling strategies
+save.py                  58    ← COG structure
+rasterize.py             58    ← vector→raster pipeline
+S2_SAFE_reader.py        47    ← S2 product levels, band groups
+abstract_reader.py       46    ← georeader type hierarchy
+ee_image.py              42    ← GEE export architecture
+prisma.py                38    ← PRISMA HDF5 layout
+enmap.py                 33    ← EnMAP product structure
+emit.py                  27    ← EMIT NetCDF layout
+─────────────────────────────
+TOTAL                  ~1148 box-drawing chars across 17 files
+```
+
+(Plus pipe-tables and `+--+`-style diagrams not counted above. Per-chapter we'll grep these out exhaustively.)
+
+---
+
+## Working method
+
+1. We pick a chapter from the table above.
+2. I extract every ASCII diagram from that module's docstrings verbatim into the chapter file.
+3. I add concise prose around each diagram explaining the concept.
+4. I add 1–3 runnable code snippets per chapter using realistic geo data (no mock arrays).
+5. We review and iterate before moving to the next chapter.
+
+**Suggested starting order:** 1 (geotensor) → 2 (abstract_reader) → 3 (rasterio_reader) → 5 (read) → 4 (window_utils) → ... — front-loads the conceptual core, then radiates outward.
+
+---
+
+## Open questions before we start writing
+
+- **Format:** `.md` per chapter (current proposal) or jupytext `.py` notebooks executed to `.ipynb` (matches the research_notebook convention)?
+- **Code execution:** do you want runnable cells with real S2/EMIT downloads, or pseudocode-only (faster, no data deps)?
+- **Scope of "Part V — Sensor readers":** all of them, or just the four flagship ones (S2, EMIT, PRISMA, EnMAP)?

--- a/projects/geotoolz/georeader_tutorial/01_geotensor.md
+++ b/projects/geotoolz/georeader_tutorial/01_geotensor.md
@@ -1,0 +1,307 @@
+# Chapter 1 — `geotensor.py`: the numpy-subclass `GeoTensor`
+
+> **Module:** `georeader/geotensor.py` (2532 LOC)
+> **Branch:** `feature/geotensor_npapi` — this module *is* the headline change of that branch.
+> **Role:** the package's central data structure. Every reader in georeader produces a `GeoTensor`; every writer consumes one; every operator in `geotoolz` will be `GeoTensor → GeoTensor`.
+
+---
+
+## 1. What `GeoTensor` is, in one sentence
+
+A `numpy.ndarray` **subclass** that carries `(transform, crs, fill_value_default, attrs)` alongside the buffer, and propagates that metadata through ufuncs, slicing, copies, and views — so `gt + 1`, `np.sqrt(gt)`, and `gt[:, 100:200, 100:200]` all return correctly georeferenced `GeoTensor`s with **zero** boilerplate at the call site.
+
+This is a fundamentally different design from the previous `GeoTensor` (which was a wrapper holding a `.values` array). On this branch:
+
+- `gt` *is* an ndarray. You can pass it to anything that takes one.
+- `gt.values` exists as a back-compat property returning `self.view(np.ndarray)`.
+- `__array_ufunc__` intercepts ufuncs to re-wrap the result with the original metadata.
+- `__array_finalize__` propagates metadata across views/copies/slices.
+- Spatial slicing rewrites `transform` so georeferencing stays correct.
+
+---
+
+## 2. Memory layout and dim conventions
+
+`GeoTensor` supports 2D, 3D, and 4D arrays. **The last two dimensions are always spatial** — `(..., y, x)` — and are the only dimensions whose semantics the class is opinionated about.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     GEOTENSOR DIMENSION CONVENTIONS                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  2D: (H, W)           Single-band raster (e.g., DEM, mask)              │
+│                       shape = (height, width)                           │
+│                                                                         │
+│  3D: (C, H, W)        Multi-band raster (e.g., RGB, multispectral)      │
+│                       shape = (channels, height, width)                 │
+│                                                                         │
+│  4D: (T, C, H, W)     Time-series cube (e.g., satellite time stack)     │
+│                       shape = (time, channels, height, width)           │
+│                                                                         │
+│  Dimension names:  dims = ("y", "x") or ("band", "y", "x") or           │
+│                          ("time", "band", "y", "x")                     │
+│                                                                         │
+│  Note: "y" decreases downward (row index), "x" increases rightward      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`dims` is computed from the array's `ndim` — it isn't free-form like xarray's. The constructor raises `ValueError` for `ndim < 2` or `ndim > 4`.
+
+---
+
+## 3. The affine transform — pixel ↔ geographic coordinates
+
+`GeoTensor.transform` is a `rasterio.Affine` (6-tuple) that maps `(col, row)` pixel coordinates to `(x, y)` geographic coordinates in the CRS units (typically metres for projected CRSs, degrees for `EPSG:4326`).
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              AFFINE TRANSFORM: PIXEL ↔ GEOGRAPHIC COORDINATES           │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Pixel Space (row, col)              Geographic Space (x, y)            │
+│  ┌───┬───┬───┬───┬───┐              ┌─────────────────────────┐         │
+│  │0,0│0,1│0,2│0,3│...│              │OriginX ──────────────►  │         │
+│  ├───┼───┼───┼───┼───┤     ═══►     │OriginY                  │         │
+│  │1,0│1,1│   │   │   │   Transform  │   │                     │         │
+│  ├───┼───┼───┼───┼───┤              │   ▼                     │         │
+│  │2,0│   │   │   │   │              │        (CRS units)      │         │
+│  └───┴───┴───┴───┴───┘              └─────────────────────────┘         │
+│                                                                         │
+│  Affine Transform:  | a  b  c |    x_geo = a * col + b * row + c        │
+│                     | d  e  f |    y_geo = d * col + e * row + f        │
+│                                                                         │
+│  Typical (north-up):  a = pixel_width (positive)                        │
+│                       e = -pixel_height (negative, y decreases down)    │
+│                       c = origin_x (upper-left corner)                  │
+│                       f = origin_y (upper-left corner)                  │
+│                       b, d = 0 (no rotation/shear)                      │
+│                                                                         │
+│  Resolution:  res = (|a|, |e|) in CRS units (e.g., meters, degrees)     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+A few things this diagram is doing implicitly:
+
+- **The y-axis is flipped.** Image-space convention is row 0 at the top; geographic-space convention is y increasing northward. The negative `e` reconciles them.
+- **`b` and `d` are nonzero only for rotated/sheared rasters.** Most readers in georeader assume north-up; some readers (PRISMA, EnMAP, MODIS swath) deliberately don't and route through `griddata` instead — see [Chapter 7](07_griddata.md).
+- **`bounds` is derived, not stored.** `gt.bounds` returns `(minx, miny, maxx, maxy)` computed from `transform` and `shape` on every access. Likewise `gt.res = (|a|, |e|)`.
+
+---
+
+## 4. NumPy operations preserve geospatial info
+
+Because `GeoTensor` is a true ndarray subclass, **all numpy operations work** — and the spatial metadata rides along automatically:
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    NUMPY OPERATIONS PRESERVE GEOSPATIAL INFO            │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Arithmetic:     gt + 1, gt * 2, gt1 + gt2 (same extent required)       │
+│  Comparison:     gt > 0, gt == other                                    │
+│  Ufuncs:         np.sqrt(gt), np.log(gt), np.clip(gt, 0, 1)             │
+│  Aggregation:    gt.mean(), gt.sum(axis=0)  # Returns scalar/array      │
+│  Slicing:        gt[0], gt[:, 10:20, 10:20]  # Updates transform        │
+│                                                                         │
+│  Important: Operations that change spatial dimensions (slicing)         │
+│  automatically update the transform to maintain georeferencing!         │
+│                                                                         │
+│  Example:                                                               │
+│    gt_subset = gt[:, 100:200, 100:200]                                  │
+│    # gt_subset.transform origin shifted by (100*res_x, 100*res_y)       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The mechanics behind this — three numpy hooks doing the heavy lifting:
+
+| Hook | Where | What it does |
+|---|---|---|
+| `__array_finalize__` | called on every new view/copy | Copies `transform`, `crs`, `fill_value_default`, `attrs` from the parent. Default behaviour: passthrough. |
+| `__array_ufunc__` | called on every ufunc (`np.add`, `np.sqrt`, …) | Strips inputs to plain ndarrays, applies the ufunc, re-wraps the output as a `GeoTensor` with metadata copied from the first `GeoTensor` input. |
+| `__getitem__` | called on `gt[...]` | Standard ndarray slice, then **rewrites `transform`** if the spatial axes (last two) were sliced — origin shifts by `start * res`, resolution rescales by `step`. |
+
+The aggregation case (`.mean()`, `.sum(axis=0)`) returns a scalar or lower-dim array; a *spatial* reduction usually returns a plain ndarray because the result no longer has a meaningful transform. (See `_preserved_spatial` at [geotensor.py:385](../../../../tmp/georeader_src/georeader/geotensor.py#L385).)
+
+---
+
+## 5. Constructor and core attributes
+
+```python
+GeoTensor(values, transform, crs, fill_value_default=0, attrs=None)
+```
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `values` | `np.ndarray` view | back-compat alias for `self.view(np.ndarray)` |
+| `transform` | `rasterio.Affine` | pixel → geographic |
+| `crs` | EPSG code / WKT / `pyproj.CRS` | passed through to rasterio |
+| `fill_value_default` | scalar or `None` | what out-of-bounds reads pad with |
+| `attrs` | `dict` | freeform metadata bag (sensor info, acquisition time…) |
+| `bounds` | `(minx, miny, maxx, maxy)` | derived from transform + shape |
+| `res` | `(x_res, y_res)` | `(|a|, |e|)` from transform |
+| `height`, `width`, `count` | `int` | last dim, second-to-last dim, third-from-last (or 1 for 2D) |
+| `dims` | `tuple[str, ...]` | `("y","x")` / `("band","y","x")` / `("time","band","y","x")` |
+
+Round-trip helpers: `gt.to_json()` / `GeoTensor.from_json(d)` — useful for catalogs and for Hydra round-trips downstream.
+
+---
+
+## 6. xarray-style indexing: `isel`
+
+`__getitem__` is the numpy-positional path. `isel` is the **named-dimension** path — closer to xarray ergonomics and the recommended API for geotoolz operators.
+
+```text
+Standard dimension names for 3D GeoTensor (C, H, W):
+┌──────────┬────────────────┬────────────────────┐
+│ Dim name │ Array axis     │ Description        │
+├──────────┼────────────────┼────────────────────┤
+│ "band"   │ axis 0 (C)     │ Spectral bands     │
+│ "y"      │ axis 1 (H)     │ Rows (north-south) │
+│ "x"      │ axis 2 (W)     │ Cols (east-west)   │
+└──────────┴────────────────┴────────────────────┘
+```
+
+`isel` accepts a dict mapping dim names to `slice`, `list[int]`, or `int`. Spatial dims (`"x"`, `"y"`) only accept slices — fancy indexing on spatial axes would invalidate the affine transform. Examples (per the docstring):
+
+- `gt.isel({"x": slice(10, 110)})` — columns 10..109
+- `gt.isel({"band": [3, 2, 1]})` — pick + reorder bands (RGB from S2 BGR)
+- `gt.isel({"x": slice(0, 100, 2), "y": slice(0, 100, 2)})` — 2× downsample (rewrites `res`)
+
+Source: [geotensor.py:1330](../../../../tmp/georeader_src/georeader/geotensor.py#L1330).
+
+---
+
+## 7. Padding for fixed-size tiles
+
+`gt.pad(pad_width=...)` extends a `GeoTensor` with the fill value. Useful when CNN inference needs a fixed input size and your tile lands at a scene edge.
+
+```text
+pad_width = {"x": (2, 3), "y": (1, 4)}
+
+Original (5×5):           Padded (10×10):
+┌─────────────┐           ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
+│ █ █ █ █ █ │           │   ← 1 row top           │
+│ █ █ █ █ █ │    →      │ ┌─────────────┐          │
+│ █ █ █ █ █ │           │ │ █ █ █ █ █ │          │
+│ █ █ █ █ █ │           │ │ █ █ █ █ █ │          │
+│ █ █ █ █ █ │           │ │ █ █ █ █ █ │          │
+└─────────────┘           │ │ █ █ █ █ █ │          │
+                          │ │ █ █ █ █ █ │          │
+                          │ └─────────────┘          │
+                          │   ← 4 rows bottom       │
+                          └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+                            ↑           ↑
+                            2 cols      3 cols
+                            left        right
+```
+
+Padding shifts `transform.c` (origin x) leftward by `pad_left * res_x` and `transform.f` (origin y) upward by `pad_top * res_y` so the geographic position of the original pixels is unchanged. There's a sister method `pad_array` that pads only the buffer without touching the transform — used internally by readers.
+
+---
+
+## 8. Window-based reads: boundless vs bounded
+
+`gt.read_from_window(window, boundless=True|False)` extracts a sub-region using a `rasterio.windows.Window`. The same interface as rasterio's lazy windowed reads, so you can swap a `RasterioReader` for an in-memory `GeoTensor` without changing call sites — this is the whole point of the [abstract reader protocol](02_abstract_reader.md).
+
+```text
+Window extends beyond data:     boundless=True:      boundless=False:
+┌───────────────┐                 ┌─────────┐           ┌─────┐
+│ ┌─────────┐   │                 │▒▒▒▒▒▒▒▒▒│           │     │
+│ │  DATA   │   │                 │▒▒▒███▒▒▒│           │ ███ │
+│ │         │   │  ─────────►    │▒▒▒███▒▒▒│           │ ███ │
+│ └─────────┘   │                 │▒▒▒▒▒▒▒▒▒│           └─────┘
+└───────────────┘                 └─────────┘           Returns only
+     Window                   Padded with            intersection
+     request                  fill_value
+```
+
+`boundless=True` (the default for `RasterioReader` reads in georeader) is the right choice for tiled inference: every chip comes back with the requested shape, so batches stack cleanly. `boundless=False` is useful when you want to *know* you're at an edge.
+
+Source: [geotensor.py:2227](../../../../tmp/georeader_src/georeader/geotensor.py#L2227).
+
+---
+
+## 9. Stacking — building time series
+
+`GeoTensor.stack([gt1, gt2, gt3])` is a classmethod that prepends a new axis. All inputs must share `transform`, `crs`, and `shape` (checked via `same_extent`).
+
+```text
+Input: 3 GeoTensors each (3, H, W)
+
+gt1: (3, 100, 100)  ─┐
+gt2: (3, 100, 100)  ─┼──► stacked: (3, 3, 100, 100)
+gt3: (3, 100, 100)  ─┘     ↑
+                        new time/batch dim
+```
+
+Result `dims = ("time", "band", "y", "x")`. There's also `concatenate(geotensors, axis=0)` for joining along an existing axis (e.g., concatenating bands from two coregistered scenes).
+
+---
+
+## 10. Method reference (the public surface)
+
+Grouped roughly by lifecycle:
+
+**Construction / I/O**
+- `GeoTensor(values, transform, crs, fill_value_default=0, attrs=None)` — primary constructor
+- `GeoTensor.load_file(path, ...)` — read a whole file into memory ([geotensor.py:2064](../../../../tmp/georeader_src/georeader/geotensor.py#L2064))
+- `GeoTensor.load_bytes(data, ...)` — read from a bytes buffer ([geotensor.py:2132](../../../../tmp/georeader_src/georeader/geotensor.py#L2132))
+- `to_json()` / `from_json(d)` — JSON round-trip of metadata
+
+**Properties**
+- `values`, `dims`, `res`, `dtype`, `height`, `width`, `count`, `bounds`
+
+**Geometry**
+- `meshgrid(dst_crs=None)` — pixel-centre coordinate arrays
+- `footprint(crs=None)` — outer polygon in any CRS
+- `valid_footprint(...)` — polygon excluding nodata regions
+- `same_extent(other, precision=1e-3)` — transform-and-shape equality
+
+**Array ops with georeferencing semantics**
+- `isel(sel)` — xarray-style slicing
+- `pad(pad_width)` / `pad_array(pad_width)` — fixed-size tile padding
+- `resize(...)` — resampling onto a new shape
+- `transpose(axes=None)` — for `(C,H,W) ↔ (H,W,C)` plotting flips
+- `squeeze`, `expand_dims`, `clip`
+- `validmask()` / `invalidmask()` — boolean masks based on `fill_value_default`
+
+**Window I/O**
+- `read_from_window(window, boundless=True)` — extract a sub-region
+- `write_from_window(data, window)` — write into a sub-region in place
+
+**Multi-tensor**
+- `GeoTensor.stack([gts])` — new leading axis (time/batch)
+- `GeoTensor.concatenate([gts], axis=0)` — join along existing axis
+
+**Arithmetic / comparison dunders**
+- `+`, `-`, `*`, `/`, `&`, `|`, `==`, `!=`, `<`, `<=`, `>`, `>=` — all preserve metadata, reject mismatched extents for binary `GeoTensor`-`GeoTensor` ops
+
+**NumPy plumbing (you rarely call these, but they're how the magic works)**
+- `__array_finalize__` — propagates metadata across views/copies
+- `__array_ufunc__` — re-wraps ufunc outputs
+- `__array__` — explicit cast back to `np.ndarray`
+- `array_as_geotensor(arr, ...)` — instance method to wrap a fresh ndarray with `self`'s metadata
+- `_preserved_spatial(method, **kwargs)` — internal: does this reduction keep the spatial shape?
+
+---
+
+## 11. Why this redesign matters for `geotoolz`
+
+Three concrete wins for the operator-composition layer:
+
+1. **Operators stop unwrapping.** Pre-redesign code looked like `out = my_func(gt.values); return GeoTensor(out, gt.transform, gt.crs, ...)`. Now it's `return my_func(gt)` — the ufunc protocol carries the metadata for free.
+2. **scikit-image / scipy.ndimage interop is half-free.** Anything that goes through ufuncs round-trips automatically. Functions that don't (`skimage.transform.resize`, `scipy.ndimage.uniform_filter`) need a small `preserve_subclass` decorator at the Tier B layer — see [geotoolz.md §5.2](../plans/geotoolz.md).
+3. **Time becomes a first-class axis** without inventing a new container. 4D `(T, C, H, W)` is just an ndarray shape; `GeoTensor.stack` builds it; numpy reductions slice it.
+
+The downside to be aware of: spatial reductions (e.g., `gt.sum(axis=(-2,-1))`) drop to a plain ndarray because the result has no transform. Operators that want to keep a `GeoTensor`-shaped result for *non-spatial* reductions must wrap the output explicitly via `gt.array_as_geotensor(...)`.
+
+---
+
+## 12. Sharp edges
+
+- **Same-extent rule for binary ops.** `gt1 + gt2` raises if the transforms or shapes don't match (see `same_extent` and the `__add__` body at [geotensor.py:625](../../../../tmp/georeader_src/georeader/geotensor.py#L625)). Reproject first, don't try to "broadcast" across spatial extent.
+- **`fill_value_default` is metadata, not a mask.** It's used by `read_from_window(boundless=True)`, `validmask()`, `invalidmask()`, and `pad`. It does *not* turn arithmetic into masked arithmetic — `gt + 1` still adds 1 to nodata pixels.
+- **Spatial slicing must use `slice`, not lists.** `gt.isel({"x": [0, 5, 10]})` is rejected; the resulting raster wouldn't be regularly sampled and the transform wouldn't be definable.
+- **`crs` is whatever rasterio accepts.** EPSG int, EPSG string, WKT, or `pyproj.CRS`. The class doesn't normalise — be consistent within a pipeline.
+
+Next chapter: [02_abstract_reader.md](02_abstract_reader.md) — the type hierarchy and protocols that make `GeoTensor` and `RasterioReader` interchangeable.

--- a/projects/geotoolz/georeader_tutorial/01_geotensor.md
+++ b/projects/geotoolz/georeader_tutorial/01_geotensor.md
@@ -1,4 +1,4 @@
-# Chapter 1 — `geotensor.py`: the numpy-subclass `GeoTensor`
+# Ch. 1 — `geotensor`
 
 > **Module:** `georeader/geotensor.py` (2532 LOC)
 > **Branch:** `feature/geotensor_npapi` — this module *is* the headline change of that branch.
@@ -120,7 +120,7 @@ The mechanics behind this — three numpy hooks doing the heavy lifting:
 | `__array_ufunc__` | called on every ufunc (`np.add`, `np.sqrt`, …) | Strips inputs to plain ndarrays, applies the ufunc, re-wraps the output as a `GeoTensor` with metadata copied from the first `GeoTensor` input. |
 | `__getitem__` | called on `gt[...]` | Standard ndarray slice, then **rewrites `transform`** if the spatial axes (last two) were sliced — origin shifts by `start * res`, resolution rescales by `step`. |
 
-The aggregation case (`.mean()`, `.sum(axis=0)`) returns a scalar or lower-dim array; a *spatial* reduction usually returns a plain ndarray because the result no longer has a meaningful transform. (See `_preserved_spatial` at [geotensor.py:385](../../../../tmp/georeader_src/georeader/geotensor.py#L385).)
+The aggregation case (`.mean()`, `.sum(axis=0)`) returns a scalar or lower-dim array; a *spatial* reduction usually returns a plain ndarray because the result no longer has a meaningful transform. (See `_preserved_spatial` at [geotensor.py:385](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L385).)
 
 ---
 
@@ -167,7 +167,7 @@ Standard dimension names for 3D GeoTensor (C, H, W):
 - `gt.isel({"band": [3, 2, 1]})` — pick + reorder bands (RGB from S2 BGR)
 - `gt.isel({"x": slice(0, 100, 2), "y": slice(0, 100, 2)})` — 2× downsample (rewrites `res`)
 
-Source: [geotensor.py:1330](../../../../tmp/georeader_src/georeader/geotensor.py#L1330).
+Source: [geotensor.py:1330](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L1330).
 
 ---
 
@@ -217,7 +217,7 @@ Window extends beyond data:     boundless=True:      boundless=False:
 
 `boundless=True` (the default for `RasterioReader` reads in georeader) is the right choice for tiled inference: every chip comes back with the requested shape, so batches stack cleanly. `boundless=False` is useful when you want to *know* you're at an edge.
 
-Source: [geotensor.py:2227](../../../../tmp/georeader_src/georeader/geotensor.py#L2227).
+Source: [geotensor.py:2227](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L2227).
 
 ---
 
@@ -244,8 +244,8 @@ Grouped roughly by lifecycle:
 
 **Construction / I/O**
 - `GeoTensor(values, transform, crs, fill_value_default=0, attrs=None)` — primary constructor
-- `GeoTensor.load_file(path, ...)` — read a whole file into memory ([geotensor.py:2064](../../../../tmp/georeader_src/georeader/geotensor.py#L2064))
-- `GeoTensor.load_bytes(data, ...)` — read from a bytes buffer ([geotensor.py:2132](../../../../tmp/georeader_src/georeader/geotensor.py#L2132))
+- `GeoTensor.load_file(path, ...)` — read a whole file into memory ([geotensor.py:2064](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L2064))
+- `GeoTensor.load_bytes(data, ...)` — read from a bytes buffer ([geotensor.py:2132](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L2132))
 - `to_json()` / `from_json(d)` — JSON round-trip of metadata
 
 **Properties**
@@ -299,7 +299,7 @@ The downside to be aware of: spatial reductions (e.g., `gt.sum(axis=(-2,-1))`) d
 
 ## 12. Sharp edges
 
-- **Same-extent rule for binary ops.** `gt1 + gt2` raises if the transforms or shapes don't match (see `same_extent` and the `__add__` body at [geotensor.py:625](../../../../tmp/georeader_src/georeader/geotensor.py#L625)). Reproject first, don't try to "broadcast" across spatial extent.
+- **Same-extent rule for binary ops.** `gt1 + gt2` raises if the transforms or shapes don't match (see `same_extent` and the `__add__` body at [geotensor.py:625](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L625)). Reproject first, don't try to "broadcast" across spatial extent.
 - **`fill_value_default` is metadata, not a mask.** It's used by `read_from_window(boundless=True)`, `validmask()`, `invalidmask()`, and `pad`. It does *not* turn arithmetic into masked arithmetic — `gt + 1` still adds 1 to nodata pixels.
 - **Spatial slicing must use `slice`, not lists.** `gt.isel({"x": [0, 5, 10]})` is rejected; the resulting raster wouldn't be regularly sampled and the transform wouldn't be definable.
 - **`crs` is whatever rasterio accepts.** EPSG int, EPSG string, WKT, or `pyproj.CRS`. The class doesn't normalise — be consistent within a pipeline.

--- a/projects/geotoolz/georeader_tutorial/02_abstract_reader.md
+++ b/projects/geotoolz/georeader_tutorial/02_abstract_reader.md
@@ -1,0 +1,173 @@
+# Chapter 2 — `abstract_reader.py`: the type protocols
+
+> **Module:** `georeader/abstract_reader.py` (257 LOC)
+> **Role:** the duck-typing contract that lets `GeoTensor` (in-memory) and `RasterioReader` (lazy on-disk) be passed interchangeably to every function in the package.
+
+---
+
+## 1. The one-line idea
+
+Anything with `transform`, `crs`, `shape` is **`GeoDataBase`**. Anything that *additionally* knows how to materialise its data (`values`, `load()`, `read_from_window()`) is **`GeoData`** (alias `AbstractGeoData`). Most of `georeader.read`, `georeader.window_utils`, `georeader.mosaic` etc. type-annotate against these protocols, so the same function body works on either substrate.
+
+This is the seam that the [`georeader.md` plan](../plans/georeader.md) wants to widen — make `RasterioReader`, `LazyCOGReader`, and `AsyncGeoTIFFReader` all honour the same protocol, then user code does `reader_class=...` strategy injection.
+
+---
+
+## 2. The type hierarchy
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    GEOREADER TYPE HIERARCHY                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  GeoDataBase (Protocol)           Minimal interface for geospatial data │
+│  ├── transform: Affine            Pixel → coordinate mapping            │
+│  ├── crs: Any                     Coordinate reference system           │
+│  └── shape: Tuple                 (C, H, W) or (H, W) dimensions        │
+│       │                                                                  │
+│       ▼                                                                  │
+│  AbstractGeoData (Protocol)       Adds read capabilities                │
+│  ├── values: ndarray              Array data                            │
+│  ├── fill_value_default           Nodata value                          │
+│  └── load(): GeoTensor            Read all data                         │
+│       │                                                                  │
+│       ├──────────────────────┬──────────────────────┐                   │
+│       ▼                      ▼                      ▼                   │
+│  RasterioReader         GeoTensor              Custom Readers           │
+│  (Lazy file access)     (In-memory)           (User-defined)           │
+│                                                                          │
+│  GeoData = Union[AbstractGeoData, GeoTensor]  ← Common type alias       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Two splits to notice:
+
+- **Vertical:** `GeoDataBase` (just enough to *describe* a raster — useful for window math without ever loading bytes) vs `GeoData` (can materialise). The `FakeGeoData` dataclass below is the canonical `GeoDataBase`-only object.
+- **Horizontal:** `RasterioReader` (lazy, file-backed), `GeoTensor` (in-memory ndarray subclass), and any third-party reader that conforms.
+
+In the file, `AbstractGeoData = GeoData` is set as a back-compat alias — older code refers to `AbstractGeoData`; new code should prefer `GeoData`.
+
+---
+
+## 3. The protocol contract
+
+What you must supply to be a `GeoData`:
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    REQUIRED PROPERTIES                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Property              Type                  Description                 │
+│  ──────────           ──────                ───────────                 │
+│  transform            rasterio.Affine       6-element affine matrix     │
+│  crs                  Any (CRS-like)        EPSG code, WKT, or CRS obj  │
+│  shape                Tuple[int, ...]       (C, H, W) or (H, W)         │
+│  values               ndarray               Raster data array           │
+│  fill_value_default   number                Nodata/fill value           │
+│                                                                          │
+│  Required Methods:                                                       │
+│  ─────────────────                                                       │
+│  load() → GeoTensor   Read all data into memory                         │
+│                                                                          │
+│  Derived Properties (computed from above):                              │
+│  ──────────────────────────────────────────                             │
+│  width                shape[-1]             Number of columns           │
+│  height               shape[-2]             Number of rows              │
+│  bounds               From transform+shape  (minx, miny, maxx, maxy)    │
+│  res                  From transform        (xres, yres) pixel size     │
+│  footprint            Polygon               Bounding polygon in CRS     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`GeoData` provides default implementations for the **derived** properties on top of the required five — so a custom reader only has to wire up the required ones, and gets `bounds` / `res` / `footprint` for free.
+
+The base class deliberately raises `NotImplementedError` for `dtype`, `dims`, and `fill_value_default` rather than inventing a default — these are sensor-specific and any subclass that ignores them is going to bite users elsewhere.
+
+---
+
+## 4. Reading the source
+
+The whole file is short enough to read in one sitting. Key landmarks:
+
+- **`GeoDataBase`** — [abstract_reader.py:147](../../../../tmp/georeader_src/georeader/abstract_reader.py#L147). Pure `Protocol` with `transform`, `crs`, `shape` and computed `width`/`height`. No `load`. Any class that has these three attrs satisfies it without inheriting (structural typing via `typing.Protocol`).
+
+- **`FakeGeoData`** — [abstract_reader.py:169](../../../../tmp/georeader_src/georeader/abstract_reader.py#L169). A `@dataclass` placeholder used for window/bounds math when you don't want to allocate the array. Three fields: `crs`, `transform`, `shape` (optional). Used heavily inside `read.py` to do "what window would I read?" calculations before deciding whether to actually fetch bytes.
+
+- **`GeoData`** — [abstract_reader.py:188](../../../../tmp/georeader_src/georeader/abstract_reader.py#L188). The full reader interface. Defines `load(boundless=True)`, `read_from_window(window, boundless)`, plus the derived `bounds` / `res` / `footprint` / `values` (which delegates to `load`).
+
+- **`AbstractGeoData = GeoData`** — [abstract_reader.py:249](../../../../tmp/georeader_src/georeader/abstract_reader.py#L249). Back-compat alias.
+
+- **`same_extent(geo1, geo2, precision=1e-3)`** — [abstract_reader.py:252](../../../../tmp/georeader_src/georeader/abstract_reader.py#L252). The canonical "are these two rasters geographically interchangeable" check: transform-almost-equal, CRS-compare, last-two-dims-equal. Used by `GeoTensor`'s binary arithmetic and by `mosaic` / `read` before broadcasting operations.
+
+---
+
+## 5. `FakeGeoData` — describing a grid without owning one
+
+```python
+fake = FakeGeoData(
+    crs="EPSG:4326",
+    transform=Affine.translation(-122.5, 37.5) * Affine.scale(0.001, -0.001),
+    shape=(3, 1000, 1000),
+)
+```
+
+Why this exists:
+
+1. **Pre-flight calculations.** `window_from_bounds(fake, bounds, crs_bounds)` lets you ask "if I had a raster with this transform and shape, what window would my AOI be?" — before opening any file.
+2. **Designing output grids.** When mosaicking or reprojecting, you build a `FakeGeoData` describing the *target* grid, then pass it to `read.read_reproject_like(src, dst=fake)`.
+3. **Testing.** Cheap fixtures for window-math tests.
+
+`shape` is `Optional[Tuple[int, ...]]` — if you only need `transform` + `crs` for a coordinate calc, you can leave it as `None`. `width` and `height` then raise `ValueError("Shape is not defined")` if accessed, which is correct: you said you didn't have one.
+
+---
+
+## 6. `same_extent` — the equality predicate
+
+```python
+def same_extent(geo1: GeoData, geo2: GeoData, precision: float = 1e-3) -> bool:
+    return (
+        geo1.transform.almost_equals(geo2.transform, precision=precision)
+        and window_utils.compare_crs(geo1.crs, geo2.crs)
+        and (geo1.shape[-2:] == geo2.shape[-2:])
+    )
+```
+
+Three observations on the design:
+
+- **`transform.almost_equals(precision=1e-3)`** — not exact. Floating-point transforms drift through reprojection round-trips; an exact comparison would be too strict.
+- **`compare_crs`** is in `window_utils` — it normalises across "EPSG:4326" / `4326` / `pyproj.CRS.from_epsg(4326)` so the user doesn't have to.
+- **Only the last two dims** are checked. A 3-band stack and a 5-band stack at the same footprint are "same-extent" — what matters is the spatial grid.
+
+Used by `GeoTensor.__add__` etc. to refuse `gt1 + gt2` when extents disagree (see [Chapter 1 §12](01_geotensor.md)).
+
+---
+
+## 7. How this protocol shows up downstream
+
+Almost every public function in `georeader.read` and `georeader.window_utils` is annotated `data: GeoData` or `data: GeoDataBase`. Concretely:
+
+| Caller-side type | What you typically pass |
+|---|---|
+| `GeoDataBase` | `FakeGeoData`, `GeoTensor`, `RasterioReader` — anything with the three structural attrs |
+| `GeoData` / `AbstractGeoData` | `GeoTensor`, `RasterioReader`, custom readers — anything that can materialise |
+| `GeoTensor` (concrete) | only when an in-memory ndarray is genuinely required |
+
+This means most of your geotoolz operators should be typed `data: GeoData` (not `GeoTensor`) so they accept lazy readers transparently — the `load()` happens once, inside the operator, and is cheap when the operator is the leaf.
+
+---
+
+## 8. Sharp edges
+
+- **`Protocol` doesn't enforce at runtime.** `isinstance(obj, GeoDataBase)` works only if you've decorated `GeoDataBase` with `@runtime_checkable` (this module does *not*). So duck-typing is by static checker (mypy/ty) or by `try/except AttributeError`. In practice: be liberal in what you accept, raise loud errors in `__init__`/factory functions if a required attribute is missing.
+- **`load(boundless=True)` is the universal handshake.** Every reader must implement it. The default contract: return a `GeoTensor` of the same shape, padding with `fill_value_default` for any out-of-bounds region.
+- **Subclasses, not Protocol implementations.** Despite the docstring talking about "Protocol", `GeoData` is a regular base class with `NotImplementedError` stubs — `RasterioReader` and the hyperspectral readers actually subclass it. The `Protocol` form is only `GeoDataBase`. That asymmetry is historical; treat both as duck-typed contracts in your own code.
+- **Last two dims are spatial.** This is enforced nowhere in the protocol — it's a convention, and the rest of the package relies on it. A reader returning `(H, W, C)` ("channels-last") would silently break things.
+
+---
+
+## 9. The shape of a custom reader (what's in the next chapter)
+
+The next chapter unpacks `RasterioReader` — the canonical `GeoData` subclass. Reading it is the fastest way to understand what a real implementation of this protocol looks like and what conveniences (`.isel`, `.read_from_window`, multi-file stacks, overviews, VSI cloud paths) sit on top of the bare contract above.
+
+Next chapter: [03_rasterio_reader.md](03_rasterio_reader.md).

--- a/projects/geotoolz/georeader_tutorial/02_abstract_reader.md
+++ b/projects/geotoolz/georeader_tutorial/02_abstract_reader.md
@@ -1,4 +1,4 @@
-# Chapter 2 — `abstract_reader.py`: the type protocols
+# Ch. 2 — `abstract_reader`
 
 > **Module:** `georeader/abstract_reader.py` (257 LOC)
 > **Role:** the duck-typing contract that lets `GeoTensor` (in-memory) and `RasterioReader` (lazy on-disk) be passed interchangeably to every function in the package.
@@ -90,15 +90,15 @@ The base class deliberately raises `NotImplementedError` for `dtype`, `dims`, an
 
 The whole file is short enough to read in one sitting. Key landmarks:
 
-- **`GeoDataBase`** — [abstract_reader.py:147](../../../../tmp/georeader_src/georeader/abstract_reader.py#L147). Pure `Protocol` with `transform`, `crs`, `shape` and computed `width`/`height`. No `load`. Any class that has these three attrs satisfies it without inheriting (structural typing via `typing.Protocol`).
+- **`GeoDataBase`** — [abstract_reader.py:147](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L147). Pure `Protocol` with `transform`, `crs`, `shape` and computed `width`/`height`. No `load`. Any class that has these three attrs satisfies it without inheriting (structural typing via `typing.Protocol`).
 
-- **`FakeGeoData`** — [abstract_reader.py:169](../../../../tmp/georeader_src/georeader/abstract_reader.py#L169). A `@dataclass` placeholder used for window/bounds math when you don't want to allocate the array. Three fields: `crs`, `transform`, `shape` (optional). Used heavily inside `read.py` to do "what window would I read?" calculations before deciding whether to actually fetch bytes.
+- **`FakeGeoData`** — [abstract_reader.py:169](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L169). A `@dataclass` placeholder used for window/bounds math when you don't want to allocate the array. Three fields: `crs`, `transform`, `shape` (optional). Used heavily inside `read.py` to do "what window would I read?" calculations before deciding whether to actually fetch bytes.
 
-- **`GeoData`** — [abstract_reader.py:188](../../../../tmp/georeader_src/georeader/abstract_reader.py#L188). The full reader interface. Defines `load(boundless=True)`, `read_from_window(window, boundless)`, plus the derived `bounds` / `res` / `footprint` / `values` (which delegates to `load`).
+- **`GeoData`** — [abstract_reader.py:188](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L188). The full reader interface. Defines `load(boundless=True)`, `read_from_window(window, boundless)`, plus the derived `bounds` / `res` / `footprint` / `values` (which delegates to `load`).
 
-- **`AbstractGeoData = GeoData`** — [abstract_reader.py:249](../../../../tmp/georeader_src/georeader/abstract_reader.py#L249). Back-compat alias.
+- **`AbstractGeoData = GeoData`** — [abstract_reader.py:249](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L249). Back-compat alias.
 
-- **`same_extent(geo1, geo2, precision=1e-3)`** — [abstract_reader.py:252](../../../../tmp/georeader_src/georeader/abstract_reader.py#L252). The canonical "are these two rasters geographically interchangeable" check: transform-almost-equal, CRS-compare, last-two-dims-equal. Used by `GeoTensor`'s binary arithmetic and by `mosaic` / `read` before broadcasting operations.
+- **`same_extent(geo1, geo2, precision=1e-3)`** — [abstract_reader.py:252](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L252). The canonical "are these two rasters geographically interchangeable" check: transform-almost-equal, CRS-compare, last-two-dims-equal. Used by `GeoTensor`'s binary arithmetic and by `mosaic` / `read` before broadcasting operations.
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/03_rasterio_reader.md
+++ b/projects/geotoolz/georeader_tutorial/03_rasterio_reader.md
@@ -1,0 +1,268 @@
+# Chapter 3 — `rasterio_reader.py`: the lazy file-backed reader
+
+> **Module:** `georeader/rasterio_reader.py` (1630 LOC)
+> **Role:** the canonical `GeoData` implementation. Wraps `rasterio` to give you a `GeoTensor`-shaped interface over a file (local, S3, GCS, Azure, HTTP) **without** reading the bytes until you ask.
+
+---
+
+## 1. Why a lazy reader exists
+
+Three concrete reasons rasterio alone isn't enough:
+
+1. **Process-safety.** `RasterioReader` opens the file *fresh on every `read()` call*. That's the unlock for `multiprocessing` / `joblib` / Dask workers — you can pickle the reader, send it to workers, and each worker opens its own dataset handle. A cached `rasterio.DatasetReader` cannot be pickled safely.
+2. **A `GeoTensor`-shaped surface without the bytes.** `reader.shape`, `reader.transform`, `reader.bounds`, `reader.dtype`, `reader.isel(...)` all work without reading data. Only `read()` / `load()` / `read_from_window().load()` materialise.
+3. **Multi-file stacks as one object.** Pass a list of paths, get a `(T, C, H, W)` reader. `isel({"time": 0})` returns a single-time-step reader. The time dimension is a structural feature, not a wrapper.
+
+This is the class your operators should accept whenever they don't strictly need the data in memory.
+
+---
+
+## 2. RasterioReader vs GeoTensor
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                 RASTERIOREADER vs GEOTENSOR                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  RasterioReader (Lazy)              GeoTensor (In-Memory)               │
+│  ─────────────────────              ────────────────────                │
+│                                                                         │
+│  • Data on disk/cloud               • Data in RAM                       │
+│  • Read on demand                   • Instant access                    │
+│  • Memory efficient                 • Full numpy API                    │
+│  • Parallel-safe                    • Arithmetic operations             │
+│  • Overview/pyramid support         • Broadcasting                      │
+│                                                                         │
+│  Use for:                           Use for:                            │
+│  • Large files                      • Processing pipelines              │
+│  • Cloud data                       • CNN inference                     │
+│  • Tiled processing                 • Index calculations                │
+│  • Quick previews                   • Visualizations                    │
+│                                                                         │
+│  Convert: reader.load() ────────────────────────────────► GeoTensor     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The mental model: `RasterioReader` is the **address book**, `GeoTensor` is the **delivered package**. `reader.load()` is the postman.
+
+The arithmetic ops (`+`, `*`, etc.) only exist on `GeoTensor`. If you write `reader * 2` you get an error — and that's deliberate. Arithmetic on a lazy reader implies you've decided to materialise; the explicit `.load()` makes that decision visible at the call site.
+
+---
+
+## 3. Multi-file reading: time series as structure
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    MULTI-FILE READING                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Input: List of paths                Output array shape                 │
+│  ────────────────────                ──────────────────                 │
+│                                                                         │
+│  paths = [                                                              │
+│    "2023-01.tif",   ─────┐                                              │
+│    "2023-02.tif",   ─────┼──────► stack=True:  (T, C, H, W)             │
+│    "2023-03.tif"    ─────┘                      (3, 4, 1000, 1000)      │
+│  ]                                                                      │
+│                                                                         │
+│  Each file: (4, 1000, 1000)        stack=False: (T×C, H, W)             │
+│  4 bands, 1000×1000 pixels                       (12, 1000, 1000)       │
+│                                                                         │
+│  Requirements for multi-file:                                           │
+│  • Same CRS                                                             │
+│  • Same transform (resolution, origin)                                  │
+│  • Same shape (unless allow_different_shape=True)                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Two modes worth distinguishing:
+
+- **`stack=True` (default, time-as-axis).** Result `dims = ("time", "band", "y", "x")`. This is what you almost always want for time-series analysis. `isel({"time": 0})` returns a (C, H, W) reader pointing at one file.
+- **`stack=False` (concat along bands).** Result `(T*C, H, W)`. Useful when files are *band groups* of a single observation rather than time steps — e.g., S2 SAFE where each band is its own JP2 and there's no time meaning to the file list.
+
+Validation is strict: `__init__` checks CRS / transform / shape match across files unless you opt out via `allow_different_shape=True`. The check only relaxes shape — CRS and transform mismatches always raise. (See [rasterio_reader.py:301](../../../../tmp/georeader_src/georeader/rasterio_reader.py#L301).)
+
+---
+
+## 4. Window focus — "view" semantics
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    WINDOW FOCUS CONCEPT                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Full raster (10000 × 10000)                                            │
+│  ┌────────────────────────────────────────────────────────────────┐     │
+│  │                                                                │     │
+│  │                                                                │     │
+│  │        ┌─────────────────────┐                                 │     │
+│  │        │    window_focus     │  ← reader.set_window(...)       │     │
+│  │        │    (2000 × 2000)    │                                 │     │
+│  │        │                     │  After set_window:              │     │
+│  │        │  ┌───────────┐      │  • reader.shape → (C, 2000, 2000)│    │
+│  │        │  │ read()    │      │  • reader.bounds → window bounds│     │
+│  │        │  │ window    │      │  • read(window=...) is relative │     │
+│  │        │  └───────────┘      │    to window_focus              │     │
+│  │        └─────────────────────┘                                 │     │
+│  │                                                                │     │
+│  └────────────────────────────────────────────────────────────────┘     │
+│                                                                         │
+│  Benefits: • Work with large files efficiently                          │
+│            • Coordinates/bounds reflect the focused region              │
+│            • Tiled processing with consistent interface                 │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`set_window(window_focus)` is the single most useful trick in this class for tiled processing:
+
+- After it's set, **the reader pretends the focused region is the whole raster.** `reader.shape` shrinks; `reader.bounds` reflects the window; `reader.transform` is rewritten with the new origin.
+- All subsequent `read()` / `read_from_window()` / `isel()` calls are **relative to the focused window** — you can hand a focused reader to a function that doesn't know about windowing and it will Just Work on the sub-region.
+- Overlapping window scans become a loop of `set_window` + `load()` without ever computing nested coordinate offsets in user code.
+
+The non-mutating sister is `read_from_window(window, boundless=True)` ([rasterio_reader.py:654](../../../../tmp/georeader_src/georeader/rasterio_reader.py#L654)) which returns a *new reader* with the focus applied — preferred for parallel pipelines where mutating shared state is awkward.
+
+---
+
+## 5. Constructor parameters
+
+```python
+RasterioReader(
+    paths,                          # str | list[str]
+    allow_different_shape=False,
+    window_focus=None,              # rasterio.windows.Window
+    fill_value_default=None,        # falls back to file's nodata, then 0
+    stack=True,                     # only matters for list paths
+    indexes=None,                   # 1-based band indices (rasterio convention)
+    overview_level=None,            # 0 = first overview, None = full res
+    check=True,                     # validate CRS/transform/shape across paths
+    rio_env_options=None,           # GDAL options dict (vsi creds etc.)
+)
+```
+
+A few non-obvious ones:
+
+- **`indexes`** is **1-based** because rasterio is. `indexes=[1, 2, 3]` on a 4-band S2 image gives you BGR (the first three bands). The reader stores the requested indices and lazily honours them on every read.
+- **`overview_level=2`** lets you skip the full-res file entirely for previews. COGs ship overviews at 2×, 4×, 8× downsampled levels; reading from `overview_level=2` is roughly 64× cheaper than full-res reads.
+- **`rio_env_options`** is the escape hatch for GDAL config — proxy creds, custom timeout, AWS_REGION, etc. Defaults to a sensible `RIO_ENV_OPTIONS_DEFAULT` defined near the top of the file.
+- **`fill_value_default=None`** means "use the file's nodata value if it has one, else 0." Set it explicitly if you have a reason — the default is rarely wrong but rarely what you'd choose if asked.
+
+---
+
+## 6. The four read paths
+
+Each method emphasises a different ergonomic. They all ultimately call into `rasterio.DatasetReader.read`.
+
+| Method | Returns | Use for |
+|---|---|---|
+| `load(boundless=True)` | `GeoTensor` of full focus | "give me everything in memory now" |
+| `read(**kwargs)` | `np.ndarray` (no metadata) | rasterio-compatible; passes kwargs through |
+| `read_from_window(window, boundless=True)` | `RasterioReader` (focused) | tiled inference; chain with `.load()` to materialise |
+| `read_from_tile(x, y, z, ...)` | `np.ndarray` | XYZ web-tile schema (used by `tileserver` reader) |
+
+The `boundless=True` default on `read_from_window`/`load` matches `GeoTensor.read_from_window` — you get the requested shape no matter where the window lands, padded with `fill_value_default`. This is critical for batched CNN inference: every chip has the same shape, batches stack cleanly.
+
+---
+
+## 7. xarray-style `isel` over time + band
+
+```python
+reader.isel({"time": [0, 2], "band": [1, 2, 3]})
+```
+
+Same dim-name vocabulary as `GeoTensor.isel` (Chapter 1 §6) but with `"time"` admitted for stacked multi-file readers. Returns a *new reader* — still lazy. Spatial dims (`"x"`, `"y"`) accept slices and rewrite the focus window.
+
+The internal mechanism: `isel` returns a copied reader with `indexes` adjusted (band selection), `paths` filtered (time selection), and `window_focus` updated (spatial slice). Nothing reads. Source: [rasterio_reader.py:739](../../../../tmp/georeader_src/georeader/rasterio_reader.py#L739).
+
+---
+
+## 8. Overviews — the "free preview" path
+
+```python
+reader = RasterioReader("s3://bucket/big.tif", overview_level=2)
+preview = reader.load()  # ~64× cheaper than full res
+```
+
+Two methods to know:
+
+- **`reader.overviews(index=1, time_index=0)`** — list available decimation factors for a band. Empty list means no overviews in the file (it's not a COG, or it's a single-resolution GeoTIFF).
+- **`reader.reader_overview(overview_level)`** — return a *new reader* configured to read from that level. Useful when you've already opened a full-res reader and decide you want a thumbnail without re-instantiating from the path.
+
+This is also the right tool for "should I load this whole scene to decide if it's cloudy?" — read overview level 3, run your cloud check on the small image, then go full-res only if it's worth it.
+
+---
+
+## 9. The cloud story — VSI paths and credentials
+
+`rasterio` (via GDAL) handles cloud paths transparently if you pass them in the right form:
+
+| URI form | Backend |
+|---|---|
+| `s3://bucket/key.tif` | GDAL VSI `/vsis3/` |
+| `gs://bucket/key.tif` | `/vsigs/` |
+| `https://...cog.tif` | `/vsicurl/` (range requests) |
+| `az://account/key.tif` | `/vsiaz/` |
+
+Internal helper `_get_rio_options_path(path)` (and the module-level `_vsi_path` in `geotensor.py`) translate user-friendly URIs to VSI form. Credentials come from `rio_env_options` or from environment (`AWS_*`, `GOOGLE_APPLICATION_CREDENTIALS`, etc.) — same as plain rasterio.
+
+The [`georeader.md` plan](../plans/georeader.md) is about widening this seam: `LazyCOGReader` and the async-obstore reader plug in here as alternative implementations of the same interface, swapping GDAL VSI for direct HTTP-range / obstore reads. That's the unification work.
+
+---
+
+## 10. Method reference (the public surface)
+
+**Lifecycle**
+- `__init__(paths, ...)` — opens *no* file yet; reads metadata once if `check=True`
+- `__copy__()`, `copy()` — shallow copy with the same path, fresh state
+- `__repr__()` — multi-line human-readable summary
+
+**Inspection (no I/O after `__init__`)**
+- `shape`, `crs`, `transform`, `dtype`, `count`, `width`, `height`, `bounds`, `res`, `nodata`, `fill_value_default`, `dims`, `attrs`
+- `tags()` — file/band-level GDAL tags
+- `descriptions()` — band names
+- `same_extent(other, precision=1e-3)` — extent equality (Chapter 2 §6)
+- `footprint(crs=None)` — outer polygon
+- `meshgrid(dst_crs=None)` — pixel-centre coordinates
+
+**Configuration (mutating)**
+- `set_indexes(indexes, relative=True)` — change which bands to read
+- `set_indexes_by_name(names)` — same, but by description
+- `set_window(window_focus, ...)` — restrict to a sub-region
+
+**Read**
+- `load(boundless=True)` → `GeoTensor`
+- `read(**kwargs)` → `np.ndarray`
+- `read_from_window(window, boundless=True)` → `RasterioReader`
+- `read_from_tile(x, y, z, ...)` → `np.ndarray` (XYZ tiles)
+- `isel(sel, boundless=True)` → `RasterioReader`
+- `values` (property) → eager array
+
+**Overviews**
+- `overviews(index=1, time_index=0)` → list of decimation factors
+- `reader_overview(overview_level)` → `RasterioReader` at that level
+- `block_windows(bidx=1, time_idx=0)` → list of `(block_id, Window)` for native tiling
+
+---
+
+## 11. Sharp edges
+
+- **`indexes` is 1-based** (rasterio convention), but `block_windows` and overview-level integers are 0-based. Easy to flip without realising.
+- **`set_window` mutates state.** If you're sharing a reader across functions or threads, prefer `read_from_window` / `isel` which return new readers. The mutating form exists because some legacy call sites needed it.
+- **`stack=True` requires identical metadata across files.** When that's not true (e.g., bands at different resolutions), `mosaic` or `griddata` is the right tool, not `RasterioReader`.
+- **Cloud reads are *not* free.** Each `read_from_window().load()` issues HTTP range requests. For tile-loops over the same scene, a `set_window` + `load()` of a coarse window into memory followed by `GeoTensor` slicing is often dramatically faster than N small cloud reads.
+- **Files are opened on every read.** This is a feature (process-safety) but it costs ~ms per call. For tight inner loops over the same file in one process, batching reads matters.
+- **Overviews don't always exist.** Plain GeoTIFFs without pyramids have empty `reader.overviews()`. The reader doesn't *create* overviews on the fly; that's `gdaladdo` territory.
+
+---
+
+## 12. Connection to the rest of the package
+
+Where `RasterioReader` shows up downstream:
+
+- **`georeader.read`** — every `read_from_*` function takes a `GeoData`, and a `RasterioReader` is the typical input. Reprojection ([Chapter 5](05_read.md)) is where lazy reading really pays off: you compute the source window from the destination grid first, then read only that window.
+- **`georeader.mosaic`** — combine multiple `RasterioReader`s into one composite, reading only the windows that cover the target.
+- **`georeader.save`** — `save_cog(reader, path)` streams a reader to disk without ever having the full array in memory.
+- **`georeader.readers.S2_SAFE_reader`** — the Sentinel-2 reader is a `RasterioReader` underneath, with band-group logic on top.
+
+For curvilinear sensors (PRISMA, EnMAP, MODIS) `RasterioReader` is the wrong tool — those use a custom reader pattern routed through `griddata` ([Chapter 7](07_griddata.md)).
+
+Next chapter: [04_window_utils.md](04_window_utils.md) — the window/coordinate-system math that all of the above relies on.

--- a/projects/geotoolz/georeader_tutorial/03_rasterio_reader.md
+++ b/projects/geotoolz/georeader_tutorial/03_rasterio_reader.md
@@ -1,4 +1,4 @@
-# Chapter 3 — `rasterio_reader.py`: the lazy file-backed reader
+# Ch. 3 — `rasterio_reader`
 
 > **Module:** `georeader/rasterio_reader.py` (1630 LOC)
 > **Role:** the canonical `GeoData` implementation. Wraps `rasterio` to give you a `GeoTensor`-shaped interface over a file (local, S3, GCS, Azure, HTTP) **without** reading the bytes until you ask.
@@ -80,7 +80,7 @@ Two modes worth distinguishing:
 - **`stack=True` (default, time-as-axis).** Result `dims = ("time", "band", "y", "x")`. This is what you almost always want for time-series analysis. `isel({"time": 0})` returns a (C, H, W) reader pointing at one file.
 - **`stack=False` (concat along bands).** Result `(T*C, H, W)`. Useful when files are *band groups* of a single observation rather than time steps — e.g., S2 SAFE where each band is its own JP2 and there's no time meaning to the file list.
 
-Validation is strict: `__init__` checks CRS / transform / shape match across files unless you opt out via `allow_different_shape=True`. The check only relaxes shape — CRS and transform mismatches always raise. (See [rasterio_reader.py:301](../../../../tmp/georeader_src/georeader/rasterio_reader.py#L301).)
+Validation is strict: `__init__` checks CRS / transform / shape match across files unless you opt out via `allow_different_shape=True`. The check only relaxes shape — CRS and transform mismatches always raise. (See [rasterio_reader.py:301](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/rasterio_reader.py#L301).)
 
 ---
 
@@ -119,7 +119,7 @@ Validation is strict: `__init__` checks CRS / transform / shape match across fil
 - All subsequent `read()` / `read_from_window()` / `isel()` calls are **relative to the focused window** — you can hand a focused reader to a function that doesn't know about windowing and it will Just Work on the sub-region.
 - Overlapping window scans become a loop of `set_window` + `load()` without ever computing nested coordinate offsets in user code.
 
-The non-mutating sister is `read_from_window(window, boundless=True)` ([rasterio_reader.py:654](../../../../tmp/georeader_src/georeader/rasterio_reader.py#L654)) which returns a *new reader* with the focus applied — preferred for parallel pipelines where mutating shared state is awkward.
+The non-mutating sister is `read_from_window(window, boundless=True)` ([rasterio_reader.py:654](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/rasterio_reader.py#L654)) which returns a *new reader* with the focus applied — preferred for parallel pipelines where mutating shared state is awkward.
 
 ---
 
@@ -171,7 +171,7 @@ reader.isel({"time": [0, 2], "band": [1, 2, 3]})
 
 Same dim-name vocabulary as `GeoTensor.isel` (Chapter 1 §6) but with `"time"` admitted for stacked multi-file readers. Returns a *new reader* — still lazy. Spatial dims (`"x"`, `"y"`) accept slices and rewrite the focus window.
 
-The internal mechanism: `isel` returns a copied reader with `indexes` adjusted (band selection), `paths` filtered (time selection), and `window_focus` updated (spatial slice). Nothing reads. Source: [rasterio_reader.py:739](../../../../tmp/georeader_src/georeader/rasterio_reader.py#L739).
+The internal mechanism: `isel` returns a copied reader with `indexes` adjusted (band selection), `paths` filtered (time selection), and `window_focus` updated (spatial slice). Nothing reads. Source: [rasterio_reader.py:739](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/rasterio_reader.py#L739).
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/04_window_utils.md
+++ b/projects/geotoolz/georeader_tutorial/04_window_utils.md
@@ -1,4 +1,4 @@
-# Chapter 4 — `window_utils.py`: pixel ↔ geographic coordinate math
+# Ch. 4 — `window_utils`
 
 > **Module:** `georeader/window_utils.py` (1471 LOC, the second-densest in diagrams)
 > **Role:** the math underneath everything else in the package. Windows, bounds, transforms, rounding, padding, polygon reprojection. Reading these utilities once is the cheapest way to understand why the higher-level `read.py` API is shaped the way it is.
@@ -264,7 +264,7 @@ Given two windows:
 
 The reader then reads the slice from disk and applies `np.pad` (or its own `fill_value_default`-aware equivalent) to produce a full-size array. CNN inference at scene edges relies entirely on this — every chip comes back the requested shape, with off-edge regions filled with nodata.
 
-Source: [window_utils.py:599](../../../../tmp/georeader_src/georeader/window_utils.py#L599).
+Source: [window_utils.py:599](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/window_utils.py#L599).
 
 ---
 
@@ -281,7 +281,7 @@ The companion to `pad_window` for inference pipelines: when you've read a tile *
 
 The reference is Huang et al. (2018) — the standard tile-and-stitch recipe. Used by ml4floods and similar segmentation pipelines built on georeader.
 
-Source: [window_utils.py:1256](../../../../tmp/georeader_src/georeader/window_utils.py#L1256).
+Source: [window_utils.py:1256](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/window_utils.py#L1256).
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/04_window_utils.md
+++ b/projects/geotoolz/georeader_tutorial/04_window_utils.md
@@ -1,0 +1,348 @@
+# Chapter 4 — `window_utils.py`: pixel ↔ geographic coordinate math
+
+> **Module:** `georeader/window_utils.py` (1471 LOC, the second-densest in diagrams)
+> **Role:** the math underneath everything else in the package. Windows, bounds, transforms, rounding, padding, polygon reprojection. Reading these utilities once is the cheapest way to understand why the higher-level `read.py` API is shaped the way it is.
+
+---
+
+## 1. What this module owns
+
+Three responsibilities in one file:
+
+1. **Windows ↔ bounds.** Convert between pixel-space rectangles (`rasterio.windows.Window`) and geographic rectangles `(minx, miny, maxx, maxy)` — both directions, both signs of CRS mismatch.
+2. **Padding & rounding.** Grow / shrink / round windows so they align with pixel boundaries, fit a fixed CNN input size, or include all partial pixels intersected by a query.
+3. **Polygon ↔ pixel.** Reproject Shapely geometries between CRSs and convert their vertices to pixel-coordinate paths (used by `rasterize` and `vectorize` downstream).
+
+A single design decision sits underneath all of it: `PIXEL_PRECISION = 3` decimal places. Coordinate transforms drift through reprojection round-trips, so the module deliberately tolerates ≤ 0.001-pixel error before deciding "this is or isn't an integer offset."
+
+---
+
+## 2. Window anatomy
+
+A `rasterio.windows.Window` is a rectangle in *pixel* space — not geographic space. The constructor argument order is the source of most bugs that touch this module.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    RASTERIO WINDOW ANATOMY                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│    Full Raster (0,0 at top-left)                                        │
+│    ↓                                                                     │
+│    ┌────────────────────────────────────────────────────────┐           │
+│    │ (0,0)                                        cols →    │           │
+│    │     ┌────────────────────┐                             │           │
+│    │     │← col_off →│        │                             │           │
+│    │     │    (row_off, col_off) ← Window origin            │           │
+│    │     │           ·─────────────────┐                    │           │
+│  r │     │           │    WINDOW       │                    │           │
+│  o │     │           │                 │ height             │           │
+│  w │     │           │    width        │                    │           │
+│  s │     │           └─────────────────┘                    │           │
+│    │     │                                                  │           │
+│  ↓ │     │                                                  │           │
+│    └────────────────────────────────────────────────────────┘           │
+│                                                                          │
+│    Window = rasterio.windows.Window(col_off, row_off, width, height)    │
+│                                     ───────  ───────  ─────  ──────     │
+│                                     column   row      cols   rows       │
+│                                     offset   offset                     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+> **NOTE:** Window constructor order is `(col_off, row_off)` but most geospatial
+> operations use `(row, col)` or `(y, x)` order. **Be careful!**
+
+That note is in the source verbatim and it earns its caps. Three places this trips people up:
+
+- `np.zeros(shape)` is `(rows, cols)` = `(height, width)`. A `Window` is `(col_off, row_off, width, height)`. Mismatched axis order between the two has cost more than one afternoon.
+- `pad_window(window, pad_size)` takes `(pad_rows, pad_cols)` — numpy order, **not** Window order. The docstring warns about this.
+- `pad_window_to_size(window, size)` takes `(height, width)` — numpy order, **not** `(width, height)`.
+
+The module commits to numpy order for axis-tuple arguments because that's what users coming from `np.pad` expect. The Window constructor order is fixed by rasterio.
+
+---
+
+## 3. Window ↔ bounds — the core conversion
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              WINDOW ↔ BOUNDS TRANSFORMATION                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│    WINDOW (pixels)              AFFINE TRANSFORM           BOUNDS       │
+│    ┌─────────────┐                    ║                ┌─────────────┐  │
+│    │ col_off=100 │                    ║                │ minx=-122.5 │  │
+│    │ row_off=200 │   ──────────────►  ║  ──────────►   │ miny=37.0   │  │
+│    │ width=256   │   window_bounds()  ║                │ maxx=-122.0 │  │
+│    │ height=256  │                    ║                │ maxy=37.5   │  │
+│    └─────────────┘                    ║                └─────────────┘  │
+│                                       ║                                  │
+│                                       ║   Affine(a, b, c,               │
+│                      ◄────────────────║          d, e, f)               │
+│                      bounds_to_windows()                                │
+│                                       ║                                  │
+│    Affine Transform encodes:          ║                                  │
+│    • Pixel resolution (a, e)          ║                                  │
+│    • Origin coordinates (c, f)        ║                                  │
+│    • Rotation/shear (b, d)            ║                                  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Two named functions handle the round-trip:
+
+- **`window_bounds(window, transform) → (minx, miny, maxx, maxy)`** — apply `transform` to the four window corners, return their axis-aligned bounding box. Fast, deterministic, no CRS involved.
+- **`bounds_to_windows(data, bounds_dst, crs_dst) → list[Window]`** — the more interesting one. Reprojects `bounds_dst` from `crs_dst` into `data.crs`, then inverts the transform. Returns a **list** because a query that crosses the antimeridian splits into two windows in the source CRS. Most calls return a length-1 list; AOI bboxes that wrap longitude need length-2 handling.
+
+The asymmetry — one direction is geometry math, the other is CRS-aware — is why this module is bigger than it might first seem.
+
+---
+
+## 4. Rounding: outer vs inner
+
+Bounds rarely land on integer pixel boundaries. You have to choose which way to round.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    WINDOW ROUNDING STRATEGIES                            │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   Exact bounds (before rounding):                                       │
+│   ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐                                │
+│   │           Desired area             │                                │
+│   └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘                                │
+│                                                                          │
+│   round_outer_window():                 round_inner_window():           │
+│   ┌─────────────────────────────┐      ┌─────────────────────┐         │
+│   │ ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐  │      │  ┌ ─ ─ ─ ─ ─ ─ ─ ┐ │         │
+│   │ │                       │  │      │  │               │  │         │
+│   │ │   Expands outward     │  │      │  │ Shrinks inward │  │         │
+│   │ │   to include all      │  │      │  │ to only fully  │  │         │
+│   │ │   partial pixels      │  │      │  │ covered pixels │  │         │
+│   │ └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘  │      │  └ ─ ─ ─ ─ ─ ─ ─ ┘ │         │
+│   └─────────────────────────────┘      └─────────────────────┘         │
+│                                                                          │
+│   Use outer when: You need all data that intersects the bounds          │
+│   Use inner when: You need only data fully within the bounds            │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Default in georeader: **outer**. Reasons:
+
+- For a read query, "give me everything that intersects this AOI" is what users mean 99% of the time.
+- Combined with `boundless=True` reads, outer rounding plus padding gives you a guaranteed-shape result with no missing data inside the AOI.
+
+`round_inner_window` shows up in two niche cases: when you're cropping to a strict mask (no partial-pixel contamination), and when you're computing the largest *fully covered* sub-window for tile-aligned reads.
+
+Both functions tolerate `PIXEL_PRECISION = 3` slop before rounding — the example in the docstring: `99.9997 → 100`, `100.5 → unchanged`. That tolerance is what lets reprojection round-trips not slowly drift the window by sub-pixel amounts each pass.
+
+---
+
+## 5. Padding for CNN tiles
+
+Two related functions, both in the "make my tile a fixed size" job.
+
+### `pad_window(window, pad_size=(pad_rows, pad_cols))`
+
+Symmetric expansion on all four sides. Used to add **context** around an inference tile.
+
+```text
+Original window:              Padded window (pad_size=(2, 3)):
+┌─────────────┐               ┌─────────────────────┐
+│             │               │← 3 cols → ← 3 cols →│
+│   100×50    │     ───►      │↑         ↑          │
+│   window    │               │2   106×54 window    │
+│             │               │↓         ↓          │
+└─────────────┘               │← 3 cols → ← 3 cols →│
+                              └─────────────────────┘
+
+Output: width = 100 + 2×3 = 106
+        height = 50 + 2×2 = 54
+        col_off = original - 3
+        row_off = original - 2
+```
+
+The output window may have **negative offsets** — that's intentional, and you read it via `read_from_window(..., boundless=True)` to pad the off-edge region with `fill_value_default`. (Chapter 3 §6.)
+
+### `pad_window_to_size(window, size=(height, width))`
+
+Re-centre to a target size. Both expansion *and* contraction work — passing a size smaller than the window gives you a centre crop.
+
+```text
+Expansion (size > window):          Contraction (size < window):
+
+┌───────────────────────┐          ┌───────────────────────┐
+│     padded area       │          │                       │
+│   ┌─────────────┐     │          │   ┌─────────────┐     │
+│   │             │     │          │   │┌───────────┐│     │
+│   │   original  │     │    ◄──   │   ││  center   ││     │
+│   │    window   │     │          │   ││   crop    ││     │
+│   └─────────────┘     │          │   │└───────────┘│     │
+│     padded area       │          │   └─────────────┘     │
+└───────────────────────┘          └───────────────────────┘
+
+Symmetric expansion             Symmetric contraction
+```
+
+Odd differences favour the bottom/right edge (integer division). When you need exact symmetry, use `pad_window` with explicit `pad_size`.
+
+---
+
+## 6. `figure_out_transform` — building output grids
+
+When mosaicking, reprojecting, or designing an output grid, you usually have *some* of `{transform, bounds, resolution_dst}` and want georeader to derive the rest.
+
+```text
+┌────────────┬────────┬──────────────┬─────────────────────────────┐
+│ transform  │ bounds │ resolution   │ Result                      │
+├────────────┼────────┼──────────────┼─────────────────────────────┤
+│ ✓          │ ✗      │ ✗            │ Return unchanged            │
+│ ✓          │ ✗      │ ✓            │ Rescale resolution          │
+│ ✓          │ ✓      │ ✗            │ Shift origin to bounds      │
+│ ✓          │ ✓      │ ✓            │ Rescale + shift             │
+│ ✗          │ ✓      │ ✓            │ Create new rectilinear      │
+│ ✗          │ ✗      │ any          │ ERROR (need bounds)         │
+│ ✗          │ ✓      │ ✗            │ ERROR (need resolution)     │
+└────────────┴────────┴──────────────┴─────────────────────────────┘
+```
+
+Useful idioms:
+
+- **"Same grid, coarser resolution":** `figure_out_transform(transform=src.transform, resolution_dst=20.0)` — keeps origin and orientation; rescales `a` and `e`.
+- **"New AOI, same resolution as source":** `figure_out_transform(transform=src.transform, bounds=aoi)` — keeps `a, b, d, e`; shifts `c, f` to the AOI's upper-left.
+- **"Fresh rectilinear from scratch":** `figure_out_transform(bounds=aoi, resolution_dst=10.0)` — north-up, square pixels, `b = d = 0`.
+
+The "ERROR" rows are validation: you can't conjure an origin without bounds, and you can't size a grid without resolution.
+
+This function is the seam between `read.read_from_bounds` (which calls it) and the higher-level mosaic / reprojection workflows in `read.py` ([Chapter 5](05_read.md)).
+
+---
+
+## 7. Polygon ↔ pixel — exterior coordinates
+
+`window_polygon` is the geometry-aware sibling of `window_bounds`. Returns a Shapely `Polygon` rather than a 4-tuple — important when the transform has rotation/shear (`b ≠ 0` or `d ≠ 0`), where the bounding box and the actual footprint differ.
+
+```text
+window_surrounding=False (default):     window_surrounding=True:
+Polygon includes full pixels             Polygon passes through pixel centers
+
+┌───┬───┬───┬───┐                       ┌───┬───┬───┬───┐
+│ P │ P │ P │ P │ ◄─ Polygon            │ · │ · │ · │ · │
+├───┼───┼───┼───┤    edges              ├───○───○───○───┤
+│ P │ P │ P │ P │    touch              │ · │ · │ · │ · │ ◄─ Polygon
+├───┼───┼───┼───┤    pixel              ├───○───○───○───┤    passes
+│ P │ P │ P │ P │    boundaries         │ · │ · │ · │ · │    through ○
+└───┴───┴───┴───┘                       └───┴───┴───┴───┘
+```
+
+The `window_surrounding` flag picks between two valid pixel-footprint conventions:
+
+- **`False` (default)** — the polygon traces the *outside* of the pixel grid. Pixels are areas with non-zero extent. Use when you're computing intersections with vector geometries that should agree with `window_bounds`.
+- **`True`** — the polygon vertices sit at *pixel centres*. Pixels are samples (points) on a regular grid. Use when you're matching against point clouds or building irregular-grid representations.
+
+The default matches GIS convention; the alternative is needed when interfacing with point-sampling tools (some scipy/skimage routines treat pixels as samples by default).
+
+Companion functions:
+
+- **`polygon_to_crs(polygon, crs_polygon, dst_crs)`** — reproject a Shapely geometry. Works on `Polygon` and `MultiPolygon`; preserves geometry type.
+- **`exterior_pixel_coords(transform, crs, polygon, crs_polygon=None)`** — reproject `polygon` into the raster's CRS, then convert each ring of vertices to pixel coordinates. Returns `List[List[(col, row)]]` (one inner list per polygon part). Used by `rasterize` ([Chapter 9](09_rasterize.md)) to draw filled regions.
+
+---
+
+## 8. The "boundless reading" mechanics — `get_slice_pad`
+
+This is the function that makes `read_from_window(boundless=True)` actually work, and it deserves a callout because the behaviour seems magical until you see it.
+
+Given two windows:
+
+- `window_data` — the actual data extent (e.g., `(0, 0, W, H)` for a file)
+- `window_read` — the (possibly out-of-bounds) read request
+
+…it returns:
+
+- A `dict[str, slice]` to extract the part of `window_read` that **does** overlap `window_data`
+- A `dict[str, (pad_left, pad_right)]` to pad the result so it ends up the requested shape
+
+The reader then reads the slice from disk and applies `np.pad` (or its own `fill_value_default`-aware equivalent) to produce a full-size array. CNN inference at scene edges relies entirely on this — every chip comes back the requested shape, with off-edge regions filled with nodata.
+
+Source: [window_utils.py:599](../../../../tmp/georeader_src/georeader/window_utils.py#L599).
+
+---
+
+## 9. Tiling-and-stitching: `slice_save_for_pred`
+
+The companion to `pad_window` for inference pipelines: when you've read a tile *with* padded context, run a CNN, and now want to write only the centre back into a global output, this function tells you which slice to extract from the prediction.
+
+```text
+1. Read overlapping tiles with padding to avoid edge artifacts
+2. Run CNN inference on padded tiles
+3. Extract only the center region (removing padding) for final output
+4. Stitch extracted regions together to form complete prediction
+```
+
+The reference is Huang et al. (2018) — the standard tile-and-stitch recipe. Used by ml4floods and similar segmentation pipelines built on georeader.
+
+Source: [window_utils.py:1256](../../../../tmp/georeader_src/georeader/window_utils.py#L1256).
+
+---
+
+## 10. Function reference
+
+Grouped by purpose. Every function takes / returns `rasterio.Affine`, `rasterio.windows.Window`, or shapely `Polygon`/`MultiPolygon` — no GeoTensor/Reader anywhere in this module.
+
+**Padding & rounding**
+- `pad_window(window, pad_size=(rows, cols))` — symmetric expansion
+- `pad_window_to_size(window, size=(h, w))` — re-centre to fixed size
+- `round_outer_window(window, precision=3)` — expand to integer pixels
+- `round_inner_window(window, precision=3)` — shrink to integer pixels
+- `get_slice_pad(window_data, window_read)` — boundless-read decomposition
+- `pad_list_numpy(pad_width)` — convert dim-named pad dict to `np.pad` arg list
+- `slice_save_for_pred(w_read, w_write)` — tile-and-stitch slice extractor
+
+**Windows ↔ bounds**
+- `window_bounds(window, transform)` — pixels → geo bbox
+- `bounds_to_windows(data, bounds_dst, crs_dst)` — geo bbox → windows (handles antimeridian)
+- `normalize_bounds(bounds, margin_add_if_equal=0.0005)` — fix inverted / degenerate bboxes
+
+**Transforms**
+- `figure_out_transform(transform=None, bounds=None, resolution_dst=None)` — flexible factory
+- `transform_to_resolution_dst(transform, resolution_dst)` — rescale a transform's pixel size
+- `compare_crs(a, b)` — CRS equality across EPSG int / string / WKT / pyproj
+- `res(transform)` — `(|a|, |e|)` from a transform
+
+**Polygons**
+- `window_polygon(window, transform, window_surrounding=False)` — pixel rect → Shapely polygon
+- `polygon_to_crs(polygon, src_crs, dst_crs)` — reproject geometry
+- `exterior_pixel_coords(transform, crs, polygon, crs_polygon=None)` — polygon vertices → pixel coords
+- `apply_transform_to_pol(pol, transform)` — apply affine to polygon vertices
+- `get_valid_mask(...)` — mask of valid (in-polygon) pixels
+
+**Convenience indexes**
+- `row_end(window) → int` — `row_off + height`
+- `col_end(window) → int` — `col_off + width`
+
+(Functions starting with `_` like `_is_exact_round` are internal precision helpers and aren't part of the public API.)
+
+---
+
+## 11. Sharp edges
+
+- **Window order vs numpy order.** `Window(col_off, row_off, width, height)` — `(x, y, w, h)` in screen-coordinate parlance. `pad_window(pad_size)` is `(rows, cols)` — `(y, x)` in numpy parlance. `pad_window_to_size(size)` is `(height, width)`. The module deliberately uses numpy order for axis-tuple args; the rasterio Window constructor is fixed.
+- **`PIXEL_PRECISION = 3` is module-global.** If you have a workflow with sub-millipixel meaningful precision (you don't, but if), you'd need to thread `precision=` through every call. In practice, 3 is right.
+- **Antimeridian-crossing AOIs return *two* windows.** `bounds_to_windows` returns a list. Code that does `windows[0]` will silently lose half the AOI when an Asia/Pacific bbox is queried.
+- **Rotated transforms break `window_bounds`.** When `b ≠ 0` or `d ≠ 0`, the four-corner bounding box overestimates the data footprint. Use `window_polygon` and intersect against actual geometry.
+- **`figure_out_transform` errors are validation, not bugs.** "ERROR (need bounds)" rows in the table are deliberate — there's no sensible default.
+- **`exterior_pixel_coords` returns col-row, not row-col.** Matches Shapely (x, y) convention. Don't pass it directly to `np.zeros[...]`.
+
+---
+
+## 12. Why this module matters for `geotoolz`
+
+Three concrete things `geotoolz.sampling` and `geotoolz.inference` will lean on:
+
+1. **`pad_window` + `slice_save_for_pred`** is the entire ApplyToChips machinery. Read with context, predict, save the centre, stitch.
+2. **`bounds_to_windows`** is what a `BoundingBoxSampler` (TorchGeo-style) calls under the hood when chips are specified in geographic coords rather than pixel coords.
+3. **`figure_out_transform`** is the "design my output grid" function. Every reprojection-aware operator (mosaicking, ensemble averaging across scenes) needs it.
+
+You can build the whole `geotoolz.sampling` module without touching anything in `georeader` *except* this file plus `read.py`. That's a clean cut for the operator layer.
+
+Next chapter: [05_read.md](05_read.md) — the high-level reading API (`read_from_bounds`, `read_from_polygon`, `read_from_center_coords`, reprojection / resampling). The single densest module in the package by diagram count, and the one most users touch first.

--- a/projects/geotoolz/georeader_tutorial/05_read.md
+++ b/projects/geotoolz/georeader_tutorial/05_read.md
@@ -1,0 +1,340 @@
+# Chapter 5 — `read.py`: the high-level reading API
+
+> **Module:** `georeader/read.py` (1967 LOC, the densest module in the package — 123 box-drawing characters across the docstring)
+> **Role:** the public face of georeader. Most users start here. Six "specify the AOI in the form most natural to your problem" entry points, plus reprojection / resampling / grid-matching.
+
+---
+
+## 1. The mental model
+
+You have:
+
+- A **source** that satisfies the `GeoData` protocol (a `RasterioReader`, a `GeoTensor`, or any reader you build) — see [Chapter 2](02_abstract_reader.md).
+- An **AOI** described in some natural form — a polygon, a bbox, a centre coordinate, a pixel window, a web tile, or another raster's grid.
+- A **destination CRS / resolution / shape** — possibly the same as the source (cheap), possibly different (full reprojection).
+
+`read.py` is the dispatcher: it converts whichever AOI form you supplied into a window in the source's pixel space, asks the source for that window (lazily), reprojects/resamples if needed, and hands you a `GeoTensor`.
+
+The whole module is built on `window_utils` ([Chapter 4](04_window_utils.md)) and on the `GeoData.read_from_window` / `GeoData.load` interface from [Chapter 2](02_abstract_reader.md).
+
+---
+
+## 2. Six ways to specify "what region do I want?"
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    READING WORKFLOW: AREA SPECIFICATION                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Input Specification          Function                     Output       │
+│  ────────────────────         ─────────────────────        ──────────   │
+│                                                                          │
+│  Polygon (geometry)     ───►  read_from_polygon()    ───►  GeoTensor   │
+│                                                                          │
+│  Bounds (minx,miny,     ───►  read_from_bounds()     ───►  GeoTensor   │
+│          maxx,maxy)                                                      │
+│                                                                          │
+│  Center + Shape         ───►  read_from_center_coords() ─► GeoTensor   │
+│  (x, y) + (H, W)                                                         │
+│                                                                          │
+│  Window (row_off,       ───►  read_from_window()     ───►  GeoTensor   │
+│          col_off, H, W)                                                  │
+│                                                                          │
+│  Web Tile (x, y, z)     ───►  read_from_tile()       ───►  GeoTensor   │
+│                                                                          │
+│  Match another raster   ───►  read_reproject_like()  ───►  GeoTensor   │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Quick guide to which one to reach for:
+
+| Your situation | Use |
+|---|---|
+| You have a Shapely polygon | `read_from_polygon` |
+| You have a bbox tuple | `read_from_bounds` |
+| You have a click-point + a chip size | `read_from_center_coords` |
+| You're already in pixel coordinates | `read_from_window` |
+| You're rendering a slippy-map tile | `read_from_tile` |
+| You need to match another raster's grid exactly | `read_reproject_like` |
+
+Each `read_from_*` has a sibling `window_from_*` that returns just the `Window` without reading bytes — used internally and useful when you want to inspect "what pixels will I read?" before committing.
+
+---
+
+## 3. Window vs bounds — the semantic split
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              WINDOW (PIXELS) vs BOUNDS (GEOGRAPHIC COORDINATES)          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  WINDOW (pixel space)                BOUNDS (CRS units)                 │
+│  ─────────────────────               ──────────────────                 │
+│                                                                          │
+│  (col_off, row_off)                  (minx, maxy)  ← upper-left         │
+│       ↓                                   ↓                              │
+│    ┌──────────────┐                  ┌──────────────┐                   │
+│    │ width pixels │                  │              │ geographic        │
+│    │              │   ◄═══════►      │              │ extent in         │
+│    │ height pixels│    transform     │              │ CRS units         │
+│    └──────────────┘                  └──────────────┘                   │
+│                                           ↑                              │
+│                                      (maxx, miny)  ← lower-right        │
+│                                                                          │
+│  Window: rasterio.windows.Window(col_off, row_off, width, height)       │
+│  Bounds: (minx, miny, maxx, maxy) - order matches shapely/rasterio      │
+│                                                                          │
+│  Conversion:                                                             │
+│    bounds = window_utils.window_bounds(window, transform)               │
+│    window = window_from_bounds(data, bounds, crs_bounds)                │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The split matters because:
+
+- **Windows are CRS-free.** Once you have a window in the source's pixel space, no further coordinate math is needed. `read_from_window` is the cheapest entry point.
+- **Bounds carry a CRS.** `read_from_bounds(data, bounds, crs_bounds)` *always* takes a separate `crs_bounds` arg — even if it's the same as the data — because there's no way to read the CRS off a tuple. Forgetting `crs_bounds` is a common bug.
+
+The `window_from_*` siblings are the bridge: they normalise any AOI specification into a pixel window in the source's CRS, with antimeridian handling and outer-rounding applied. The `read_from_*` functions then call `data.read_from_window(window, boundless=True).load()`.
+
+---
+
+## 4. Reprojection and resampling
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     REPROJECTION WORKFLOW                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Source CRS (e.g., EPSG:4326)         Target CRS (e.g., EPSG:32633)    │
+│  ┌─────────────────────┐              ┌─────────────────────┐           │
+│  │  ╱╲    ╱╲    ╱╲    │              │ □ □ □ □ □ □ □ □ □ │           │
+│  │ ╱  ╲  ╱  ╲  ╱  ╲   │    ═════►    │ □ □ □ □ □ □ □ □ □ │           │
+│  │╱    ╲╱    ╲╱    ╲  │   Reproject  │ □ □ □ □ □ □ □ □ □ │           │
+│  │ Irregular grid     │   + Resample │ Regular UTM grid   │           │
+│  └─────────────────────┘              └─────────────────────┘           │
+│                                                                          │
+│  Resampling Methods (rasterio.warp.Resampling):                         │
+│  ┌────────────────┬────────────────────────────────────────────────┐    │
+│  │ Method         │ Best for                                       │    │
+│  ├────────────────┼────────────────────────────────────────────────┤    │
+│  │ nearest        │ Categorical data, masks, classification        │    │
+│  │ bilinear       │ Continuous data, fast                          │    │
+│  │ cubic          │ Continuous data, smooth                        │    │
+│  │ cubic_spline   │ Continuous data, very smooth (DEFAULT)         │    │
+│  │ lanczos        │ Downsampling, sharp edges                      │    │
+│  │ average        │ Downsampling, area-weighted mean               │    │
+│  │ mode           │ Downsampling categorical data                  │    │
+│  └────────────────┴────────────────────────────────────────────────┘    │
+│                                                                          │
+│  Anti-aliasing: Automatic Gaussian blur before downsampling to          │
+│                 prevent aliasing artifacts. Controlled by:              │
+│                 - anti_aliasing=True (default in resize)                │
+│                 - anti_aliasing_sigma (auto-calculated or manual)       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Three reprojection-flavoured entry points:
+
+- **`read_to_crs(data, dst_crs, resampling=...)`** — simplest case: same bounds, new CRS. Used for visualisation flips (UTM → Web Mercator).
+- **`read_reproject(data, dst_crs=None, bounds=None, resolution_dst_crs=None, dst_transform=None, ...)`** — the workhorse. Choose any combination of CRS / bounds / resolution / explicit transform; the function fills in the rest using `window_utils.figure_out_transform`.
+- **`read_reproject_like(data_in, data_like, ...)`** — match another raster's grid exactly. Reads `data_like.transform`, `data_like.crs`, `data_like.shape` and builds the matching read. Standard pattern for stacking heterogeneous sources onto a common grid.
+
+The default resampling is `cubic_spline`. The advice in the table is good: **switch to `nearest` for masks and class labels**, otherwise you'll get fractional class IDs after resampling.
+
+The `resize` function is the resolution-only sibling — same CRS, same origin, new pixel size — with built-in anti-aliasing pre-blur for downsampling.
+
+---
+
+## 5. Boundless reading
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    BOUNDLESS READING (boundless=True)                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Requested Window              Result with boundless=True               │
+│  ─────────────────              ─────────────────────────               │
+│                                                                          │
+│       ┌─────────────┐           ┌─────────────┐                         │
+│       │ fill │ data │           │  0  │ data │   fill_value_default    │
+│       │ ─────┼───── │           │ ────┼───── │   fills out-of-bounds   │
+│       │ fill │ data │           │  0  │ data │   pixels                │
+│       └─────────────┘           └─────────────┘                         │
+│            ↑                                                             │
+│     Request extends                                                      │
+│     beyond raster bounds                                                 │
+│                                                                          │
+│  boundless=False: Raises error or clips to valid region                 │
+│  boundless=True:  Pads with fill_value_default (default behavior)       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`boundless=True` is the default everywhere in `read.py`. This is deliberate: the moment you compose tiled inference with edge tiles, you *want* fixed-size outputs and don't want to special-case "this tile is at the edge."
+
+`boundless=False` is the right choice when you specifically want to detect off-edge requests — e.g., "did my AOI actually fall inside the scene?"
+
+---
+
+## 6. The eight-step `read_reproject` walkthrough
+
+The implementation of `read_reproject` ([read.py:1348](../../../../tmp/georeader_src/georeader/read.py#L1348)) is annotated with eight numbered banner-comments inside the function body. They're not a single ASCII diagram, but they're the clearest map of how reprojection actually works in this package — worth preserving.
+
+```text
+─────────────────────────────────────────────────────────────────────────
+STEP 1: DETERMINE OUTPUT TRANSFORM
+─────────────────────────────────────────────────────────────────────────
+The output transform defines the mapping from pixel coordinates to
+geographic coordinates in the destination CRS. It can be:
+- Provided directly (dst_transform)
+- Computed from bounds + resolution
+- Computed from bounds with inferred resolution
+
+Shape tracking:
+  Input:  named_shape = {'band': C, 'y': H_in, 'x': W_in}
+  Output: will have {'band': C, 'y': H_out, 'x': W_out}
+─────────────────────────────────────────────────────────────────────────
+
+STEP 2: COMPUTE OUTPUT DIMENSIONS
+─────────────────────────────────────────────────────────────────────────
+The output window defines pixel dimensions (W_out, H_out). Either:
+- Provided directly (window_out)
+- Computed from bounds in dst_crs coordinate units
+
+Example: bounds=(0, 0, 1000, 1000) with 10m resolution → (100, 100) pixels
+─────────────────────────────────────────────────────────────────────────
+
+STEP 3: CHECK FOR NO-OP OPTIMIZATION
+─────────────────────────────────────────────────────────────────────────
+If source and destination have:
+  - Same CRS
+  - Same pixel size (transform.a and transform.e)
+  - Grid-aligned origins (integer pixel offset)
+Then we can skip reprojection entirely and use a simple window read.
+This is ~10-100x faster for aligned data.
+─────────────────────────────────────────────────────────────────────────
+
+STEP 4: HANDLE DATA TYPES
+─────────────────────────────────────────────────────────────────────────
+Boolean arrays need special handling:
+  bool → float32 → interpolate → threshold(0.5) → bool
+This prevents interpolation artifacts in mask data while still
+allowing smooth boundaries (anti-aliasing effect).
+─────────────────────────────────────────────────────────────────────────
+
+STEP 5: ALLOCATE OUTPUT ARRAY
+─────────────────────────────────────────────────────────────────────────
+Pre-allocate with nodata fill. Shape is built by replacing x,y dims
+with the new window dimensions while preserving other dims (band, time).
+
+Example shape transformation:
+  Input:  (4, 1000, 1000)  → 4 bands, 1000×1000 pixels
+  Output: (4, 500, 600)    → 4 bands, 500×600 pixels (new extent)
+─────────────────────────────────────────────────────────────────────────
+
+STEP 6: CHECK INTERSECTION
+─────────────────────────────────────────────────────────────────────────
+If the requested output region doesn't overlap the input data at all,
+return early with the nodata-filled array. Saves computation.
+─────────────────────────────────────────────────────────────────────────
+
+STEP 7: LOAD SOURCE DATA
+─────────────────────────────────────────────────────────────────────────
+For lazy data (xarray/dask), read only the region that will contribute
+to the output, plus a 3-pixel buffer for interpolation edge handling.
+The buffer prevents edge artifacts from bilinear/cubic resampling.
+─────────────────────────────────────────────────────────────────────────
+
+STEP 8: ITERATE OVER NON-SPATIAL DIMENSIONS
+─────────────────────────────────────────────────────────────────────────
+rasterio.warp.reproject operates on 2D arrays. For multi-band or
+multi-temporal data, we iterate over all (time, band) combinations.
+
+Example: shape (4, 3, H, W) with dims ('time', 'band', 'y', 'x')
+  → iterates over 4×3=12 slices: (0,0), (0,1), (0,2), (1,0), ...
+─────────────────────────────────────────────────────────────────────────
+
+CORE REPROJECTION: rasterio.warp.reproject
+─────────────────────────────────────────────────────────────────────────
+This is where the actual coordinate transformation happens:
+1. For each output pixel, compute its geographic coordinates
+2. Transform those coords from dst_crs to src_crs
+3. Sample the input raster at those locations using resampling
+4. Write the result to the output array
+─────────────────────────────────────────────────────────────────────────
+```
+
+Five things worth highlighting from this walkthrough:
+
+1. **Step 3 is the fast path.** Same CRS + same pixel size + grid-aligned origins → reprojection collapses to a window read. ~10–100× speedup. This is why operators that read coregistered data should reach for `read_from_bounds` (which dispatches via this path) instead of `read_reproject` blindly.
+2. **Step 6 short-circuits non-intersecting requests.** Asking for an AOI that doesn't overlap the scene returns a nodata-filled array, not an error. Composing tiled inference across catalogs of partially-overlapping scenes works without try/except.
+3. **Step 7 reads with a 3-pixel buffer.** That's the anti-aliasing-of-resampling-kernels reason. Bilinear / cubic kernels need neighbouring pixels at the destination boundary; without the buffer you get a thin nodata stripe along edges.
+4. **Step 4's bool dance.** Reprojecting a bool mask via `nearest` is correct semantically but loses smooth boundaries. The float32 → interpolate → threshold trick gives anti-aliased mask edges while preserving bool dtype on output.
+5. **Step 8 iterates by non-spatial dim.** A `(T, C, H, W)` GeoTensor reprojects band-by-band, time-by-time. The outer loop is in Python; the inner reprojection is in `rasterio.warp.reproject` (GDAL). For very large stacks this can be a bottleneck — one of the things a JAX-batched reprojection in `geotoolz` could improve later.
+
+---
+
+## 7. Function reference
+
+**Window factories (no I/O)**
+- `window_from_polygon(data_in, polygon, crs_polygon=None, ...)`
+- `window_from_bounds(data_in, bounds, crs_bounds, ...)`
+- `window_from_center_coords(data_in, center, shape, crs_center_coords=None, ...)`
+- `window_from_tile(data_in, x, y, z)` — Web Mercator XYZ tile
+
+**Read functions (return `GeoTensor`)**
+- `read_from_window(data_in, window, boundless=True, return_only_data=False, trigger_load=True)`
+- `read_from_bounds(data_in, bounds, crs_bounds=None, ...)`
+- `read_from_polygon(data_in, polygon, crs_polygon=None, pad_add=(0, 0), ...)`
+- `read_from_center_coords(data_in, center, shape, crs_center_coords=None, ...)`
+- `read_from_tile(data, x, y, z, ...)` — slippy-map tile
+
+**Reprojection / resampling**
+- `read_to_crs(data, dst_crs, resampling=...)` — same bounds, new CRS
+- `read_reproject(data_in, dst_crs=None, bounds=None, resolution_dst_crs=None, dst_transform=None, window_out=None, dst_nodata=None, dtype_dst=None, resampling=cubic_spline)` — the workhorse
+- `read_reproject_like(data_in, data_like, ...)` — match another raster's grid
+- `resize(data_in, output_shape=..., resolution_dst=..., anti_aliasing=True, anti_aliasing_sigma=None, ...)` — same CRS / origin, new resolution
+- `apply_anti_aliasing(data_in, sigma=...)` — Gaussian pre-blur (used by `resize` internally)
+- `calculate_transform_window(...)` — utility for computing matched windows
+
+**Lower-level utilities**
+- `read_rpcs(input_npy, ...)` — handle Rational Polynomial Coefficients (sensor-model georeferencing for raw imagery)
+- `_round_all`, `_transform_from_crs` — internal helpers; not public API
+
+---
+
+## 8. The `pad_add` argument on `read_from_polygon`
+
+`read_from_polygon` accepts `pad_add=(rows, cols)` — a tuple of pixel padding to grow the read window beyond the polygon's bounding box. This isn't documented as a feature of the others, but it shows up in two contexts:
+
+- **Reprojection edge handling.** Internal calls in `read_reproject` use `pad_add=(3, 3)` so that the resampling kernel has neighbours at the destination boundary (Step 7 above).
+- **CNN context windows.** For a segmentation model that needs context around the AOI, `pad_add=(32, 32)` reads a buffer; you pass through to inference, then crop the centre.
+
+For other entry points, achieve the same effect by `pad_window`-ing the result of `window_from_*` and calling `read_from_window` directly.
+
+---
+
+## 9. Sharp edges
+
+- **`crs_bounds` / `crs_polygon` / `crs_center_coords` are required when they differ from the source.** If omitted, the function assumes the AOI is already in the source's CRS — which is silently wrong if it isn't. Pass the CRS explicitly always.
+- **Default resampling is `cubic_spline`.** Wrong for masks. Pass `resampling=Resampling.nearest` for class labels / cloud masks.
+- **`read_reproject` allocates the output upfront (Step 5).** A misconfigured huge output shape (e.g., units mismatch in `resolution_dst_crs`) tries to allocate a TB-scale array. If allocation seems suspicious, print the inferred output shape before reading.
+- **The fast path (Step 3) requires *exact* integer pixel offsets.** A fractional offset of 0.0003 still triggers the full reproject path. The `_is_exact_round` precision check matches `PIXEL_PRECISION = 3` from `window_utils`.
+- **`read_from_polygon` reads the polygon's *bounding box*, then masks.** It doesn't do per-pixel polygon membership at the read step — the read returns a rectangle. For pixel-level masking, follow with `rasterize` ([Chapter 9](09_rasterize.md)) or use `data.footprint().intersects(polygon)` checks.
+- **Antimeridian-crossing AOIs split into two reads.** Inherited from `bounds_to_windows` ([Chapter 4 §3](04_window_utils.md)); the splitting is automatic but it's two HTTP requests on cloud data.
+- **`read_from_tile` returns a Web Mercator tile.** If your source isn't in Web Mercator, this triggers a full reprojection per tile — fine for occasional rendering, expensive for a tile-loop.
+
+---
+
+## 10. Why this module is the operator surface for `geotoolz.sampling`
+
+Three functions from this module are essentially the entire `geotoolz.sampling.GridSampler` / `RandomSampler` / `Stitch` machinery:
+
+- `window_from_bounds` — convert a sampler's geographic chip query to a source window.
+- `read_from_window(boundless=True)` — fixed-shape chip retrieval.
+- `read_reproject_like` — when sampling from heterogeneous sources, match all chips to a common grid.
+
+A `GridSampler` is mostly a generator of `(x_min, y_min, x_max, y_max)` tuples in the source CRS; the `chip_op` calls `read_from_bounds` per tuple. Add `pad_add=(context, context)` for inference with context, then `slice_save_for_pred` ([Chapter 4 §9](04_window_utils.md)) to crop back when stitching. The whole loop is ~50 lines that wrap functions already in this module.
+
+Next chapter: [06_slices.md](06_slices.md) — tiling strategies (overlap, stride, chunked) for memory-efficient processing of datasets that don't fit in RAM.

--- a/projects/geotoolz/georeader_tutorial/05_read.md
+++ b/projects/geotoolz/georeader_tutorial/05_read.md
@@ -1,4 +1,4 @@
-# Chapter 5 — `read.py`: the high-level reading API
+# Ch. 5 — `read`
 
 > **Module:** `georeader/read.py` (1967 LOC, the densest module in the package — 123 box-drawing characters across the docstring)
 > **Role:** the public face of georeader. Most users start here. Six "specify the AOI in the form most natural to your problem" entry points, plus reprojection / resampling / grid-matching.
@@ -179,7 +179,7 @@ The `resize` function is the resolution-only sibling — same CRS, same origin, 
 
 ## 6. The eight-step `read_reproject` walkthrough
 
-The implementation of `read_reproject` ([read.py:1348](../../../../tmp/georeader_src/georeader/read.py#L1348)) is annotated with eight numbered banner-comments inside the function body. They're not a single ASCII diagram, but they're the clearest map of how reprojection actually works in this package — worth preserving.
+The implementation of `read_reproject` ([read.py:1348](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/read.py#L1348)) is annotated with eight numbered banner-comments inside the function body. They're not a single ASCII diagram, but they're the clearest map of how reprojection actually works in this package — worth preserving.
 
 ```text
 ─────────────────────────────────────────────────────────────────────────

--- a/projects/geotoolz/georeader_tutorial/06_slices.md
+++ b/projects/geotoolz/georeader_tutorial/06_slices.md
@@ -1,4 +1,4 @@
-# Chapter 6 — `slices.py`: tiling generators for tiled processing
+# Ch. 6 — `slices`
 
 > **Module:** `georeader/slices.py` (404 LOC)
 > **Role:** divide a raster into tiles. Three diagrams cover the *what* (overlap vs not), the *vocabulary* (Python `slice` vs `rasterio.windows.Window`), and the *what-do-I-do-at-the-edge* problem. Three public functions: `create_slices`, `create_windows`, plus the dict↔window converters.

--- a/projects/geotoolz/georeader_tutorial/06_slices.md
+++ b/projects/geotoolz/georeader_tutorial/06_slices.md
@@ -1,0 +1,222 @@
+# Chapter 6 — `slices.py`: tiling generators for tiled processing
+
+> **Module:** `georeader/slices.py` (404 LOC)
+> **Role:** divide a raster into tiles. Three diagrams cover the *what* (overlap vs not), the *vocabulary* (Python `slice` vs `rasterio.windows.Window`), and the *what-do-I-do-at-the-edge* problem. Three public functions: `create_slices`, `create_windows`, plus the dict↔window converters.
+
+---
+
+## 1. The job
+
+When a raster doesn't fit in RAM (or a model has a fixed input size), you process it in tiles. The whole module exists to answer one question:
+
+**Given a raster shape, a tile size, and an overlap, give me the list of windows that cover it.**
+
+Everything else — overlap semantics, edge handling, dict-vs-tuple ergonomics — is a knob on that core operation.
+
+---
+
+## 2. Tiling strategies
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    TILING STRATEGIES                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Non-overlapping (overlap=0)          Overlapping (overlap>0)           │
+│  ─────────────────────────            ──────────────────────            │
+│                                                                          │
+│  ┌────┬────┬────┬────┐              ┌────┬────┬────┬────┐               │
+│  │ 1  │ 2  │ 3  │ 4  │              │ 1 ─┼─ 2 ┼─ 3 ┼─ 4 │               │
+│  ├────┼────┼────┼────┤              ├───┬┼───┬┼───┬┼───┬┤               │
+│  │ 5  │ 6  │ 7  │ 8  │              │ 5 │├ 6 │├ 7 │├ 8 ││               │
+│  ├────┼────┼────┼────┤              ├───┼┼───┼┼───┼┼───┼┤               │
+│  │ 9  │ 10 │ 11 │ 12 │              │ 9 ││10 ││11 ││12 ││               │
+│  └────┴────┴────┴────┘              └───┴┴───┴┴───┴┴───┴┘               │
+│                                          └─ overlap region              │
+│  Best for:                          Best for:                           │
+│  • Independent tiles                • Edge-sensitive algorithms         │
+│  • Aggregation tasks                • Convolutions/filters              │
+│  • Simple mosaicking                • Seamline blending                 │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Stride** = `tile_size - overlap`. That single equation drives the whole module:
+
+- `overlap=0` → stride = tile_size → tiles abut perfectly. Best for per-pixel work that has no spatial neighbourhood (mean per tile, classification heads applied independently).
+- `overlap>0` → stride < tile_size → tiles share rows/cols with neighbours. Necessary for any operation with a spatial kernel (convolutions, Lee-speckle filters, cubic resampling). The overlap should be at least the kernel half-width plus a margin — typical values 16/32/64 for U-Net-shaped models.
+
+The overlapped form composes with `slice_save_for_pred` ([Chapter 4 §9](04_window_utils.md)) for the standard "predict on padded chip, save the centre" tile-and-stitch recipe.
+
+---
+
+## 3. Slices vs Windows
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              SLICES (Python) vs WINDOWS (Rasterio)                       │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  slice(start, stop)              Window(col_off, row_off, width, height)│
+│  ──────────────────              ──────────────────────────────────────│
+│                                                                          │
+│  • Python array indexing         • Rasterio file reading                │
+│  • 2D: (row_slice, col_slice)    • 2D: explicit offsets + sizes         │
+│  • End-exclusive                 • Width/height inclusive               │
+│                                                                          │
+│  Conversion:                                                             │
+│    slices_to_windows((row_slice, col_slice)) → Window                   │
+│    window_to_slices(window) → (row_slice, col_slice)                    │
+│                                                                          │
+│  Example:                                                                │
+│    slice(100, 356), slice(200, 456)  →  Window(200, 100, 256, 256)      │
+│    (rows 100-355, cols 200-455)          (col=200, row=100, 256x256)    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Two vocabularies for the same rectangle. Pick by audience:
+
+| Use slices when | Use windows when |
+|---|---|
+| Indexing a numpy / xarray array directly | Calling `rasterio.read(window=...)` |
+| Composing with `xarray.isel` | Calling `read_from_window` |
+| Working in numpy `(rows, cols)` order | Working in rasterio `(col, row)` order |
+
+The conversion is purely arithmetic — there's no CRS or transform involved. The example: rows 100–355 inclusive (256 rows) and cols 200–455 inclusive (256 cols) is `Window(col_off=200, row_off=100, width=256, height=256)`. Note the order swap: numpy is rows-first, Window is col-first.
+
+`create_slices` returns dicts (`{"y": slice(...), "x": slice(...)}`); `create_windows` returns `Window` objects. They're the same data wearing different hats.
+
+---
+
+## 4. Edge handling — three knobs
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    EDGE HANDLING OPTIONS                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Raster: 500px, Tile: 128px, Overlap: 0                                 │
+│  ──────────────────────────────────────                                 │
+│                                                                          │
+│  include_incomplete=True (default):                                     │
+│  ┌────────┬────────┬────────┬────────┬────┐                             │
+│  │  128   │  128   │  128   │  128   │ 12 │  ← 5 tiles, last is 12px   │
+│  └────────┴────────┴────────┴────────┴────┘                             │
+│                                                                          │
+│  include_incomplete=False:                                              │
+│  ┌────────┬────────┬────────┐                                           │
+│  │  128   │  128   │  128   │  ← 3 tiles, drops edge                    │
+│  └────────┴────────┴────────┘                                           │
+│                                                                          │
+│  trim_incomplete=True:                                                   │
+│  Same as include_incomplete=True but last slice is trimmed              │
+│  slice(384, 500) instead of slice(384, 512)                             │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+500 isn't divisible by 128 — what to do with the remainder? Three flags settle it:
+
+- **`include_incomplete=True` (default).** Keep the partial last tile. Result has 5 tiles for our example, the last covering only 12 pixels. Use this for visualization / aggregation where every pixel must be covered.
+- **`include_incomplete=False`.** Drop the partial last tile. Result has 3 tiles covering 384 of the 500 pixels. Use this for ML training where a partial tile would have a different shape from the rest of the batch.
+- **`trim_incomplete=True` (default).** Last slice is `slice(384, 500)` — trimmed to the raster bound. The alternative (`trim_incomplete=False`) is `slice(384, 512)` — extending past the raster, requiring `boundless=True` reads to pad with `fill_value_default`. The trimmed version is what you want when reading; the un-trimmed is what you want when *writing back* into a fixed-size grid that already has padding allocated.
+
+There's also a fourth, narrower flag:
+
+- **`start_negative_if_padding=True`.** Shifts the first tile by `-overlap//2`, so overlap is symmetric across the *whole* raster (including the first/last edges) rather than just between interior tiles. Required when tile-and-stitch with a CNN that introduces edge artefacts even at the global boundary; usually paired with `boundless=True`.
+
+---
+
+## 5. The three public functions
+
+### `create_windows(geodata_shape, window_size, overlap=None, ...)`
+
+The primary entry point. `geodata_shape=(height, width)` (numpy order); `window_size=(height, width)`; `overlap=(row_overlap, col_overlap)`. Returns `list[rasterio.windows.Window]`.
+
+**Use this** for tiled reading from a raster.
+
+### `create_slices(named_shape, dims, overlap=None, ...)`
+
+Generalised N-dimensional version. `named_shape={"y": H, "x": W, ...}`, `dims={"y": tile_h, "x": tile_w, ...}`. Returns `list[dict[str, slice]]` — one dict per tile, with one slice per named dimension.
+
+**Use this** for xarray-style indexing or for tiling along non-spatial dims (time chunks, band groups).
+
+Internally, `create_windows` is a thin wrapper around `create_slices` with `dims={"y": ..., "x": ...}` and a final dict-to-window conversion.
+
+### `slices_to_windows((row_slice, col_slice))` / `window_to_slices(window)`
+
+Pair-wise converters. No tiling logic — just rectangle-shape translation.
+
+There are also private helpers `_slices` (1D), `_slices_nd` (N-D tuple form), and `_slices_2d` (2D tuple form) — used internally and occasionally exposed in older code paths.
+
+---
+
+## 6. Composing with the rest of georeader
+
+The three idiomatic patterns:
+
+**Pattern A — sequential tiled read into memory:**
+
+```python
+windows = slices.create_windows(
+    geodata_shape=reader.shape[-2:],
+    window_size=(512, 512),
+    overlap=(64, 64),
+)
+for w in windows:
+    chip = reader.read_from_window(w, boundless=True).load()
+    # chip is (C, 512, 512) GeoTensor regardless of position
+```
+
+**Pattern B — tile-and-stitch CNN inference:**
+
+```python
+windows = slices.create_windows(
+    geodata_shape=reader.shape[-2:],
+    window_size=(512, 512),
+    overlap=(64, 64),
+    start_negative_if_padding=True,    # symmetric edge handling
+    trim_incomplete=False,             # let boundless padding handle the edge
+)
+for w_read in windows:
+    chip = reader.read_from_window(w_read, boundless=True).load()
+    pred = model(chip.values)
+    # crop the prediction to remove the 32-px overlap on each side
+    # save back to global output via slice_save_for_pred (Chapter 4 §9)
+```
+
+**Pattern C — N-D tiling for time-series chunks:**
+
+```python
+chunks = slices.create_slices(
+    named_shape={"time": T, "band": C, "y": H, "x": W},
+    dims={"time": 30, "y": 512, "x": 512},     # tile time + space; full bands
+    overlap={"y": 64, "x": 64},                 # overlap only spatially
+)
+for sel in chunks:
+    sub = data.isel(sel)                        # xarray-style
+```
+
+Pattern C is the one that lets you process a year of S2 in monthly time-chunks without ever materialising the whole stack.
+
+---
+
+## 7. Sharp edges
+
+- **Numpy axis order vs Window order, again.** `geodata_shape=(H, W)`, `window_size=(H, W)`, `overlap=(row_overlap, col_overlap)` — all numpy `(y, x)`. The returned `Window` objects are `(col_off, row_off, width, height)` — rasterio `(x, y)`. The function does the swap; you have to pass numpy order in.
+- **`include_incomplete=False` *drops* coverage.** The 12-pixel remainder of the worked example is unread. If you don't want to drop and don't want a small tile, pad the raster first or use `start_negative_if_padding`.
+- **`trim_incomplete` interacts with `boundless`.** Trimmed tiles are smaller than `window_size` — chip batches won't stack. Untrimmed-and-boundless gives uniform shape but allocates padding. Pick consciously.
+- **No CRS / transform involvement.** This module is pure pixel arithmetic. If you want geographic-coordinate tiles (e.g., "tiles aligned to UTM grid lines"), you compute a `figure_out_transform` first and use `bounds_to_windows` ([Chapter 4 §3](04_window_utils.md)) per tile-bbox.
+- **`overlap` argument order matches the dims order.** In `create_windows` it's `(row_overlap, col_overlap)`. In `create_slices` it's `{"y": ..., "x": ...}` — the dict keys make this less ambiguous.
+
+---
+
+## 8. Why this module is small and stays small
+
+`slices.py` is one of the cleanest files in georeader. 404 lines, three public functions, no dependencies beyond `rasterio.windows`. The strategic minimalism is deliberate: tiling is a generator, not a pipeline. The pipeline (read → predict → stitch) is the user's responsibility, composed from this module + `read.py` + `window_utils.py`.
+
+For `geotoolz.sampling`:
+
+- `geotoolz.sampling.GridSampler(chip_size, stride)` is `slices.create_windows(window_size=chip_size, overlap=chip_size-stride, ...)` plus a CRS-aware wrapper if the user wants geographic chip queries.
+- `geotoolz.sampling.RandomSampler` is **not** in this module — random sampling is just `np.random.randint` over the geographic bbox; no tiling structure to share.
+- `geotoolz.sampling.Stitch` lives in [Chapter 4 §9](04_window_utils.md) (`slice_save_for_pred`) — this module gives you the chips, that one tells you how to put predictions back.
+
+Next chapter: [07_griddata.md](07_griddata.md) — irregular-grid interpolation and the geolocation-lookup-table (GLT) pattern. Where the package grows past "rectilinear rasters" into swath sensors like MODIS / PRISMA.

--- a/projects/geotoolz/georeader_tutorial/07_griddata.md
+++ b/projects/geotoolz/georeader_tutorial/07_griddata.md
@@ -1,0 +1,284 @@
+# Chapter 7 — `griddata.py`: irregular-grid interpolation and GLT orthorectification
+
+> **Module:** `georeader/griddata.py` (617 LOC)
+> **Role:** the onramp for **curvilinear sensors** — pushbroom imagers, swath scanners, and any sensor that gives you per-pixel `lons` and `lats` rather than a clean affine transform. Where `read.py` ends and EMIT / PRISMA / EnMAP / MODIS / VIIRS begin.
+
+---
+
+## 1. Why this module exists
+
+Rectilinear rasters (S2, Landsat, Planet) come with an `Affine` transform — six numbers that map pixel `(col, row)` to geographic `(x, y)`. Every function in `read.py` assumes this transform exists.
+
+But many sensors **don't ship that way**. EMIT, PRISMA, EnMAP, MODIS, VIIRS, AVHRR all give you:
+
+- A 3D radiance/reflectance array `(H, W, bands)`.
+- Two 2D coordinate arrays `lons (H, W)` and `lats (H, W)`, **one per pixel**.
+
+There's no transform. Two adjacent pixels in the array don't necessarily map to adjacent points on Earth. Reading a polygon AOI requires either **interpolating** the irregular grid onto a regular one, or **looking up** which sensor pixel each output pixel came from. This module does both.
+
+---
+
+## 2. Irregular vs regular grids
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│   IRREGULAR vs REGULAR GRIDS                                            │
+│                                                                         │
+│   Irregular (Swath/Sensor)           Regular (Orthorectified)           │
+│   ─────────────────────────           ──────────────────────            │
+│                                                                         │
+│       ●  ●   ●  ●                     ┌──┬──┬──┬──┐                     │
+│     ●    ●  ●    ●                    ├──┼──┼──┼──┤                     │
+│      ●   ● ●  ●                       ├──┼──┼──┼──┤                     │
+│    ●   ●    ●   ●                     ├──┼──┼──┼──┤                     │
+│                                       └──┴──┴──┴──┘                     │
+│                                                                         │
+│   Each pixel has unique (lon, lat)    Fixed transform: pixel → geo      │
+│   Spacing varies with scan angle      Uniform spacing, axis-aligned     │
+│   Common in: pushbroom sensors        Required for: GIS, web maps       │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The job of `griddata.py` is to take the left and produce the right — a `GeoTensor` with a real affine transform that the rest of the package can consume.
+
+There are two strategies for doing this:
+
+1. **Interpolation** (`reproject`, `read_to_crs`, `read_reproject_like`) — sample the scattered points onto a regular grid via `scipy.interpolate.griddata`. Works for any sensor that gives you `(lons, lats)` arrays. Slow for large hyperspectral cubes; smooth output.
+2. **GLT lookup** (`georreference`) — apply a precomputed Geolocation Lookup Table that names "for each output pixel, which sensor pixel?" Fast, lossless (no interpolation artefacts), but requires the sensor's product to ship a GLT (NASA EMIT does; PRISMA doesn't).
+
+---
+
+## 3. Interpolation method comparison
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│  INTERPOLATION METHOD COMPARISON                                       │
+│                                                                        │
+│  Method      │ Continuity │ Speed  │ Best For                          │
+│  ────────────┼────────────┼────────┼─────────────────────────────────  │
+│  "nearest"   │ C⁰         │ Fast   │ Categorical data, masks           │
+│  "linear"    │ C⁰         │ Medium │ Simple surfaces, quick preview    │
+│  "cubic"     │ C²         │ Slow   │ Smooth continuous data (default)  │
+│                                                                        │
+│  C⁰ = continuous but not differentiable (may have sharp edges)         │
+│  C² = smooth, twice differentiable (recommended for radiance/refl)     │
+│                                                                        │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+The default is `"cubic"` — Clough-Tocher interpolation on the Delaunay triangulation of the scattered points. C² smoothness matters for hyperspectral retrievals because matched filters and unmixing react badly to discontinuities. The cost: cubic on a ~10⁶-point hyperspectral scene is multi-minute; consider downsampling first if the geometry doesn't need full-res.
+
+`"linear"` is the right default for "I just want to look at it"; `"nearest"` for categorical data (cloud masks, class labels).
+
+---
+
+## 4. GLT — geolocation lookup tables
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│  GLT-BASED ORTHORECTIFICATION                                          │
+│                                                                        │
+│  Sensor Array (irregular)              Output Grid (regular)           │
+│  ┌───────────────────────┐             ┌──┬──┬──┬──┬──┐                │
+│  │  0   1   2   3   ...  │             │  │  │  │  │  │                │
+│  │                       │             ├──┼──┼──┼──┼──┤                │
+│  │ [r,c] = radiance      │     GLT     │  │██│██│  │  │                │
+│  │                       │  ────────►  ├──┼──┼──┼──┼──┤                │
+│  │                       │             │  │██│██│██│  │                │
+│  └───────────────────────┘             └──┴──┴──┴──┴──┘                │
+│                                                                        │
+│  GLT[0, i, j] = column in sensor array                                 │
+│  GLT[1, i, j] = row in sensor array                                    │
+│  output[i, j] = sensor[GLT[1,i,j], GLT[0,i,j]]                         │
+│                                                                        │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+A GLT is a `(2, H_out, W_out)` integer array. Channel 0 holds the source column, channel 1 holds the source row, and each output pixel reads from `data[..., glt[1, i, j], glt[0, i, j]]` — a pure index gather. Invalid pixels (output cells with no source coverage) are marked with `fill_value_default` (typically `-1`).
+
+GLTs are produced **once** by the data provider's processing chain (using the full sensor model — orbital ephemeris, look angles, terrain DEM) and shipped alongside the radiance product. NASA EMIT does this; the EnMAP and PRISMA L1 products instead ship raw lons/lats and require interpolation at consumption time. The structural diagram repeats inside the `georreference` docstring:
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│  GLT ARRAY STRUCTURE                                               │
+│                                                                    │
+│  glt.shape = (2, H_out, W_out)                                     │
+│                                                                    │
+│  glt[0, i, j] = source column (x-index in sensor array)            │
+│  glt[1, i, j] = source row    (y-index in sensor array)            │
+│                                                                    │
+│  For each output pixel (i, j):                                     │
+│    output[..., i, j] = data[..., glt[1,i,j], glt[0,i,j]]           │
+│                                                                    │
+│  ┌──────────────────────┐      ┌──────────────────────┐            │
+│  │    Sensor Array     │       │   Output Grid        │            │
+│  │    (raw data)       │       │   (orthorectified)   │            │
+│  │   ┌───┬───┬───┐     │       │  ┌──┬──┬──┬──┐       │            │
+│  │   │ A │ B │ C │     │       │  │  │ A│ B│  │       │            │
+│  │   ├───┼───┼───┤     │ GLT   │  ├──┼──┼──┼──┤       │            │
+│  │   │ D │ E │ F │  ───────►   │  │  │ D│ E│ F│       │            │
+│  │   ├───┼───┼───┤     │       │  ├──┼──┼──┼──┤       │            │
+│  │   │ G │ H │ I │     │       │  │ G│ H│ I│  │       │            │
+│  │   └───┴───┴───┘     │       │  └──┴──┴──┴──┘       │            │
+│  └──────────────────────┘      └──────────────────────┘            │
+│                                                                    │
+│  GLT handles: terrain distortion, sensor geometry, Earth curvature │
+│  Invalid pixels: glt values = fill_value_default (typically -1)    │
+│                                                                    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The output grid in the diagram has cells that pull from non-adjacent sensor pixels — that's terrain distortion encoded in the GLT. Because it's a pure gather, GLT orthorectification:
+
+- Preserves **exact** sensor pixel values (no interpolation artefacts).
+- Runs at memory-bandwidth speed — a single fancy-index over the band dim.
+- Handles arbitrary geometry (rotation, terrain warp, antimeridian) without special cases.
+
+The trade-off: fixed output grid. If you want a different resolution or CRS than the GLT was built for, you either re-ship the GLT or fall back to interpolation.
+
+---
+
+## 5. The interpolation workflow, step by step
+
+The internal walkthrough lives inside `reproject`'s docstring:
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│  INTERPOLATION WORKFLOW                                            │
+│                                                                    │
+│  1. Flatten inputs                                                 │
+│     data: (H, W, C) → (H×W, C)  [or (H, W) → (H×W,)]               │
+│     lons/lats: (H, W) → (H×W,)                                     │
+│                                                                    │
+│  2. Generate output coordinate grid                                │
+│     meshgrid(transform, width, height) → (xs, ys)                  │
+│     Transform xs, ys from dst_crs to input crs if different        │
+│                                                                    │
+│  3. Call scipy.interpolate.griddata                                │
+│     points = (lons_flat, lats_flat)                                │
+│     values = data_flat                                             │
+│     xi = (xs_grid, ys_grid)                                        │
+│     result = griddata(points, values, xi, method=method)           │
+│                                                                    │
+│  4. Reshape and handle nodata                                      │
+│     Fill NaN regions with fill_value_default                       │
+│     Transpose to (C, H, W) if multi-band                           │
+│                                                                    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+A few details that bite:
+
+- **Step 1 expects `(H, W, C)`, not `(C, H, W)`.** `griddata` is the only entry point in the package that takes channels-last input. The output is transposed back to `(C, H, W)` in step 4. Don't pass a `GeoTensor` directly — strip to `data.values.transpose(1, 2, 0)` first if you have one.
+- **Step 2 inverts directions.** The `meshgrid` call uses `source_crs=dst_crs, dst_crs=crs` — the output grid coordinates need to be expressed in the **input's** CRS so they line up with the `(lons, lats)` arrays. This is why the function also accepts `crs="EPSG:4326"` as the input CRS by default.
+- **Step 3 is the slow one.** `scipy.interpolate.griddata` builds a Delaunay triangulation over `H × W` scattered points and then samples at `width × height` query locations. For a 1000×1000 EMIT scene at full res, that's ~10⁶ triangulation points and ~10⁶ queries. Cubic adds the Clough-Tocher per-triangle solve. Budget 1–10 minutes per scene per band group.
+- **Step 4's NaN handling.** Output pixels outside the convex hull of the input points come back as NaN. The function replaces them with `fill_value_default` (default `-1`). For `boundless`-style behaviour, that's correct; for downstream NaN-aware code, set `fill_value_default=np.nan` explicitly.
+
+---
+
+## 6. The three high-level entry points
+
+All three return a `GeoTensor` with a real affine transform. Pick by what you have on hand:
+
+### `read_to_crs(data, lons, lats, resolution_dst, dst_crs=..., crs="EPSG:4326", method="cubic")`
+
+You have `(data, lons, lats)` and a target resolution. Auto-computes the output bounds (from `footprint(lons, lats)`), the output shape, and a `figure_out_transform`. Default `dst_crs` is the auto-detected UTM zone.
+
+**Use this** for the first orthorectification of a scene with no preferred grid.
+
+### `read_reproject_like(data, lons, lats, data_like, method="cubic", ...)`
+
+You have `(data, lons, lats)` and want the result on **another raster's grid** (e.g., to coregister an EMIT scene with a Sentinel-2 scene). Reads `data_like.transform`, `data_like.crs`, `data_like.shape` and dispatches to `reproject`.
+
+**Use this** when stacking heterogeneous sensors onto a common grid.
+
+### `reproject(data, lons, lats, width, height, transform, dst_crs, crs="EPSG:4326", fill_value_default=-1, method="cubic")`
+
+The full-control entry point. You provide the output grid explicitly. Both wrappers above ultimately call this.
+
+**Use this** for production pipelines where the output grid is fixed by upstream config (e.g., a tile catalog).
+
+There's also `get_shape_transform_crs(lons, lats, resolution_dst, ...)` — the inverse-design helper that `read_to_crs` uses internally. Useful when you want to plan a grid before committing to the slow interpolation step.
+
+---
+
+## 7. The fast path: `georreference(glt, data)`
+
+```python
+georreference(glt: GeoTensor, data: NDArray,
+              valid_glt: Optional[NDArray] = None,
+              fill_value_default: Optional[Union[int, float]] = None) -> GeoTensor
+```
+
+`glt` carries the transform and CRS (because it's a `GeoTensor`); `data` is the raw sensor array. The function:
+
+1. Checks the `valid_glt` mask (or computes it from `glt != fill_value_default`).
+2. Allocates the output array with shape inferred from `glt.shape[1:]` plus `data`'s leading dims.
+3. Issues `output[..., valid_glt] = data[..., glt[1, valid_glt], glt[0, valid_glt]]` — a single fancy-index gather.
+
+Speed scales with output pixel count and band count, not with input scene size. A 285-band EMIT scene orthorectifies in seconds vs minutes for `cubic` interpolation.
+
+Source: [griddata.py:473](../../../../tmp/georeader_src/georeader/griddata.py#L473).
+
+---
+
+## 8. Footprint helper
+
+```python
+footprint(lons: NDArray, lats: NDArray) -> Polygon
+```
+
+Builds a Shapely polygon for an irregular grid. Picks the four extremum points (argmin/argmax of lon and lat in raveled form) and connects them. Approximate — not the actual hull — but fast and good enough for AOI-overlap checks.
+
+For exact hulls use `shapely.MultiPoint(zip(lons.ravel(), lats.ravel())).convex_hull`. The fast version is used inside `read_to_crs` to derive output bounds.
+
+---
+
+## 9. Function reference
+
+| Function | Returns | Use for |
+|---|---|---|
+| `reproject(data, lons, lats, width, height, transform, dst_crs, ...)` | `GeoTensor` | full-control interpolation |
+| `read_to_crs(data, lons, lats, resolution_dst, ...)` | `GeoTensor` | auto-grid interpolation |
+| `read_reproject_like(data, lons, lats, data_like, ...)` | `GeoTensor` | match another raster's grid |
+| `get_shape_transform_crs(lons, lats, resolution_dst, ...)` | `(shape, transform, crs)` | plan before interpolating |
+| `meshgrid(transform, width, height, source_crs=..., dst_crs=...)` | `(xs, ys)` arrays | build query points |
+| `georreference(glt, data, valid_glt=..., fill_value_default=...)` | `GeoTensor` | GLT-based orthorectification |
+| `footprint(lons, lats)` | `Polygon` | quick irregular-grid hull |
+
+`METHOD_DEFAULT = "cubic"` is the module-level default for all interpolation entry points.
+
+---
+
+## 10. Sharp edges
+
+- **`(H, W, C)` channels-last for input data.** The package convention everywhere else is `(C, H, W)`. `griddata.reproject` is the exception. Transpose before, untranspose after — or rely on the EMIT/PRISMA readers in `georeader.readers` which handle this internally.
+- **`fill_value_default = -1` is unusual.** Most of the package uses `0`. The `-1` choice here is to make "outside convex hull" visually obvious. Override if you're feeding the result into something that interprets negative numbers as physical (e.g., reflectance models).
+- **The Delaunay triangulation is built per call.** If you're orthorectifying many bands of the same scene, *don't* call `reproject` per band. Pass the multi-band array; `griddata` builds the triangulation once and queries it for each band internally. This is a 100× speedup.
+- **`lons` and `lats` must be 2D and same-shape as `data`'s spatial dims.** Some sensor products ship them as 1D `(H,)` and `(W,)` axes (rectilinear lat/lon grids that aren't projected); for those, build `lats[:, None] + 0*lons[None, :]` to broadcast to 2D first, or just use `read.read_reproject` which handles the rectilinear case.
+- **NaN inputs propagate through `griddata`.** Mask them out before calling — `griddata` has no `nan_policy`. The function's NaN handling at step 4 is for *out-of-hull* output pixels, not for NaN inputs.
+- **The function's name is `georreference` — note the double 'r'.** It's a typo that's now part of the public API (renaming is a breaking change). Don't fix it locally.
+
+---
+
+## 11. How the curvilinear sensor readers use this module
+
+- **EMIT** (NASA, ISS) — ships a GLT in the L1B product. `georeader.readers.emit.load(...)` calls `georreference(glt, radiance)`. Fast.
+- **PRISMA** (ASI) — ships per-pixel `(lons, lats)` but no GLT. `georeader.readers.prisma.load(...)` calls `read_to_crs(...)`. Slow but unavoidable.
+- **EnMAP** (DLR) — same pattern as PRISMA. Per-pixel coords, interpolation on read.
+- **MODIS, VIIRS** (planned in [`modis.md`](../plans/modis.md)) — same pattern as PRISMA, with extra wrinkles (bowtie pixel duplicates, antimeridian crossing for polar orbits).
+
+The `geotoolz` plan is to keep this division: GLT-equipped sensors get the fast path, everyone else gets cubic interpolation. The `griddata` module is the substrate; the readers are the per-sensor wrappers.
+
+---
+
+## 12. Why this matters for `geotoolz`
+
+Three concrete things downstream:
+
+1. **Hyperspectral operators (matched filter, ACE, RX, unmixing) consume orthorectified `GeoTensor`s.** The interpolation step happens at *read* time, inside the sensor reader. By the time `geotoolz.hyperspectral.MatchedFilter` runs, it's just a `GeoTensor` like any other — the curvilinear-ness is invisible.
+2. **The cost asymmetry shapes the pipeline.** Interpolating a 285-band EMIT scene cubically is minutes. Operators that re-read the scene (e.g., parameter sweeps) should `load()` once and reuse, not ortho-on-demand.
+3. **GLT support is sensor-specific.** A `geotoolz.presets.emit.EMIT_METHANE_MF` preset can rely on the fast GLT path; the equivalent EnMAP/PRISMA preset cannot. This shows up as different default behaviour in those presets — not a bug, a substrate constraint.
+
+Next chapter: [08_mosaic.md](08_mosaic.md) — combining multiple rasters into seamless composites with reprojection and nodata fill.

--- a/projects/geotoolz/georeader_tutorial/07_griddata.md
+++ b/projects/geotoolz/georeader_tutorial/07_griddata.md
@@ -1,4 +1,4 @@
-# Chapter 7 — `griddata.py`: irregular-grid interpolation and GLT orthorectification
+# Ch. 7 — `griddata`
 
 > **Module:** `georeader/griddata.py` (617 LOC)
 > **Role:** the onramp for **curvilinear sensors** — pushbroom imagers, swath scanners, and any sensor that gives you per-pixel `lons` and `lats` rather than a clean affine transform. Where `read.py` ends and EMIT / PRISMA / EnMAP / MODIS / VIIRS begin.
@@ -219,7 +219,7 @@ georreference(glt: GeoTensor, data: NDArray,
 
 Speed scales with output pixel count and band count, not with input scene size. A 285-band EMIT scene orthorectifies in seconds vs minutes for `cubic` interpolation.
 
-Source: [griddata.py:473](../../../../tmp/georeader_src/georeader/griddata.py#L473).
+Source: [griddata.py:473](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/griddata.py#L473).
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/08_mosaic.md
+++ b/projects/geotoolz/georeader_tutorial/08_mosaic.md
@@ -1,4 +1,4 @@
-# Chapter 8 — `mosaic.py`: combining rasters into composites
+# Ch. 8 — `mosaic`
 
 > **Module:** `georeader/mosaic.py` (450 LOC)
 > **Role:** turn N partially-overlapping `GeoData` sources into a single seamless `GeoTensor`. Reprojects, resamples, and fills nodata gaps from later rasters in the list.
@@ -167,7 +167,7 @@ A few non-obvious points:
 - **`resampling=cubic_spline` is the default.** Same caveat as `read.py` — flip to `Resampling.nearest` when mosaicking categorical data (cloud masks, class labels).
 - **The "first raster wins" defaults** (CRS, dtype, nodata) make the call short for "give me everything in raster1's coordinate system." Override only when you have a reason — passing inconsistent dtype across rasters can silently truncate values during the first reproject step.
 
-Source: [mosaic.py:159](../../../../tmp/georeader_src/georeader/mosaic.py#L159).
+Source: [mosaic.py:159](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/mosaic.py#L159).
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/08_mosaic.md
+++ b/projects/geotoolz/georeader_tutorial/08_mosaic.md
@@ -1,0 +1,263 @@
+# Chapter 8 — `mosaic.py`: combining rasters into composites
+
+> **Module:** `georeader/mosaic.py` (450 LOC)
+> **Role:** turn N partially-overlapping `GeoData` sources into a single seamless `GeoTensor`. Reprojects, resamples, and fills nodata gaps from later rasters in the list.
+
+---
+
+## 1. The job
+
+You have a list of rasters and one of these problems:
+
+- **Adjacent scenes with gaps.** Two S2 tiles cover an AOI that straddles a swath edge. Each has a triangular nodata zone where the other has data. You want the union with no gaps.
+- **Cloudy time series.** Three S2 acquisitions of the same scene over a month, each with different clouds. You want a single cloud-free image — pixel by pixel, take the first valid observation.
+- **Heterogeneous mixed sources.** S2 + Landsat covering the same AOI at different resolutions. You want one grid, S2 where available, Landsat to fill gaps.
+
+All three are the same operation underneath: **iterate the list, fill remaining nodata from each subsequent raster.** That's `spatial_mosaic`.
+
+---
+
+## 2. Spatial mosaic — gap filling by precedence
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    SPATIAL MOSAIC CONCEPT                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Input Rasters (with gaps)              Output Mosaic                   │
+│  ─────────────────────────              ─────────────                   │
+│                                                                          │
+│   Raster 1         Raster 2                                             │
+│  ┌─────────┐      ┌─────────┐           ┌─────────────────┐            │
+│  │▓▓▓░░░░░░│      │░░░░░▓▓▓▓│           │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│            │
+│  │▓▓▓▓░░░░░│  +   │░░░░▓▓▓▓▓│    ═══►   │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│            │
+│  │▓▓▓▓▓░░░░│      │░░░▓▓▓▓▓▓│           │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│            │
+│  │░░░░░░░░░│      │░░▓▓▓▓▓▓▓│           │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│            │
+│  └─────────┘      └─────────┘           └─────────────────┘            │
+│                                                                          │
+│   ░ = nodata/gaps                        Gaps filled from               │
+│   ▓ = valid data                         overlapping rasters            │
+│                                                                          │
+│  Processing Order:                                                       │
+│  • First raster fills as much as possible                               │
+│  • Each subsequent raster fills remaining gaps                          │
+│  • Continues until no nodata remains (or list exhausted)                │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The two rules underneath:
+
+1. **Order = priority.** `[A, B, C]` means "use A wherever A is valid; use B where A is nodata but B is valid; use C only where both A and B are nodata."
+2. **Early termination.** If after raster B every pixel is valid, raster C is never read. A user-supplied list of cloud-free fallback scenes pays nothing for the unused tail when the AOI is mostly cloud-free.
+
+This is the `rasterio.merge.merge` shape but with two extras `merge` doesn't have: per-raster validity masks (next section) and arbitrary masking functions (e.g., apply a cloud detector lazily before contributing to the mosaic).
+
+---
+
+## 3. Temporal reduction — many timesteps, one image
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    TEMPORAL REDUCTION CONCEPT                            │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Time Series Input                      Reduction Output                │
+│  ─────────────────                      ────────────────                │
+│                                                                          │
+│   t=1    t=2    t=3                                                     │
+│  ┌───┐  ┌───┐  ┌───┐                   ┌───────────────┐               │
+│  │ 5 │  │ 7 │  │ 6 │                   │               │               │
+│  │   │  │   │  │   │   ─────────────►  │  median = 6   │               │
+│  │   │  │   │  │   │   np.nanmedian    │  mean = 6.0   │               │
+│  └───┘  └───┘  └───┘   np.nanmean      │  max = 7      │               │
+│                                        └───────────────┘               │
+│                                                                          │
+│  Common Reduction Functions:                                            │
+│  • np.nanmedian: Robust to outliers (clouds, shadows)                   │
+│  • np.nanmean: Average value                                            │
+│  • np.nanmax: Maximum composite (e.g., max NDVI)                        │
+│  • np.nanmin: Minimum composite                                         │
+│  • np.nanstd: Temporal variability                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Conceptually different from spatial mosaicking: **every** timestep contributes (subject to nodata), and a reduction (median, mean, max, ...) decides the per-pixel output value.
+
+The module docstring promises a `rasters_reduction(rasters, reducer=np.nanmedian, ...)` function for this. **It isn't implemented in the current module** — only `spatial_mosaic` is exported. See [§8 below](#8-the-implementation-vs-docstring-gap) for what's actually shipped vs documented.
+
+The conceptual reduction recipes are still useful as a reference:
+
+- **`nanmedian`** — robust temporal composite. The standard cloud-free recipe: stack T scenes, mask clouds to NaN, take the per-pixel median across time. Outliers (residual clouds, shadows, snow) bias the mean but barely move the median.
+- **`nanmean`** — when you actually want the average (e.g., monthly mean radiance for an energy-budget paper).
+- **`nanmax`** — max-NDVI compositing. For each pixel, pick the timestep where NDVI was highest. Standard greenness-of-the-year recipe.
+- **`nanmin`** — minimum compositing. Useful for water/wetland detection where the *darkest* observation rejects clouds.
+- **`nanstd`** — temporal variability map. Not a composite but a derived product (where does the scene change a lot?).
+
+---
+
+## 4. Mosaic with masks
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    MASKED MOSAIC WORKFLOW                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Input: (data, mask) tuples                                             │
+│  ─────────────────────────                                              │
+│                                                                          │
+│   Raster 1     Cloud Mask      │    Raster 2     Cloud Mask            │
+│  ┌─────────┐  ┌─────────┐      │   ┌─────────┐  ┌─────────┐            │
+│  │▓▓▓▓▓▓▓▓▓│  │░░░█████░│      │   │▓▓▓▓▓▓▓▓▓│  │░░░░░░░░░│            │
+│  │▓▓▓▓▓▓▓▓▓│  │░░█████░░│      │   │▓▓▓▓▓▓▓▓▓│  │░░░░░░░░░│            │
+│  │▓▓▓▓▓▓▓▓▓│  │░██████░░│   +  │   │▓▓▓▓▓▓▓▓▓│  │░░░░░░░░░│            │
+│  └─────────┘  └─────────┘      │   └─────────┘  └─────────┘            │
+│                   ↑            │                                        │
+│               █ = invalid      │   Uses Raster 2 where Raster 1        │
+│               (cloud/shadow)   │   is masked as invalid                 │
+│                                                                          │
+│  Usage:                                                                  │
+│    data_list = [(raster1, mask1), (raster2, mask2), ...]               │
+│    mosaic = spatial_mosaic(data_list, ...)                             │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`spatial_mosaic` accepts two list shapes:
+
+```python
+spatial_mosaic([reader1, reader2, reader3], ...)              # nodata-only
+spatial_mosaic([(reader1, mask1), (reader2, mask2), ...], ...) # explicit masks
+```
+
+The mask convention: **`True` means invalid** (cloud, shadow, sensor flag set). Invalid pixels are treated like nodata — fall through to the next raster.
+
+There's also a third form via `masking_function`:
+
+```python
+spatial_mosaic([reader1, reader2, reader3], masking_function=detect_clouds, ...)
+```
+
+`masking_function` is called with each `GeoData` and returns a `GeoData` of invalid pixels. The wrapper computes the mask lazily, which avoids materialising mask rasters when the spatial precedence rules out their parent (early termination above).
+
+The masking function is the seam where downstream packages plug in cloud detectors (CloudSEN12, s2cloudless, FMask) without the mosaic module taking a hard dep.
+
+---
+
+## 5. The `spatial_mosaic` signature
+
+```python
+spatial_mosaic(
+    data_list,                    # list[GeoData] | list[(GeoData, GeoData)]
+    polygon=None,                 # output AOI as Shapely polygon
+    crs_polygon=None,
+    dst_transform=None,           # output transform
+    bounds=None,                  # output bbox (alternative to polygon)
+    dst_crs=None,                 # output CRS (defaults to first raster's)
+    dtype_dst=None,               # output dtype (defaults to first raster's)
+    window_size=None,             # tile size for chunked processing
+    resampling=Resampling.cubic_spline,
+    masking_function=None,        # GeoData → invalid-mask GeoData
+    dst_nodata=None,              # output nodata (defaults to first raster's)
+) -> GeoTensor
+```
+
+A few non-obvious points:
+
+- **Output grid is configured via the same triplet as `read_reproject`.** Polygon / bounds + transform / dst_crs + resolution. Pass any consistent subset; `figure_out_transform` ([Chapter 4 §6](04_window_utils.md)) fills in the rest.
+- **`window_size=(h, w)` switches to tiled processing.** For large mosaics that don't fit in RAM, tile through the output grid; for each output tile, call `read_reproject(reader, bounds=tile_bounds)` per input raster. Memory cost is `O(tile_size × n_rasters)`, not `O(output_size)`.
+- **`resampling=cubic_spline` is the default.** Same caveat as `read.py` — flip to `Resampling.nearest` when mosaicking categorical data (cloud masks, class labels).
+- **The "first raster wins" defaults** (CRS, dtype, nodata) make the call short for "give me everything in raster1's coordinate system." Override only when you have a reason — passing inconsistent dtype across rasters can silently truncate values during the first reproject step.
+
+Source: [mosaic.py:159](../../../../tmp/georeader_src/georeader/mosaic.py#L159).
+
+---
+
+## 6. Building cloud-free composites — the canonical recipe
+
+The whole module exists to make this idiomatic:
+
+```python
+# 1. Acquire scenes from a catalog (e.g., a month of S2 over an AOI)
+scenes = [reader_jan_5, reader_jan_12, reader_jan_19, reader_jan_26]
+masks  = [cloudsen12_jan_5, cloudsen12_jan_12, cloudsen12_jan_19, cloudsen12_jan_26]
+
+# 2. Order by quality (least cloudy first)
+ranked = sorted(zip(scenes, masks), key=lambda sm: sm[1].values.mean())
+
+# 3. Mosaic
+composite = mosaic.spatial_mosaic(
+    ranked,
+    polygon=aoi,
+    crs_polygon="EPSG:4326",
+    dst_crs="EPSG:32630",          # output UTM
+)
+```
+
+Key idea: **rank before mosaicking.** The "first raster wins" rule means the order of `data_list` controls per-pixel preference. Ordering by global cloud cover (or by acquisition recency, or by snow score, etc.) makes the composite reflect a quality preference, not just a temporal order.
+
+For temporal reductions that *don't* prefer one timestep — true median compositing — you'd want `rasters_reduction`, which (see next section) isn't actually implemented yet.
+
+---
+
+## 7. Function reference
+
+What's actually exported from this module:
+
+| Function | Status | Notes |
+|---|---|---|
+| `spatial_mosaic` | ✅ implemented | the only public function |
+| `spatial_mosaic_chunked` | ❌ not in source | promised in module docstring |
+| `rasters_reduction` | ❌ not in source | promised in module docstring |
+| `pad_add_rasters` | ❌ not in source | promised in module docstring |
+
+The `window_size=(h, w)` argument on `spatial_mosaic` covers the chunked-processing case that `spatial_mosaic_chunked` would have provided.
+
+---
+
+## 8. The implementation-vs-docstring gap
+
+The module docstring promises four functions; the source defines one. This is worth flagging because:
+
+- If you read the docstring expecting a `rasters_reduction` for temporal compositing, **it doesn't exist**. You'd implement it yourself using `np.nanmedian` over a stacked-time `GeoTensor` (Chapter 1 §9 covers `GeoTensor.stack`).
+- The `pad_add_rasters` helper would have been useful for aligning rasters of different shapes prior to stacking; the workaround is `read_reproject_like` per raster against a common reference.
+
+This is one of the loose ends downstream `geotoolz.compositing` fills in — `MeanComposite`, `MedianComposite`, `MaxNDVIComposite`, `CloudFreeComposite` (the [geotoolz.md plan §1.2](../plans/geotoolz.md)) are the operator-form versions of what the docstring here describes but doesn't implement.
+
+For now, a hand-rolled temporal reduction looks like:
+
+```python
+gts = [read.read_from_polygon(reader, aoi, ...) for reader in readers]    # list of (C, H, W)
+stacked = GeoTensor.stack(gts)                                            # (T, C, H, W)
+median = np.nanmedian(stacked.values, axis=0)                             # (C, H, W) ndarray
+out = GeoTensor(median, transform=stacked.transform, crs=stacked.crs)
+```
+
+That's six lines you'd otherwise expect to be `mosaic.rasters_reduction(readers, reducer=np.nanmedian)`. Worth knowing it isn't there.
+
+---
+
+## 9. Sharp edges
+
+- **First raster's metadata wins.** `dst_crs`, `dtype_dst`, `dst_nodata` all default to the first raster. Mixing dtypes silently truncates; mixing CRS triggers reprojection (correct, but the cost surprises people who didn't realise their list was heterogeneous).
+- **Mask convention is `True = invalid`.** It's the inverse of "valid mask." Easy to get backwards if you're coming from `masked_array` or sklearn.
+- **Default `cubic_spline` resampling.** Flip to `nearest` for categorical mosaics (cloud masks, class labels).
+- **Tile processing (`window_size`) is per-tile complete.** It doesn't stream — each output tile fully reads and reprojects each contributing input tile. Memory bound is per-tile; total compute is the same.
+- **`spatial_mosaic_chunked` / `rasters_reduction` / `pad_add_rasters` aren't implemented.** Don't trust the module docstring's "Module Functions Overview" list. Inspect the source.
+- **No deduplication.** Passing the same reader twice in `data_list` reads it twice. The module doesn't try to detect identity.
+- **Order matters and is silent.** Two cloud-free scenes in `[scene1, scene2]` vs `[scene2, scene1]` produce different mosaics in their overlap region. There's no "blend" mode in the current implementation.
+
+---
+
+## 10. Connection to `geotoolz.compositing`
+
+The [geotoolz.md plan §1.2](../plans/geotoolz.md) lists `compositing` as one of the v0.2 modules with four operators: `MedianComposite`, `MaxNDVIComposite`, `CloudFreeComposite`, `MeanComposite`. Mapping to this module:
+
+| `geotoolz` operator | Maps to `mosaic.spatial_mosaic` how |
+|---|---|
+| `CloudFreeComposite` | direct: list of `(scene, cloud_mask)` tuples, ranked, → `spatial_mosaic` |
+| `MaxNDVIComposite` | not direct: needs the unimplemented `rasters_reduction` with a custom argmax-of-NDVI reducer |
+| `MedianComposite` | not direct: needs `rasters_reduction(reducer=np.nanmedian)` |
+| `MeanComposite` | not direct: needs `rasters_reduction(reducer=np.nanmean)` |
+
+So `geotoolz.compositing` is *partly* a thin wrapper over `spatial_mosaic` and *partly* the missing `rasters_reduction` reimplemented at the operator layer. The implementation gap above means `geotoolz.compositing` will probably ship its own temporal-reduction core rather than depending on this module for it.
+
+Next chapter: [09_rasterize.md](09_rasterize.md) — burning vector geometries into raster grids (the inverse of `vectorize`).

--- a/projects/geotoolz/georeader_tutorial/09_rasterize.md
+++ b/projects/geotoolz/georeader_tutorial/09_rasterize.md
@@ -1,4 +1,4 @@
-# Chapter 9 — `rasterize.py`: vectors → rasters
+# Ch. 9 — `rasterize`
 
 > **Module:** `georeader/rasterize.py` (438 LOC)
 > **Role:** burn vector geometries (polygons, lines, GeoDataFrames) into raster grids aligned to an existing `GeoData`. The standard tool for building masks, segmentation labels, and ROI maps from GIS-flavoured data.

--- a/projects/geotoolz/georeader_tutorial/09_rasterize.md
+++ b/projects/geotoolz/georeader_tutorial/09_rasterize.md
@@ -1,0 +1,210 @@
+# Chapter 9 — `rasterize.py`: vectors → rasters
+
+> **Module:** `georeader/rasterize.py` (438 LOC)
+> **Role:** burn vector geometries (polygons, lines, GeoDataFrames) into raster grids aligned to an existing `GeoData`. The standard tool for building masks, segmentation labels, and ROI maps from GIS-flavoured data.
+
+---
+
+## 1. The job
+
+You have:
+
+- One or more vector geometries (`Polygon`, `MultiPolygon`, `LineString`, or a `GeoDataFrame` with attribute values).
+- A reference raster — `GeoTensor` or `RasterioReader` — whose grid you want the output aligned to.
+
+You want a raster of the same shape and georeferencing as the reference, with **inside-the-geometry** pixels set to a chosen value and outside-the-geometry pixels set to a fill value.
+
+This is what GIS calls "rasterization" or "burning vectors." The implementation underneath is `rasterio.features.rasterize` (which delegates to GDAL); this module wraps it with `GeoData`-aware ergonomics so you don't manually pass transform / shape / dtype every time.
+
+---
+
+## 2. The rasterization process
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    RASTERIZATION PROCESS                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Vector (Polygon)                    Raster (Grid)                      │
+│  ─────────────────                   ─────────────                      │
+│                                                                          │
+│       ╔═══════════╗                  ┌─┬─┬─┬─┬─┬─┬─┬─┐                  │
+│      ╔╝           ╚╗                 │░│░│░│▓│▓│▓│░│░│                  │
+│     ╔╝             ╚╗                ├─┼─┼─┼─┼─┼─┼─┼─┤                  │
+│    ╔╝               ╚╗   ═══════►   │░│░│▓│▓│▓│▓│▓│░│                  │
+│    ║     Polygon     ║   Rasterize  ├─┼─┼─┼─┼─┼─┼─┼─┤                  │
+│    ╚╗               ╔╝               │░│▓│▓│▓│▓│▓│▓│░│                  │
+│     ╚╗             ╔╝                ├─┼─┼─┼─┼─┼─┼─┼─┤                  │
+│      ╚╗           ╔╝                 │░│░│▓│▓│▓│▓│░│░│                  │
+│       ╚═══════════╝                  └─┴─┴─┴─┴─┴─┴─┴─┘                  │
+│                                                                          │
+│  ░ = fill value (outside polygon)                                       │
+│  ▓ = burn value (inside polygon)                                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Two values control the output: `value` (the "burn" value, default `1`) and `fill` (the "outside" value, default `0`). The default produces a binary mask — pass non-binary `value` for class labels (e.g., `value=3` for "this polygon is class 3").
+
+---
+
+## 3. The `all_touched` decision
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              all_touched=False vs all_touched=True                       │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  all_touched=False (default)         all_touched=True                   │
+│  ───────────────────────────         ──────────────────                 │
+│                                                                          │
+│  Only pixels with CENTER inside      ALL pixels that TOUCH the polygon  │
+│                                                                          │
+│  ┌─┬─┬─┬─┬─┬─┐                       ┌─┬─┬─┬─┬─┬─┐                      │
+│  │░│░│░│░│░│░│  ╱ polygon edge       │░│▓│▓│▓│▓│░│                      │
+│  ├─┼─┼─┼─┼─┼─┤ ╱                     ├─┼─┼─┼─┼─┼─┤                      │
+│  │░│░│·│▓│▓│░│╱                      │░│▓│▓│▓│▓│▓│                      │
+│  ├─┼─┼─┼─┼─┼─┤                       ├─┼─┼─┼─┼─┼─┤                      │
+│  │░│░│▓│▓│▓│░│    · = center         │░│▓│▓│▓│▓│░│                      │
+│  └─┴─┴─┴─┴─┴─┘    ▓ = included       └─┴─┴─┴─┴─┴─┘                      │
+│                                                                          │
+│  Best for:                           Best for:                          │
+│  • Area calculations                 • Inclusive masks                   │
+│  • Avoiding edge pixels              • Conservative estimates            │
+│  • Conservative estimates            • Complete coverage                 │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+A pixel that's **half** inside the polygon: include it or not?
+
+- **`all_touched=False`** (default) — include only if the pixel **centre** is inside. Conservative; preserves area; matches GDAL's default. The right choice for area computations and for ML labels where you don't want bordering pixels labelled as belonging to a class their centre isn't in.
+- **`all_touched=True`** — include any pixel the polygon **touches**. Inclusive; over-estimates area; never gaps at boundaries. The right choice for masks where you want **no missing data inside the AOI** — e.g., reading a polygon AOI before doing per-pixel work, where missing edge pixels would bias statistics.
+
+The two modes can produce visibly different masks for thin geometries (lines, narrow polygons). For a `LineString`, `all_touched=False` produces an effectively empty raster (lines have zero area, so no pixel centre is "inside") — you almost always want `all_touched=True` for line rasterization.
+
+---
+
+## 4. GeoDataFrame rasterization with attributes
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              GEODATAFRAME RASTERIZATION                                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  GeoDataFrame:                       Output Raster:                     │
+│  ┌──────────────────────┐            ┌─┬─┬─┬─┬─┬─┬─┬─┐                  │
+│  │ geometry │ class_id  │            │0│0│0│0│0│0│0│0│                  │
+│  ├──────────┼───────────┤            ├─┼─┼─┼─┼─┼─┼─┼─┤                  │
+│  │ Poly A   │    1      │  ══════►   │0│1│1│1│0│2│2│0│                  │
+│  │ Poly B   │    2      │            ├─┼─┼─┼─┼─┼─┼─┼─┤                  │
+│  │ Poly C   │    3      │            │0│1│1│0│0│0│3│0│                  │
+│  └──────────┴───────────┘            └─┴─┴─┴─┴─┴─┴─┴─┘                  │
+│                                                                          │
+│  Usage:                                                                  │
+│    rasterize_geodataframe(gdf, data_like, attribute="class_id")         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Each row contributes a different burn value, taken from the named attribute column. The standard pattern for building **segmentation labels** from GIS-curated training data:
+
+- Column = `class_id` integer per row.
+- `fill=0` so background is class 0.
+- Output dtype determined by the column's dtype (cast to `uint8` if you have ≤ 256 classes).
+
+For overlapping polygons, **last-row wins** — the rasterio default. If your classes have a meaningful precedence (water > vegetation > bare), sort the GeoDataFrame in priority order before passing.
+
+---
+
+## 5. The four functions
+
+The module exports four entry points distinguished by **input** (single geometry vs DataFrame) and **grid spec** (matching another raster vs explicit transform/shape):
+
+| Function | Input | Grid spec | Use for |
+|---|---|---|---|
+| `rasterize_geometry_like(geometry, data_like, value=1, fill=0, ...)` | one Shapely geometry | another `GeoData`'s grid | the common case — make a mask aligned to a raster |
+| `rasterize_from_geometry(geometry, transform, shape, value=1, fill=0, ...)` | one Shapely geometry | explicit `(transform, shape)` | when you don't have a reference raster, only an output grid spec |
+| `rasterize_geopandas_like(dataframe, data_like, column, fill=0, ...)` | `GeoDataFrame` + attribute | another `GeoData`'s grid | building segmentation labels |
+| `rasterize_from_geopandas(dataframe, transform, shape, column, fill=0, ...)` | `GeoDataFrame` + attribute | explicit `(transform, shape)` | DataFrame on a designed grid |
+
+Common kwargs across all four:
+
+- **`crs_geometry` / `crs_dataframe`** — CRS of the input geometry. If different from the raster's CRS, it's reprojected to match before rasterising. Required when crossing CRSs; the function doesn't guess.
+- **`all_touched`** — section 3 above.
+- **`dtype`** — output dtype. Default `uint8` for the binary case; for class-label rasterization, defaults to the column's dtype.
+
+The "`_like`" forms wrap the explicit forms by reading `data_like.transform`, `data_like.crs`, `data_like.shape`, `data_like.dtype`. So in practice you'll use the `_like` forms 95% of the time.
+
+---
+
+## 6. Two idiomatic uses
+
+**Polygon AOI mask, applied to a raster:**
+
+```python
+from shapely.geometry import box
+from georeader import rasterize
+
+aoi_mask = rasterize.rasterize_geometry_like(
+    geometry=box(-122.5, 37.0, -122.0, 37.5),
+    data_like=s2_reader,
+    crs_geometry="EPSG:4326",
+    all_touched=True,             # don't drop edge pixels
+)
+gt = read.read_from_polygon(s2_reader, aoi)
+masked = gt * aoi_mask            # both are GeoTensors with same extent
+```
+
+This is how you go from "I have a Shapely polygon" to "I have a polygon-shaped mask in pixel space" without wiring transform/CRS/shape by hand.
+
+**Segmentation label raster from a labelled GeoJSON:**
+
+```python
+import geopandas as gpd
+gdf = gpd.read_file("labels.geojson")     # has class_id column
+labels = rasterize.rasterize_geopandas_like(
+    dataframe=gdf,
+    data_like=s2_reader,
+    column="class_id",
+    fill=0,
+    all_touched=False,            # match centre-only convention used in training
+)
+# labels.shape == s2_reader.shape[-2:], dtype=uint8
+```
+
+This pairs with whatever `data_like` you read for X — `(s2_image, labels)` is now a coregistered training pair.
+
+---
+
+## 7. The relationship to `window_utils.exterior_pixel_coords`
+
+`rasterize.py` could in principle be implemented purely on top of `window_utils.exterior_pixel_coords` (Chapter 4 §7) — convert polygon vertices to pixel coords, then fill via `cv2.fillPoly` or `skimage.draw.polygon`. The reason this module instead delegates to `rasterio.features.rasterize`:
+
+1. **GDAL handles topology correctly.** Multipolygons with holes, self-intersecting rings, and degenerate edge cases all just work.
+2. **`all_touched` is built in.** Reimplementing the centre-vs-touched distinction correctly across edge cases is annoying; GDAL has done it.
+3. **Multi-geometry batching is natural.** `rasterio.features.rasterize` takes an iterable of `(geom, value)` pairs and burns them in one pass.
+
+The `exterior_pixel_coords` function still has its uses (custom drawing, vertex-level analysis), but for **filling a polygon to a binary or class raster**, this module is the right tool.
+
+---
+
+## 8. Sharp edges
+
+- **`all_touched=False` is the default.** For boolean masks where you want to read everything inside the AOI, you almost always want `all_touched=True`. The default is conservative because it matches GDAL.
+- **Overlapping polygons: last-row wins.** Sort your GeoDataFrame in priority order if classes overlap.
+- **`crs_geometry` is required when CRSs differ.** No "auto-detect from rows" — pass it explicitly. A common bug: WGS84 polygons against a UTM raster, no `crs_geometry`, output is empty because the polygon coordinates are nonsensical in UTM space.
+- **Lines with `all_touched=False` are mostly empty.** Use `True` for `LineString` rasterization.
+- **Dtype matters.** Default `uint8` clips at 255; for segmentation tasks with > 256 classes, pass `dtype=np.uint16` or your column's dtype is silently truncated.
+- **Output is a `GeoTensor`, not a numpy array.** It comes with the reference raster's transform / CRS / fill_value. Ready for arithmetic with sibling `GeoTensor`s without coordinate fiddling.
+- **The shape matches the spatial dims of `data_like`.** If `data_like.shape` is `(C, H, W)`, the rasterised output is `(H, W)` (2D). Multiply with `data_like` and broadcasting handles the band axis.
+
+---
+
+## 9. Connection to `geotoolz`
+
+Two operators in [`geotoolz.md`](../plans/geotoolz.md) lean on this module:
+
+- **`cloud.ApplyMask(mask)`** — when the mask is geometry-shaped (e.g., AOI polygon), `ApplyMask` rasterises before applying. The user passes a `Polygon`, the operator handles the burn.
+- **`catalog_ops.WriteCOG(write_polygon=...)`** — clipping output to a polygon footprint at write time. Rasterise the polygon to a mask, multiply, write.
+
+Beyond those, anywhere users pass a Shapely geometry and need a per-pixel decision, this module is the bridge.
+
+Next chapter: [10_vectorize.md](10_vectorize.md) — the inverse: extracting polygon geometries from binary raster masks (segmentation outputs → GIS-ready vectors).

--- a/projects/geotoolz/georeader_tutorial/10_vectorize.md
+++ b/projects/geotoolz/georeader_tutorial/10_vectorize.md
@@ -1,4 +1,4 @@
-# Chapter 10 — `vectorize.py`: rasters → vectors
+# Ch. 10 — `vectorize`
 
 > **Module:** `georeader/vectorize.py` (370 LOC)
 > **Role:** the inverse of [Chapter 9](09_rasterize.md). Extract polygon geometries from binary raster masks. Standard tool for converting segmentation outputs and classification rasters back to GIS-friendly vector formats.
@@ -155,7 +155,7 @@ The post-processing helper for when you already have a polygon and want to:
 - **Apply an affine** (e.g., the polygon came from `get_polygons(..., transform=None)` and you now have a transform).
 - **Reproject between CRSs** (e.g., raster is UTM, you want WGS84 polygons for a GeoJSON).
 
-Source: [vectorize.py:271](../../../../tmp/georeader_src/georeader/vectorize.py#L271).
+Source: [vectorize.py:271](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/vectorize.py#L271).
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/10_vectorize.md
+++ b/projects/geotoolz/georeader_tutorial/10_vectorize.md
@@ -1,0 +1,226 @@
+# Chapter 10 — `vectorize.py`: rasters → vectors
+
+> **Module:** `georeader/vectorize.py` (370 LOC)
+> **Role:** the inverse of [Chapter 9](09_rasterize.md). Extract polygon geometries from binary raster masks. Standard tool for converting segmentation outputs and classification rasters back to GIS-friendly vector formats.
+
+---
+
+## 1. The job
+
+You have a binary (or thresholded) raster — typically the output of a CNN segmentation, a cloud detector, or a classified scene. You want a list of Shapely `Polygon`s in CRS coordinates, suitable for:
+
+- Writing to GeoJSON / Shapefile / GeoParquet for downstream GIS work.
+- Computing per-region statistics (area, perimeter, intersection with other vectors).
+- Counting / filtering objects (e.g., "how many flood polygons larger than 1 km²?").
+- Overlaying on a basemap with `lonboard` / Leaflet / QGIS.
+
+Underneath this is `rasterio.features.shapes` (which delegates to GDAL's polygonization). This module wraps it with three on-by-default ergonomics: small-polygon filtering, vertex simplification, and polygon buffering.
+
+---
+
+## 2. The vectorization process
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    VECTORIZATION PROCESS                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Raster (Binary Mask)                Vector (Polygons)                  │
+│  ────────────────────                ─────────────────                  │
+│                                                                          │
+│  ┌─┬─┬─┬─┬─┬─┬─┬─┐                       ╔═══════════╗                  │
+│  │0│0│0│1│1│1│0│0│                      ╔╝           ╚╗                 │
+│  ├─┼─┼─┼─┼─┼─┼─┼─┤                     ╔╝             ╚╗                │
+│  │0│0│1│1│1│1│1│0│   ═══════════►     ╔╝               ╚╗               │
+│  ├─┼─┼─┼─┼─┼─┼─┼─┤   Vectorize        ║    Polygon 1    ║               │
+│  │0│1│1│1│1│1│1│0│                    ╚╗               ╔╝               │
+│  ├─┼─┼─┼─┼─┼─┼─┼─┤                     ╚╗             ╔╝                │
+│  │0│0│1│1│1│1│0│0│                      ╚╗           ╔╝                 │
+│  └─┴─┴─┴─┴─┴─┴─┴─┘                       ╚═══════════╝                  │
+│                                                                          │
+│  1 = foreground (vectorized)                                            │
+│  0 = background (ignored)                                               │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Every connected component of `1`-valued pixels becomes one polygon. The polygon traces the **outside** edge of the foreground pixels — so a 3×3 patch of `1`s becomes a polygon enclosing 9 pixel squares (perimeter ≈ 12 pixels), not a single point.
+
+For multi-class rasters, threshold or mask first: `vectorize` is fundamentally a binary operation. To extract per-class polygons from a label raster, loop:
+
+```python
+polygons_per_class = {
+    c: get_polygons(labels == c, ...) for c in np.unique(labels)
+}
+```
+
+---
+
+## 3. Polygon simplification
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              POLYGON SIMPLIFICATION (tolerance parameter)                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Raw (pixelated)              Simplified (tolerance=1)                  │
+│  ────────────────              ──────────────────────                   │
+│                                                                          │
+│  ┌─┐                                ╭───────╮                            │
+│  │ └─┐                             ╱         ╲                           │
+│  │   └─┐                          ╱           ╲                          │
+│  │     └─┐   ────────────►       │             │    Fewer vertices,     │
+│  │       │   simplify            │             │    smoother edges      │
+│  │     ┌─┘                        ╲           ╱                          │
+│  │   ┌─┘                           ╲         ╱                           │
+│  └───┘                              ╰───────╯                            │
+│                                                                          │
+│  tolerance=0: Keep all vertices (staircase pattern)                     │
+│  tolerance=1: Simplify ~1 pixel tolerance (DEFAULT)                     │
+│  tolerance>1: More aggressive simplification                            │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Without simplification, a polygon traces every pixel boundary — a 100×100 region produces ~400 vertices forming a staircase pattern. That's both visually ugly and storage-expensive.
+
+`tolerance` is the Douglas-Peucker simplification distance, in **pixels**. Default `1.0` collapses single-pixel jaggies into smooth edges while preserving features ≥ 1 pixel. Larger values smooth more aggressively at the cost of accuracy:
+
+| `tolerance` | What you get |
+|---|---|
+| `0` | Exact pixel boundaries (staircase). Use when downstream consumers expect rasterise round-trip equality. |
+| `1.0` (default) | One-pixel smoothing. Visually clean while preserving ≥ 1 pixel features. |
+| `2.0–5.0` | Aggressive smoothing for visualisation. Loses fine-grained shape detail. |
+| `> 10` | Bounding-box-like simplification. Suitable only for index/preview purposes. |
+
+The simplification happens after vectorization, in pixel coordinates, before applying the affine transform. So `tolerance=1` always means "1 pixel" regardless of CRS or resolution.
+
+---
+
+## 4. Polygon filtering
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    POLYGON FILTERING                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Parameters:                                                             │
+│  ───────────                                                             │
+│                                                                          │
+│  min_area=25.5 (default)    Remove polygons smaller than ~5x5 pixels    │
+│                             Helps filter noise and artifacts             │
+│                                                                          │
+│  polygon_buffer=0           Buffer/erode polygons by N pixels           │
+│                             Positive: expand                             │
+│                             Negative: shrink (erode)                     │
+│                                                                          │
+│  Before (min_area=0):                After (min_area=25):               │
+│  ┌────────────────────┐              ┌────────────────────┐             │
+│  │  ■   ┌───────┐     │              │      ┌───────┐     │             │
+│  │ ■ ■  │       │  ■  │   ═══════►   │      │       │     │             │
+│  │      │       │     │   Filter     │      │       │     │             │
+│  │ ■    └───────┘     │              │      └───────┘     │             │
+│  └────────────────────┘              └────────────────────┘             │
+│     ↑ small polygons removed                                            │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Two filters layered onto the basic extraction:
+
+- **`min_area`** — drop any polygon whose area is below this threshold. Units are **pixels** (so `25.5` ≈ a 5×5 pixel square; the `.5` accounts for the typical pixel-centre adjustment). Crucial for noise removal: CNN segmentations often emit single-pixel false positives, and the default `25.5` filters them at very low cost. For large-scale work where every commission error matters, raise to 100 or 1000.
+- **`polygon_buffer`** — apply a shapely buffer in pixel units. Positive value expands each polygon (closes small gaps, merges nearby objects); negative value erodes (shrinks; can split a polygon into pieces or eliminate thin features). `polygon_buffer=-1` is the standard "shrink by one pixel to avoid edge inclusivity" trick.
+
+Order of operations: vectorize → buffer → simplify → filter by min_area. So the area filter applies to the *final* simplified geometry, not the raw extraction.
+
+---
+
+## 5. The two functions
+
+| Function | Returns | What it does |
+|---|---|---|
+| `get_polygons(binary_mask, min_area=25.5, polygon_buffer=0, tolerance=1.0, transform=None)` | `list[Polygon]` | the workhorse — see below |
+| `transform_polygon(polygon, transform=None, src_crs=None, dst_crs=None)` | `Polygon` / `MultiPolygon` | apply an affine transform and/or reproject between CRSs |
+
+### `get_polygons(binary_mask, ...)`
+
+Accepts either a numpy array or a `GeoData` (`GeoTensor` / `RasterioReader`).
+
+- **If `binary_mask` is a `GeoData`** — the function reads `.transform` and uses it to convert pixel-coordinate polygons to CRS-coordinate polygons. The output Polygons are georeferenced.
+- **If `binary_mask` is a plain ndarray** — output Polygons are in pixel coordinates, **unless** you pass `transform=` explicitly. In which case they're in CRS coords.
+
+This duck-typing on input is the killer convenience: pipe a CNN's `(H, W)` numpy output and a transform together, get georeferenced polygons. No manual `polygon_to_crs` round-trip.
+
+### `transform_polygon(polygon, ...)`
+
+The post-processing helper for when you already have a polygon and want to:
+
+- **Apply an affine** (e.g., the polygon came from `get_polygons(..., transform=None)` and you now have a transform).
+- **Reproject between CRSs** (e.g., raster is UTM, you want WGS84 polygons for a GeoJSON).
+
+Source: [vectorize.py:271](../../../../tmp/georeader_src/georeader/vectorize.py#L271).
+
+---
+
+## 6. The standard CNN-output-to-vectors recipe
+
+```python
+import numpy as np
+from georeader import vectorize
+
+# 1. CNN prediction on a GeoTensor input — you get back logits or probs
+probs = model(s2_gt.values)               # (H, W) float32, ndarray
+mask = probs > 0.5                        # (H, W) bool
+
+# 2. Wrap in a GeoTensor so transform tags along
+mask_gt = s2_gt.array_as_geotensor(mask)  # (H, W) bool GeoTensor
+
+# 3. Vectorize with sensible defaults
+polygons = vectorize.get_polygons(
+    mask_gt,
+    min_area=100,            # 10×10 pixel min — drops noise
+    tolerance=1.0,           # one-pixel smoothing
+    polygon_buffer=0,
+)
+
+# 4. Persist
+import geopandas as gpd
+gdf = gpd.GeoDataFrame(geometry=polygons, crs=s2_gt.crs)
+gdf.to_file("flood_polygons.geojson", driver="GeoJSON")
+```
+
+Five lines for the whole "CNN prediction → georeferenced vector layer" pipeline. The `array_as_geotensor` step (Chapter 1 §10) is what makes the final polygons georeferenced — without it you'd be in pixel coords.
+
+---
+
+## 7. The rasterize ↔ vectorize round trip
+
+`rasterize` and `vectorize` are conceptually inverses, but **they are not exactly invertible**. Three sources of asymmetry:
+
+1. **Rasterization quantises** — every pixel either is or isn't in the polygon. After `rasterize → vectorize`, you get a polygon traced along pixel boundaries (a staircase) rather than the original smooth shape.
+2. **`tolerance > 0` smooths**. Round-tripping through `vectorize(tolerance=1)` then `rasterize` will not exactly match the original raster.
+3. **`min_area` drops content**. Small features below the threshold are gone for good after `vectorize → rasterize`.
+
+For applications that need exact round-trips (e.g., test fixtures), pass `tolerance=0, min_area=0, polygon_buffer=0`. The output will have full vertex counts (large) and exact pixel boundaries.
+
+---
+
+## 8. Sharp edges
+
+- **`min_area` units are pixels, not CRS area.** A `min_area=25` means 25 pixels regardless of resolution. If you want "1 km² minimum" on a 10m raster, that's `100*100 = 10000` pixels.
+- **`polygon_buffer` units are pixels too.** Same caveat.
+- **`tolerance=0` produces large polygons.** Every pixel boundary becomes a vertex. A flood-mapping output across a city can produce polygons with 100k+ vertices each; downstream tools (especially leaflet) will choke. Default `tolerance=1` is correct in nearly all cases.
+- **The function only vectorizes `True` pixels.** For multi-class rasters, threshold or split per-class first.
+- **A `MultiPolygon` is returned as multiple `Polygon`s.** `get_polygons` doesn't preserve multipolygon grouping — disconnected components are separate list entries even if the source mask had them as part of the same logical region.
+- **Plain ndarray + no `transform` → pixel-coordinate output.** Easy to forget; the polygons look "off-by-1000-orders-of-magnitude wrong" when you plot them on a map. Either pass `transform=` or wrap as a `GeoTensor` first.
+- **GeoJSON expects WGS84 (`EPSG:4326`).** The polygons come out in the source raster's CRS. Use `transform_polygon(p, src_crs=..., dst_crs="EPSG:4326")` before exporting if your raster wasn't already WGS84.
+
+---
+
+## 9. Connection to `geotoolz`
+
+Two operators in [`geotoolz.md`](../plans/geotoolz.md) wrap this module:
+
+- **`postprocess.PolygonsFromMask(min_area=..., tolerance=...)`** — a terminal operator that converts the final `(H, W)` boolean output of a `Sequential` to a list of polygons. Useful as the last step of a `[Sequential(model + threshold + PolygonsFromMask)]` pipeline.
+- **`catalog_ops.WriteGeoJSON(...)`** — write polygons (with optional attributes) to disk per-tile during catalog processing. Internal call: `get_polygons(...)` + `gpd.GeoDataFrame(...)` + `to_file(...)`.
+
+These complete the "raster ML pipeline → GIS-ready output" loop without users touching rasterio or geopandas directly.
+
+Next chapter: [11_reflectance.md](11_reflectance.md) — the radiometry / spectral-response-function module (971 LOC, 97 box-drawing chars; the third densest in the package).

--- a/projects/geotoolz/georeader_tutorial/11_reflectance.md
+++ b/projects/geotoolz/georeader_tutorial/11_reflectance.md
@@ -1,0 +1,303 @@
+# Chapter 11 — `reflectance.py`: radiometry, SRFs, and irradiance
+
+> **Module:** `georeader/reflectance.py` (971 LOC, 97 box-drawing characters — third densest in the package)
+> **Role:** convert satellite imagery between physically meaningful radiometric quantities — radiance, top-of-atmosphere (ToA) reflectance, and band-integrated irradiance. Where the package crosses from "geospatial bookkeeping" into actual physics.
+
+---
+
+## 1. The job
+
+Satellite imagery is delivered in any of three radiometric units depending on the sensor / processing level:
+
+- **Digital numbers (DN)** — raw counts, sensor-specific, dimensionless. You almost never want to work with these.
+- **Radiance (L)** — `W / m² / sr / nm` — the actual photon flux hitting the sensor, per unit area, per unit solid angle, per wavelength. Physical, directly comparable across sensors *if* you know the geometry.
+- **Top-of-atmosphere reflectance (ρ)** — dimensionless, typically ∈ `[0, 1]` — the fraction of incoming solar radiation that the surface reflected back, **before** atmospheric correction. The starting point for most ML pipelines because it normalises out solar-illumination effects (sun angle, Earth-sun distance).
+
+This module provides:
+
+- The **conversion** between the three (`radiance_to_reflectance` / `reflectance_to_radiance`).
+- The **geometric corrections** that go into them (Earth-sun distance, solar zenith angle).
+- The **spectral integration** that maps hyperspectral radiance to multispectral bands via spectral response functions (SRFs).
+- A **bundled solar spectrum** (Thuillier 2003) used as the default `E_sun(λ)`.
+
+---
+
+## 2. Unit conversion overview
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    RADIOMETRIC UNIT CONVERSION FLOW                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│   Raw DN ──────►  Radiance ──────────────────────────►  Reflectance     │
+│   (counts)        (W/m²/sr/nm)                          (unitless 0-1)  │
+│                                                                         │
+│   Supported radiance units:                                             │
+│   ┌────────────────────────────────────────────────────────────────┐    │
+│   │  Unit              │  Factor to W/m²/sr/nm                     │    │
+│   ├────────────────────┼───────────────────────────────────────────┤    │
+│   │  W/m²/sr/nm        │  1.0         (no conversion)              │    │
+│   │  mW/m²/sr/nm       │  ÷ 1000      (milli → base)               │    │
+│   │  µW/cm²/sr/nm      │  ÷ 100       (micro/cm² → base/m²)        │    │
+│   └────────────────────┴───────────────────────────────────────────┘    │
+│                                                                         │
+│   Solar Irradiance: W/m²/nm or mW/m²/nm (at TOA, perpendicular)         │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The DN→radiance step is **sensor-specific** (linear scale + offset from per-band calibration coefficients) and lives inside the per-sensor reader, not this module. Once you have radiance, this module handles the rest.
+
+The three supported radiance unit systems all ship in real-world products:
+
+- `W/m²/sr/nm` — Sentinel-2 L1C after applying the calibration coefficients.
+- `mW/m²/sr/nm` — common in legacy products, factor of 1000 larger.
+- `µW/cm²/SR/nm` — the EMIT and PRISMA standard, factor of 100 larger than SI base.
+
+The function takes a `units=` string and applies the conversion internally, so user code stays in whatever units the sensor delivered.
+
+---
+
+## 3. The reflectance equation
+
+The ToA reflectance formula:
+
+```text
+ρ = (π × d² × L) / (E_sun × cos(θ_z))
+
+where:
+- L      = at-sensor radiance (W/m²/sr/nm)
+- E_sun  = solar irradiance at TOA (W/m²/nm)
+- d      = Earth-Sun distance in AU (varies ~3% annually)
+- θ_z    = solar zenith angle (0° = Sun overhead)
+```
+
+Three corrections combined:
+
+- **`π`** — convert from solid-angle-aware radiance to a Lambertian-equivalent reflectance.
+- **`d²`** — Earth-sun distance correction. Earth's orbit is elliptical; in January (perihelion) we're closer to the Sun and get more incoming radiation than in July (aphelion).
+- **`cos(θ_z)`** — solar zenith correction. When the Sun is low in the sky, the same surface element intercepts less radiation per unit horizontal area.
+
+The module factors them into `obfactor = π × d² / cos(θ_z)` — `observation_date_correction_factor` — so the reflectance line collapses to `ρ = L × obfactor / E_sun`.
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  UNIT CONVERSION FLOW                                            │
+│                                                                   │
+│  Input radiance        Normalized radiance      Output           │
+│  (various units)   →   (W/m²/sr/nm)         →   reflectance     │
+│                                                                   │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │ Input Unit       │ factor_div │ Conversion                  │ │
+│  ├──────────────────┼────────────┼─────────────────────────────┤ │
+│  │ W/m²/sr/nm       │ 1          │ No conversion               │ │
+│  │ mW/m²/sr/nm      │ 1000       │ ×10⁻³ (milli → base)       │ │
+│  │ µW/cm²/sr/nm     │ 100        │ ×10⁻⁶×10⁴ = ×10⁻²         │ │
+│  └──────────────────┴────────────┴─────────────────────────────┘ │
+│                                                                   │
+│  Final calculation:                                              │
+│                                                                   │
+│  L [W/m²/sr/nm] × obfactor [sr⁻¹] / E_sun [W/m²/nm]            │
+│  = dimensionless reflectance                                     │
+│                                                                   │
+│  Note: The steradian cancels with implicit assumptions about     │
+│  the solar disk's solid angle as seen from Earth.               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Earth-sun distance
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│       Earth-Sun Distance Throughout the Year                       │
+│                                                                    │
+│  Distance   ▲                                                      │
+│  (AU)       │     Aphelion (~July 4)                               │
+│             │          ╭───────╮                                   │
+│  1.017 ─────┼─────────╱         ╲─────────────────────────         │
+│             │        ╱           ╲                                 │
+│  1.000 ─────┼───────╱─────────────╲──────────────────────          │
+│             │      ╱               ╲                               │
+│  0.983 ─────┼─────╱─────────────────╲────────────────────          │
+│             │    ╱    Perihelion     ╲                             │
+│             │   ╱     (~Jan 3)        ╲                            │
+│             └───┴──────────────────────┴────────────────► Day      │
+│                 0    91   182   273   365                          │
+│                Jan  Apr   Jul   Oct   Jan                          │
+│                                                                    │
+│  d = 1 - 0.01673 × cos(0.0172 × (day_of_year - 4))                 │
+│                                                                    │
+│  Impact: ~6.5% variation in irradiance (d² factor)                 │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The annual ≈ ±1.7% variation in distance becomes ≈ ±3.4% in `d²` and therefore ≈ 6.5% peak-to-peak in irradiance over the year. **Ignoring this correction biases reflectance time series**: you'd see a fake annual cycle of ~3% amplitude with peaks in the Northern winter (smaller `d`, more apparent radiance, higher uncorrected reflectance).
+
+The closed-form expression `d = 1 - 0.01673 × cos(0.0172 × (DOY − 4))` is what `earth_sun_distance_correction_factor(date_of_acquisition)` returns. It's accurate to ~0.001 AU — well below the precision needed for radiometric calibration.
+
+---
+
+## 5. Spectral response functions
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  Spectral Response Function Convolution                          │
+│                                                                   │
+│  Hyperspectral               SRF for Band X             Result   │
+│  Radiance L(λ)               R(λ)                       L_X     │
+│                                                                   │
+│  L(λ)│     ╱╲                R(λ)│   ╱╲                         │
+│      │    ╱  ╲╱╲╱╲              │  ╱  ╲                         │
+│      │   ╱        ╲             │ ╱    ╲                        │
+│      │  ╱          ╲            │╱      ╲                       │
+│      └──────────────── λ        └──────────── λ                 │
+│            400-2500 nm              λ_center ± FWHM/2            │
+│                                                                   │
+│  Integration:  L_X = ∫ L(λ) × R(λ) dλ  /  ∫ R(λ) dλ             │
+│                                                                   │
+│  The SRF is typically Gaussian:                                  │
+│  R(λ) = exp(-(λ - λ_center)² / (2σ²))                           │
+│  where σ = FWHM / (2 × √(2 × ln(2))) ≈ FWHM / 2.355             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+When you want to take a hyperspectral measurement (~285 narrow bands) and turn it into a multispectral measurement (~12 wide bands matching another sensor's bands), you **integrate** the hyperspectral spectrum against the target sensor's per-band SRF.
+
+Two functions own this:
+
+- **`srf(center_wavelengths, fwhm, wavelengths)`** — build a Gaussian SRF DataFrame from per-band centre/FWHM specs. Returns shape `(N_wavelengths, K_bands)` normalized so each column sums to 1.
+- **`transform_to_srf(hyperspectral_data, srf, wavelengths)`** — apply the SRF: produce a `(K_bands, H, W)` multispectral cube from a `(N_wavelengths, H, W)` hyperspectral cube.
+
+Why Gaussian? Most published SRFs are well-approximated by Gaussians, and Gaussian SRFs are uniquely specified by `(centre, FWHM)`. The exact published SRFs (S2, Landsat, etc.) tend to have ~1% non-Gaussian deviations; for most ML applications the difference doesn't matter, but for radiative-transfer studies you'd want to use the exact published curves rather than a Gaussian approximation.
+
+The `2 × √(2 × ln(2)) ≈ 2.355` constant in the formula is the FWHM-to-σ ratio for a Gaussian — comes up again in any "spread parameter" discussion.
+
+---
+
+## 6. Band-integrated irradiance
+
+```text
+┌────────────────────────────────────────────────────────────────┐
+│  Spectral Integration Process                                   │
+│                                                                  │
+│  E_sun(λ)          R(λ)               E_sun(λ) × R(λ)          │
+│  (Solar)           (SRF)              (Product)                 │
+│                                                                  │
+│    │╲              │ ╱╲                 │  ╱╲                   │
+│    │ ╲╲            │╱  ╲                │ ╱  ╲                  │
+│    │  ╲╲╲          │    ╲               │╱    ╲                 │
+│    │   ╲╲╲╲        │     ╲              │      ╲                │
+│    └────────λ      └──────λ            └────────λ              │
+│                                         ████████ ← Area = E_k  │
+│                                                                  │
+│  Solar spectrum   Band response    Weighted → integrate & norm  │
+│  (~200-2500 nm)   (Gaussian)       gives band-effective E_sun   │
+└────────────────────────────────────────────────────────────────┘
+```
+
+Reflectance computation needs `E_sun` **per band** — a single number that summarises the solar spectrum as seen by that band's SRF. The closed-form:
+
+```
+E_k = ∫ E_sun(λ) × R_k(λ) dλ  /  ∫ R_k(λ) dλ
+```
+
+`integrated_irradiance(srf, solar_irradiance=None, epsilon_srf=1e-4)` computes the integral per band. If `solar_irradiance=None`, it loads the **Thuillier (2003) reference spectrum** bundled with the package as `SolarIrradiance_Thuillier.csv` (Solar Physics 214). The Thuillier spectrum covers 200–2400 nm at ~1 nm resolution — fine enough for any current orbital sensor.
+
+The `epsilon_srf` threshold zeroes out SRF values below a tiny floor — important because Gaussian SRFs technically extend forever, and the integration would otherwise pick up out-of-band noise in `E_sun(λ)`.
+
+`load_thuillier_irradiance()` returns the cached DataFrame with columns `["Nanometer", "Radiance(mW/m2/nm)"]`. The `THUILLIER_RADIANCE = None` module-level cache means it's loaded lazily on first use.
+
+---
+
+## 7. The function reference
+
+**Conversion**
+- `radiance_to_reflectance(data, solar_irradiance, date_of_acquisition=None, center_coords=None, crs_coords=None, observation_date_corr_factor=None, units="W/m2/sr/nm")` → `GeoTensor`
+- `reflectance_to_radiance(data, solar_irradiance, ..., units="W/m2/sr/nm")` → `GeoTensor` — exact inverse
+
+**Geometric correction factors**
+- `earth_sun_distance_correction_factor(date_of_acquisition: datetime) → float` (returns `d`, not `d²`)
+- `compute_sza(center_coords, date_of_acquisition, crs_coords=None) → float` (degrees)
+- `observation_date_correction_factor(center_coords, date_of_acquisition, crs_coords=None) → float` (combined `π × d² / cos(θ_z)`)
+
+**Spectral integration**
+- `srf(center_wavelengths, fwhm, wavelengths) → NDArray` — build Gaussian SRF
+- `integrated_irradiance(srf, solar_irradiance=None, epsilon_srf=1e-4) → NDArray` — band-integrated E_sun
+- `transform_to_srf(hyperspectral_data, srf, wavelengths) → GeoTensor / NDArray` — apply SRF to a hyperspectral cube
+
+**Solar reference spectrum**
+- `load_thuillier_irradiance() → pd.DataFrame` — load and cache Thuillier (2003)
+- `THUILLIER_RADIANCE` — module-level cache (None until first load)
+
+---
+
+## 8. Two idiomatic uses
+
+**A. Sentinel-2 DN → reflectance (already calibrated; needs only TOA correction):**
+
+```python
+# Suppose s2_radiance is a (B, H, W) GeoTensor in W/m²/sr/nm
+import datetime as dt
+toa_refl = reflectance.radiance_to_reflectance(
+    data=s2_radiance,
+    solar_irradiance=esun_per_band,            # (B,) array of W/m²/nm
+    date_of_acquisition=dt.datetime(2024, 6, 15, 10, 30, tzinfo=dt.timezone.utc),
+    units="W/m2/sr/nm",
+)
+# toa_refl is a (B, H, W) GeoTensor in [0, 1]
+```
+
+The `solar_irradiance` argument is what lets you specialise to *any* sensor — pass S2's per-band `E_sun` for S2, Landsat's for Landsat. The reader for each sensor typically ships these constants as a module-level array.
+
+**B. Hyperspectral EMIT → S2-equivalent multispectral:**
+
+```python
+# emit_radiance: (285, H, W) hyperspectral cube; wavelengths: (285,) array
+# Build S2 SRF (12 bands) at EMIT wavelengths
+s2_centers = np.array([443, 490, 560, 665, 705, 740, 783, 842, 865, 945, 1610, 2190])
+s2_fwhm    = np.array([20,  65,  35,  30,  15,  15,  20,  115, 20,  20,  90,   180])
+s2_srf = reflectance.srf(s2_centers, s2_fwhm, wavelengths=emit_wavelengths)
+
+# Apply
+s2_equivalent = reflectance.transform_to_srf(emit_radiance, s2_srf, wavelengths=emit_wavelengths)
+# s2_equivalent: (12, H, W) — EMIT data convolved into S2-shaped bands
+
+# Per-band irradiance for the new bands
+s2_E = reflectance.integrated_irradiance(pd.DataFrame(s2_srf, index=emit_wavelengths))
+```
+
+This is the "spectral response binning" preset that the [`geotoolz.md` plan](../plans/geotoolz.md) mentions for `presets.enmap.ENMAP_TO_S2_BANDS` — same pattern, applied to EnMAP data.
+
+---
+
+## 9. Sharp edges
+
+- **`solar_irradiance` units must be `W/m²/nm`, not `mW/m²/nm`.** Even when the input radiance is in mW units. The function normalises radiance internally; it does not normalise the solar input. Mismatched scaling here is the most common bug, off by a factor of 1000.
+- **`center_coords` for solar zenith.** If `data` is a `GeoTensor`, the function can derive scene centre from `transform`. If it's a plain ndarray, you must pass `center_coords` explicitly. Forgetting this with a non-GeoTensor input gives a silent mis-correction.
+- **`crs_coords` defaults to EPSG:4326.** If your `center_coords` are in UTM, pass `crs_coords="EPSG:32630"` (or whichever zone). Otherwise the SZA computation places your scene at lon=500000, lat=4500000 — somewhere in deep space.
+- **`observation_date_corr_factor` shortcut.** Pass it pre-computed and the function skips date and centre coords. Useful for batched processing where you've calibrated `obfactor` once and want to apply it to N tiles cheaply.
+- **Thuillier is in `mW/m²/nm`, not `W/m²/nm`.** Read the column name. If you pass it directly as `solar_irradiance` to `radiance_to_reflectance`, you'll be off by 1000.
+- **`integrated_irradiance` returns same units as input solar spectrum.** Mixing Thuillier (`mW`) with a band-integrated value used as `W` argument is the dominant unit confusion. Convert explicitly.
+- **`srf(center, fwhm, wavelengths)` doesn't normalise to unit area.** The `transform_to_srf` and `integrated_irradiance` functions do their own normalisation internally, but if you take the SRF DataFrame and use it elsewhere you may need to divide by `np.trapz(R, wavelengths)`.
+
+---
+
+## 10. Why this module is denser than its size
+
+971 LOC, 97 box-drawing characters — the third densest in the package because **physics requires illustration**. The Earth-sun distance plot, the SRF convolution diagram, and the integration visual are doing real explanatory work that prose alone wouldn't. If you only keep one chapter's diagrams from this whole tutorial, this is one of the candidates — they're the ones that explain the *why* not just the *what*.
+
+---
+
+## 11. Connection to `geotoolz`
+
+Three concrete operator-shapes from [`geotoolz.md`](../plans/geotoolz.md) wrap functions in this module:
+
+- **`correction.TOAToBOA(sun_zenith=..., atmosphere=...)`** — wraps `radiance_to_reflectance` plus an atmospheric correction step. The radiance→ToA part is what this module already does.
+- **`radiometry.SRFBin(target_centres, target_fwhm)`** — wraps `srf` + `transform_to_srf` to take a hyperspectral cube and bin it to a target sensor's bands. The basis for the `EnMAP → S2` and `EMIT → S2` preset operators.
+- **`presets.s2.S2_L1C_TO_BOA_NDVI(...)`** — a `Sequential` that includes `radiance_to_reflectance` as one of its steps when starting from L1A radiance products.
+
+The module is also implicitly used inside `readers.emit`, `readers.prisma`, and `readers.enmap` — those readers do DN → radiance internally (per their per-sensor calibration coefficients) and expose the radiance-units result. The reflectance step is then a one-line call to this module.
+
+Next chapter: [12_save.md](12_save.md) — writing GeoTensors to disk; full Cloud-Optimized GeoTIFF (COG) anatomy.

--- a/projects/geotoolz/georeader_tutorial/11_reflectance.md
+++ b/projects/geotoolz/georeader_tutorial/11_reflectance.md
@@ -1,4 +1,4 @@
-# Chapter 11 — `reflectance.py`: radiometry, SRFs, and irradiance
+# Ch. 11 — `reflectance`
 
 > **Module:** `georeader/reflectance.py` (971 LOC, 97 box-drawing characters — third densest in the package)
 > **Role:** convert satellite imagery between physically meaningful radiometric quantities — radiance, top-of-atmosphere (ToA) reflectance, and band-integrated irradiance. Where the package crosses from "geospatial bookkeeping" into actual physics.

--- a/projects/geotoolz/georeader_tutorial/12_save.md
+++ b/projects/geotoolz/georeader_tutorial/12_save.md
@@ -189,7 +189,7 @@ save.save_cog(
 )
 ```
 
-**Stream a large lazy reader to cloud storage without ever materialising in full:**
+**Save a lazy reader to cloud storage:**
 
 ```python
 save.save_cog(
@@ -198,7 +198,7 @@ save.save_cog(
 )
 ```
 
-The function does call `.load()` internally (step 1 of section 4), so this still allocates the full array briefly — the "without ever materialising" claim above is wrong as the module currently stands. For genuinely streaming I/O on truly huge files, fall back to manually iterating windows and calling `dataset.write(window=...)` per chunk.
+`save_cog` calls `data_save.load()` internally (step 1 of section 4), so the full scene is materialised in memory before the file is written and uploaded. This is fine for scenes that fit in RAM; for genuinely huge scenes that don't, this function is the wrong tool — use a manual window-loop pattern instead, opening the destination dataset with `rasterio.open(path, "w", **profile)` and calling `dataset.write(arr, window=...)` per chunk so that no buffer ever holds the full output.
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/12_save.md
+++ b/projects/geotoolz/georeader_tutorial/12_save.md
@@ -1,0 +1,235 @@
+# Chapter 12 — `save.py`: writing GeoTensors to disk and to COGs
+
+> **Module:** `georeader/save.py` (586 LOC; the empty `save_cog.py` is a deprecated stub)
+> **Role:** the export side. Take a `GeoTensor` (or anything `GeoData`-shaped), write it to disk as a tiled GeoTIFF or a Cloud-Optimized GeoTIFF (COG). Handles cloud-storage destinations (`gs://`, `s3://`, `az://`) transparently.
+
+---
+
+## 1. Why COGs
+
+A traditional GeoTIFF stores data as a single big image, with the header at the *end* of the file. To read any part of it you need to first download enough bytes to find the header, then seek into the data. Over HTTP this is awful — you pay for the round-trip on every read.
+
+A Cloud Optimized GeoTIFF (COG) reorganises the same byte stream so:
+
+- The **header lives at the start**. A few KB of HTTP range-read tells you everything about the file.
+- Data is **tiled** (default 256×256 blocks). To read one tile you fetch one tile's bytes — not the whole file.
+- **Overviews** (decimated pyramid layers — 2×, 4×, 8× downsampled copies) are interleaved at the start. Want a thumbnail? Read overview 8 — a tiny number of bytes.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│              CLOUD OPTIMIZED GEOTIFF STRUCTURE                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Traditional GeoTIFF            Cloud Optimized GeoTIFF (COG)           │
+│  ────────────────────           ─────────────────────────────           │
+│                                                                          │
+│  ┌─────────────────┐            ┌─────────────────┐                     │
+│  │ Header (end)    │            │ Header (start)  │ ← HTTP range 0-N   │
+│  │                 │            │ ─────────────── │                     │
+│  │                 │            │ Overview 8x     │ ← Pyramid layers   │
+│  │    Full        │            │ Overview 4x     │   for fast zoom    │
+│  │    Resolution  │            │ Overview 2x     │                     │
+│  │    Data        │            │ ─────────────── │                     │
+│  │                 │            │ ┌───┬───┬───┐  │ ← Tiled structure  │
+│  │                 │            │ │256│256│256│  │   (default 256x256)│
+│  │                 │            │ ├───┼───┼───┤  │                     │
+│  │                 │            │ │256│256│256│  │                     │
+│  └─────────────────┘            │ └───┴───┴───┘  │                     │
+│                                 └─────────────────┘                     │
+│                                                                          │
+│  Benefits:                                                               │
+│  • Read any region without downloading whole file                       │
+│  • Fast preview via overviews (pyramid layers)                          │
+│  • Efficient streaming for web mapping applications                     │
+│  • Compatible with all GeoTIFF readers                                  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The cost: COG files are slightly larger than minimal GeoTIFFs (overviews add ~33% on top of full resolution). The benefit: for any file you'll touch over HTTP, COG is transformative — `RasterioReader("https://...cog.tif")` becomes interactive.
+
+The practical rule: **save everything as COG by default unless you have a reason not to**.
+
+---
+
+## 2. Compression options
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    COMPRESSION RECOMMENDATIONS                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Compression    Best For                    Speed    Size                │
+│  ───────────    ────────                    ─────    ────                │
+│  lzw           General purpose (DEFAULT)    Fast     Medium             │
+│  deflate       Better compression ratio     Medium   Small              │
+│  zstd          Modern, fast + small         Fast     Small              │
+│  lzma          Maximum compression          Slow     Smallest           │
+│  jpeg          RGB imagery (lossy)          Fast     Tiny               │
+│  webp          RGB imagery (lossy/lossless) Fast     Tiny               │
+│  none          Already compressed data      N/A      Original           │
+│                                                                          │
+│  For scientific data: Use lzw or zstd (lossless)                        │
+│  For visualization: Consider jpeg or webp (lossy ok)                    │
+│  For integer masks: Use deflate with predictor=2                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The package default is **`lzw`** — a sensible "fast and lossless" choice that's universally supported by GeoTIFF readers (going back decades). Three other choices show up often:
+
+- **`zstd`** — modern, faster than lzw, smaller files. Recommended whenever your downstream readers support it (rasterio + GDAL ≥ 3.0 do; older proprietary tools may not). Probably the best default for new projects.
+- **`deflate` with `predictor=2`** — ideal for integer masks and class-label rasters. The predictor encodes pixel-to-pixel differences before deflate, giving 5–10× better ratios on data that varies smoothly.
+- **`jpeg` / `webp`** — *lossy*. Use only for visualisation outputs where you don't care about exact pixel values. Never for ML training data.
+
+Override via `profile_arg={"compress": "zstd"}`.
+
+---
+
+## 3. Data type mapping
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│  NumPy dtype     GeoTIFF dtype    Notes                                 │
+│  ────────────    ─────────────    ─────                                 │
+│  uint8           Byte             8-bit unsigned (0-255)                │
+│  uint16          UInt16           16-bit unsigned (0-65535)             │
+│  int16           Int16            16-bit signed                         │
+│  uint32          UInt32           32-bit unsigned                       │
+│  int32           Int32            32-bit signed                         │
+│  float32         Float32          32-bit floating point                 │
+│  float64         Float64          64-bit floating point                 │
+│  complex64       CFloat32         Complex 32-bit                        │
+│  bool            Byte             Converted to 0/1                      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The `bool → Byte` conversion is the only sneaky one — booleans are written as `uint8` `{0, 1}` because GeoTIFF has no boolean type. Reading them back gives a `uint8` array, and you'd usually `> 0` to convert it back to bool. The `validmask`/`invalidmask` `GeoTensor` properties (Chapter 1) are aware of this.
+
+`profile_from_dtype(dtype)` gives you the rasterio profile dict for any of these — used internally by `save_cog`.
+
+---
+
+## 4. The two save functions
+
+### `save_cog(data_save, path_tiff_save, descriptions=None, tags=None, profile_arg=None, ...)`
+
+The standard export. Steps:
+
+1. Materialise `data_save` to an in-memory ndarray (calls `.load()` if it's a reader).
+2. Build a profile from the dtype + the COG defaults (LZW, 256×256 blocks, BIGTIFF if needed).
+3. Apply user-supplied `profile_arg` overrides.
+4. Write a tiled GeoTIFF.
+5. Build overviews via `rasterio.rio.overview` (powers of 2 down to ≤256 pixels).
+6. **Reorganise** the file via `rasterio_shutil.copy(..., COG_DRIVER)` so the header and overviews land at the start.
+
+The two-pass approach (write, then reorganise) is what GDAL's COG driver does internally — this module just orchestrates it via rasterio.
+
+### `save_tiled_geotiff(data_save, path_tiff_save, ...)`
+
+The "no overviews" variant. Same profile, same compression, same tiling, but skips the overview-building and reorganisation steps. Cheaper to write; you can't preview at low res over HTTP. Use when:
+
+- Output is already a tile of a larger product and the consumer never zooms.
+- You're producing intermediate files that get re-read locally.
+- You'll add overviews later via `gdaladdo` once the file is finalised.
+
+Source: [save.py:163 (`save_tiled_geotiff`)](../../../../tmp/georeader_src/georeader/save.py#L163), [save.py:327 (`save_cog`)](../../../../tmp/georeader_src/georeader/save.py#L327).
+
+---
+
+## 5. Cloud destinations
+
+`save_cog("gs://bucket/key.tif", ...)` works. The implementation:
+
+- Detects the prefix (`gs://`, `s3://`, `az://`, `abfs://`, `oss://`, `http://`, `https://`).
+- Writes locally to a temp file.
+- Uploads via fsspec (or a user-supplied `fs` filesystem object) once writing is complete.
+- Cleans up the temp file.
+
+The constant `REMOTE_FILE_EXTENSIONS` at the top of the module is the prefix list. Extending support to a new cloud (`oss://` etc.) is mostly a one-line addition there + ensuring the right fsspec backend is installed.
+
+For HTTP destinations, the upload phase requires a destination that accepts PUTs (presigned S3 URLs work; static HTTP URLs do not). Most "I want to write to https://..." workflows mean "actually I want to write to s3://, then serve via https://" — pass the `s3://` URL.
+
+The `fs` parameter is the escape hatch for custom auth: pass `fs=gcsfs.GCSFileSystem(token=...)` to use a non-default credential.
+
+---
+
+## 6. The signature
+
+```python
+save_cog(
+    data_save,                          # GeoData (GeoTensor or RasterioReader)
+    path_tiff_save,                     # str — local path or gs://, s3://, etc.
+    descriptions=None,                  # list[str] — per-band names
+    tags=None,                          # dict[str, str] — file-level metadata
+    profile_arg=None,                   # dict — overrides the default profile
+    fs=None,                            # fsspec filesystem for cloud writes
+    nodata=None,                        # override fill_value_default
+)
+```
+
+A few non-obvious points:
+
+- **`descriptions`** maps to `rasterio`'s per-band `descriptions` field — visible in `gdalinfo`, used by some viewers as the band-picker label. Highly recommended (`["Red", "Green", "Blue"]` etc.) for any file you ship.
+- **`tags`** is file-level GDAL metadata, written into the GeoTIFF's GDAL_METADATA tag. Use for provenance: `{"source": "Sentinel-2", "date": "2024-01-15", "processing": "ndvi"}`. Survives round-trip through `RasterioReader.tags()`.
+- **`profile_arg={"compress": "zstd", "predictor": 2}`** is the override hatch. The full list of COG-relevant profile keys: `compress`, `blockxsize`, `blockysize`, `predictor`, `BIGTIFF`, `TILED`, `COPY_SRC_OVERVIEWS`.
+- **`nodata=None`** means "use `data_save.fill_value_default`". Pass explicitly when your output should have a different nodata than the input (e.g., `nodata=255` for a uint8 mask).
+
+---
+
+## 7. Idiomatic usage
+
+**Save an in-memory `GeoTensor` as a COG with band names and provenance:**
+
+```python
+save.save_cog(
+    ndvi_gt,
+    "output/ndvi_2024_06.tif",
+    descriptions=["NDVI"],
+    tags={"source": "S2_L2A", "tile": "T29SND", "date": "2024-06-15"},
+    profile_arg={"compress": "zstd"},
+)
+```
+
+**Stream a large lazy reader to cloud storage without ever materialising in full:**
+
+```python
+save.save_cog(
+    rasterio_reader_for_huge_scene,
+    "gs://bucket/output.tif",
+)
+```
+
+The function does call `.load()` internally (step 1 of section 4), so this still allocates the full array briefly — the "without ever materialising" claim above is wrong as the module currently stands. For genuinely streaming I/O on truly huge files, fall back to manually iterating windows and calling `dataset.write(window=...)` per chunk.
+
+---
+
+## 8. Internal helpers worth knowing
+
+- **`_add_overviews(rst_out, tile_size, verbose=False)`** — iterates over decimation factors (2, 4, 8, 16, ...) and stops once an overview would be ≤ `tile_size`. Public-internal: it's prefixed with `_` but stable.
+- **`_save_cog(out_np, path_tiff_save, profile, ...)`** — the actual write step. Takes a numpy array (already materialised) and a complete rasterio profile. Used by `save_cog` after step 1.
+- **`PROFILE_TILED_GEOTIFF_DEFAULT`** — module-level dict. The defaults: `lzw` compress, `BIGTIFF=IF_SAFER`, 256×256 blocks. Inspect or override via `profile_arg`.
+- **`BLOCKSIZE_DEFAULT = 256`** — module-level constant. Change at module level if your downstream tools want different blocking; pass via `profile_arg` per call otherwise.
+
+---
+
+## 9. Sharp edges
+
+- **`save_cog` materialises in memory.** Don't use it for files that won't fit. Use `save_tiled_geotiff` with windowed writes via rasterio directly for stream-write scenarios.
+- **Nodata for floating-point.** Default nodata of 0 is wrong for float reflectance (0 is a valid dark pixel). Pass `nodata=np.nan` or use a per-band sentinel like `-9999`.
+- **`bool` arrays write as `uint8`.** Round-trip gives uint8; cast with `.astype(bool)` after read if you need bool semantics.
+- **Big-endian and signed-byte exotica aren't supported.** The dtype mapping only covers what numpy + GeoTIFF agree on. If you have weird dtypes, cast first.
+- **`COPY_SRC_OVERVIEWS` doesn't apply here.** That GDAL flag is for *copying* an existing file's overviews; this module always builds them fresh.
+- **Cloud writes are atomic at the destination.** The temp-file-then-upload pattern means partial writes don't appear at the destination URL. But a crash mid-upload leaves the temp file orphaned in `/tmp`.
+- **The `save_cog.py` file in the package is empty.** It's a placeholder kept around for backwards-import-compatibility. The real code is in `save.py`.
+
+---
+
+## 10. Connection to `geotoolz`
+
+Two `geotoolz` operators wrap this module:
+
+- **`catalog_ops.WriteCOG(path_template="...")`** — a terminal Operator. Takes a `GeoTensor` from upstream, formats `path_template` with metadata from the catalog row, calls `save.save_cog(...)`. The `path_template="{tile_id}_{date}.tif"` form lets `Sequential` pipelines write per-tile outputs to deterministic filenames.
+- **`presets.s2.S2_L2A_NDVI(...)`** — implicitly uses `save_cog` if the user passes a `path` argument; otherwise returns an in-memory `GeoTensor`.
+
+The empty `save_cog.py` file alongside `save.py` is the back-compat stub from when `save_cog` lived in its own module. Don't import from it; use `from georeader.save import save_cog` (or the package-level re-export from `__init__.py`).
+
+Next chapter: [13_misc_io.md](13_misc_io.md) — the smaller utility modules (`io.py`, `dataarray.py`, `plot.py`).

--- a/projects/geotoolz/georeader_tutorial/12_save.md
+++ b/projects/geotoolz/georeader_tutorial/12_save.md
@@ -1,4 +1,4 @@
-# Chapter 12 — `save.py`: writing GeoTensors to disk and to COGs
+# Ch. 12 — `save`
 
 > **Module:** `georeader/save.py` (586 LOC; the empty `save_cog.py` is a deprecated stub)
 > **Role:** the export side. Take a `GeoTensor` (or anything `GeoData`-shaped), write it to disk as a tiled GeoTIFF or a Cloud-Optimized GeoTIFF (COG). Handles cloud-storage destinations (`gs://`, `s3://`, `az://`) transparently.
@@ -131,7 +131,7 @@ The "no overviews" variant. Same profile, same compression, same tiling, but ski
 - You're producing intermediate files that get re-read locally.
 - You'll add overviews later via `gdaladdo` once the file is finalised.
 
-Source: [save.py:163 (`save_tiled_geotiff`)](../../../../tmp/georeader_src/georeader/save.py#L163), [save.py:327 (`save_cog`)](../../../../tmp/georeader_src/georeader/save.py#L327).
+Source: [save.py:163 (`save_tiled_geotiff`)](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/save.py#L163), [save.py:327 (`save_cog`)](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/save.py#L327).
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/13_misc_io.md
+++ b/projects/geotoolz/georeader_tutorial/13_misc_io.md
@@ -1,4 +1,4 @@
-# Chapter 13 — `io.py`, `dataarray.py`, `plot.py`: smaller utilities
+# Ch. 13 — utilities
 
 > **Modules:**
 > - `georeader/io.py` (113 LOC) — NetCDF safe-open

--- a/projects/geotoolz/georeader_tutorial/13_misc_io.md
+++ b/projects/geotoolz/georeader_tutorial/13_misc_io.md
@@ -1,0 +1,145 @@
+# Chapter 13 — `io.py`, `dataarray.py`, `plot.py`: smaller utilities
+
+> **Modules:**
+> - `georeader/io.py` (113 LOC) — NetCDF safe-open
+> - `georeader/dataarray.py` (145 LOC) — xarray bridge
+> - `georeader/plot.py` (336 LOC) — matplotlib helpers
+> **Role:** the connective tissue. Each module is small, focused, and invisible until you need it.
+> **Diagrams:** none. These files don't have ASCII art — they're pure utility code.
+
+---
+
+## 1. `io.py` — NetCDF backend roulette
+
+The whole module is one helper plus one URL-detector:
+
+- **`is_url(path) → bool`** — `True` for paths starting with `http://`, `https://`, `ftp://`. Used elsewhere in the package to decide between local and VSI access.
+- **`safe_open_netcdf(file_path_or_object, cache=False, load=True, group=None, **kwargs) → xr.Dataset`** — open a NetCDF file by trying multiple xarray engines until one succeeds.
+
+### Why "safe" open exists
+
+NetCDF has three on-disk formats (NetCDF3, NetCDF4/HDF5, NetCDF-Java) and xarray has three backends (`scipy`, `h5netcdf`, `netcdf4`) with overlapping but not identical support. Different sensor providers ship different formats, and a backend that handles one will fail on another with cryptic errors.
+
+`safe_open_netcdf` cycles through engines in a sensible order until one works:
+
+| Input type | Engine order |
+|---|---|
+| Remote URL (OPeNDAP) | `netcdf4` only (the others don't support remote) |
+| Local file or file-like object | `h5netcdf` → `scipy` → `netcdf4` |
+
+`h5netcdf` is tried first for local files because it's typically faster than `netcdf4` and handles HDF5 well; `scipy` second because it's small and self-contained; `netcdf4` last because it's the most comprehensive but heaviest dep.
+
+### Sharp edges
+
+- **`load=True` by default**, meaning the entire dataset is read into memory. For multi-GB EMIT NetCDFs you almost always want `load=False` and lazy slicing via xarray.
+- **The function eats errors per-engine** and only raises `IOError` if all engines fail. Debug with `logging.getLogger("georeader.io").setLevel(logging.DEBUG)`.
+- **File-like objects need `.seek(0)`** support — the function tries to rewind between engines, but some streams (e.g., raw HTTP responses) can't be rewound. Pass a `BytesIO` wrapper if you have to retry.
+- **`group=` is honoured** — for hierarchical NetCDFs (EMIT, EnMAP) where the data lives in a sub-group like `"location"` or `"sensor_band_parameters"`. Most readers in `georeader.readers.emit` etc. already pass the right group internally.
+
+This is the function that makes the EMIT / PRISMA / EnMAP readers work cleanly across providers without users worrying about which library wraps which format.
+
+---
+
+## 2. `dataarray.py` — the xarray bridge
+
+Four functions that translate between `GeoTensor` and `xr.DataArray`. This is the substrate seam between georeader and `xr_toolz` (the climate-side sibling library — see [`geotoolz.md` §10](../plans/geotoolz.md)).
+
+### The four functions
+
+- **`coords_to_transform(coords, x_axis_name="x", y_axis_name="y") → rasterio.Affine`** — given an xarray coordinates object with `x` and `y` axes, infer the affine transform. Inverse of `xr.open_rasterio`'s coord computation. Useful when reading a NetCDF or Zarr that has lon/lat coords but no transform metadata.
+- **`getcoords_from_transform_shape(transform, shape, x_axis_name="x", y_axis_name="y") → dict`** — the forward direction. Given a transform and a `(H, W)` shape, build coordinate arrays placed at pixel centres (`+ 0.5` offset). Asserts `transform.is_rectilinear` because rotated transforms can't be expressed as simple 1D coord arrays.
+- **`toDataArray(x: GeoTensor, x_axis_name="x", y_axis_name="y", extra_coords=None) → xr.DataArray`** — `GeoTensor` → `xr.DataArray`. Builds coords from the transform, attaches `attrs={"crs": ..., "fill_value_default": ...}`, optionally adds `extra_coords` for non-spatial dims (e.g., `{"time": dates_array}`).
+- **`fromDataArray(x: xr.DataArray, crs=None, ...) → GeoTensor`** — the inverse. Reads the `crs` from the DataArray's attrs (or from `crs=` argument as override), computes transform from `coords`, returns a `GeoTensor`.
+
+### Why this matters
+
+The whole point of having both `geotoolz` (RS substrate) and `xr_toolz` (climate substrate) as separate libraries is that **`georeader` is the bridge**. A workflow that reads with georeader, runs a climate analysis in xr_toolz, and writes back via georeader looks like:
+
+```python
+gt = georeader.read_from_bounds(reader, bounds=AOI)
+da = georeader.dataarray.toDataArray(gt)            # GeoTensor → DataArray
+result_da = xr_toolz.detrend.RemoveClimatology(clim)(da)
+result_gt = georeader.dataarray.fromDataArray(result_da)  # back to GeoTensor
+georeader.save_cog(result_gt, "/out/result.tif")
+```
+
+Five lines, no metadata loss. The conversion is cheap (it's just rebuilding coord arrays, no data copy if you're careful with `.values`).
+
+### Sharp edges
+
+- **`is_rectilinear` is required.** Rotated transforms can't be expressed as 1D x and y coordinate arrays. For rotated rasters you'd have to convert to a regular grid first (Chapter 7, `griddata`).
+- **xarray's coord convention is pixel-centre.** The `+ 0.5` in `getcoords_from_transform_shape` is the pixel-centre vs pixel-edge convention. Forgetting this in custom code drifts the coord by half a pixel.
+- **CRS round-trip via `attrs`.** xarray doesn't have a first-class CRS concept; `toDataArray` stuffs it in `da.attrs["crs"]`. Other libraries (rioxarray, cf-xarray) use different conventions. If a downstream consumer expects rioxarray's `da.rio.crs`, an extra translation step is needed.
+- **`fromDataArray` defaults to `crs=None`.** It pulls from `attrs["crs"]` if present; otherwise raises. Pass `crs=` explicitly when reading from sources that don't carry CRS metadata.
+- **xarray is an optional dep.** This module fails to import if xarray isn't installed. Users without an xarray pipeline never need to touch this module.
+
+---
+
+## 3. `plot.py` — matplotlib helpers
+
+Four functions for visualising geospatial data with matplotlib:
+
+| Function | What it does |
+|---|---|
+| `show(data, add_colorbar_next_to=False, ...)` | Display a `GeoTensor` / `RasterioReader` on an axis with proper extent + georeferencing |
+| `add_shape_to_plot(shape, ax=None, ...)` | Overlay Shapely geometries / GeoDataFrames |
+| `plot_segmentation_mask(mask, color_array=None, ...)` | Discrete-class raster with categorical colormap and legend |
+| `colorbar_next_to(im, ax, fig=None, ...)` | Attach a colorbar that doesn't squeeze the main axis |
+
+### `show(data, ...)`
+
+The workhorse. Reads the GeoData's transform and bounds, calls `ax.imshow(data.values.transpose(1, 2, 0))` for RGB or `ax.imshow(data.values)` for single-band, sets the extent so axis ticks display in geographic coordinates, optionally adds a colorbar via `colorbar_next_to`.
+
+Used in the README quickstart:
+
+```python
+plot.show((gt_rgb / 3500).clip(0, 1))
+```
+
+The `/3500` and `.clip(0, 1)` are because S2 reflectance values are stored as int16 with a scale factor of 10000, and a viewable RGB needs floats in `[0, 1]`. Note this still uses `GeoTensor` arithmetic — the clipped result has the same transform/CRS, so the axis ticks are correct geo coords.
+
+### `add_shape_to_plot(shape, ax=None, ...)`
+
+Accept `Polygon`, `MultiPolygon`, list of geometries, or `GeoDataFrame`. Draws on the supplied axis or `plt.gca()`. Reprojects the geometry to the axis's CRS if needed (via the `crs_geometry=` arg). The standard "draw the AOI on top of the imagery" pattern.
+
+### `plot_segmentation_mask(mask, color_array=None, ...)`
+
+Class-label rasters need a categorical colormap and a legend, not a continuous colorbar. This function:
+
+1. Converts the integer label raster to RGB using `color_array` (or a sensible default palette).
+2. Adds a legend with one entry per class.
+3. Handles nodata transparency.
+
+Useful for showing CNN segmentation outputs in notebooks.
+
+### `colorbar_next_to(im, ax, fig=None, ...)`
+
+The "don't squeeze the main axis" colorbar. Uses `mpl_toolkits.axes_grid1.make_axes_locatable` to allocate a thin axis to the right of the main one, sized in the same proportion as the figure. Standard matplotlib idiom that never quite works on the first try; this packages it.
+
+### Sharp edges
+
+- **`show` reads the entire data into memory.** Calls `data.load()` if it's a reader. For large rasters, downsample first via `read.resize` or read from an overview level (Chapter 3 §8).
+- **RGB ordering is `(C, H, W)` → matplotlib's `(H, W, C)`.** The function does the transpose; user code that bypasses `show` and does `ax.imshow(gt.values)` directly will get the wrong shape.
+- **Tick labels are in the source CRS.** If you want lat/lon ticks on a UTM-projected raster, reproject first (Chapter 5 §4).
+- **No interactive zoom optimisation.** This is a static-figure module. For interactive maps use `lonboard` / `leafmap` against the COG-on-disk ([Chapter 12](12_save.md)).
+- **Matplotlib is a hard import.** Unlike xarray, no `try/except`. Importing `georeader.plot` requires matplotlib to be installed.
+
+---
+
+## 4. Why these three are grouped here
+
+None of `io`, `dataarray`, `plot` carry the architectural weight of the modules in Parts I–IV. They're small, single-purpose, and you reach for them when you need them rather than designing pipelines around them. Grouping into one chapter avoids three thin chapters with little to say.
+
+The pattern they share: **delegate to a well-maintained external library, paper over the sharp edges that come up in real RS workflows.** `safe_open_netcdf` papers over the engine-format mismatch; `to/fromDataArray` papers over the xarray-vs-rasterio metadata convention gap; `show` papers over the matplotlib boilerplate for georeferenced display.
+
+---
+
+## 5. Connection to `geotoolz`
+
+These three modules don't have direct `geotoolz` operators wrapping them, but each shows up indirectly:
+
+- **`io.safe_open_netcdf`** — used inside the curvilinear-sensor readers (EMIT, PRISMA, EnMAP). When `geotoolz.presets.emit.EMIT_METHANE_MF` runs `georeader.readers.emit.load(scene_path)`, it's `safe_open_netcdf` underneath.
+- **`dataarray.toDataArray` / `fromDataArray`** — the `geotoolz`/`xr_toolz` substrate-bridge example in [`geotoolz.md` §10.4](../plans/geotoolz.md) is literally these two functions. They keep the libraries decoupled while still letting users compose pipelines across substrates.
+- **`plot.show`** — `geotoolz.radiometry` viz operators (`PercentileClip → Gamma → MinMax → S2_L2A_RGB`) produce visualisation-shaped `GeoTensor`s; the natural last step is `plot.show(...)` for inline display in notebooks.
+
+Next chapter: [14_sentinel2.md](14_sentinel2.md) — the Sentinel-2 SAFE reader (1845 LOC, the largest single file in the package).

--- a/projects/geotoolz/georeader_tutorial/14_sentinel2.md
+++ b/projects/geotoolz/georeader_tutorial/14_sentinel2.md
@@ -1,4 +1,4 @@
-# Chapter 14 — `readers/S2_SAFE_reader.py`: Sentinel-2 SAFE products
+# Ch. 14 — Sentinel-2
 
 > **Module:** `georeader/readers/S2_SAFE_reader.py` (1845 LOC — the largest file in the package)
 > **Role:** read Sentinel-2 imagery in the official SAFE product format. Both Level-1C (top-of-atmosphere reflectance) and Level-2A (atmospherically-corrected surface reflectance) are supported, from local folders or Google Cloud's free public bucket.
@@ -104,19 +104,19 @@ S2Image                    # base class — do not instantiate directly
 └── S2ImageL2A             # L2A-specific: SCL band, no B10
 ```
 
-`S2Image` lives at [S2_SAFE_reader.py:295](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L295). It implements the `GeoData` protocol (Chapter 2 §3) plus S2-specific machinery:
+`S2Image` lives at [S2_SAFE_reader.py:295](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L295). It implements the `GeoData` protocol (Chapter 2 §3) plus S2-specific machinery:
 
 - Granule discovery: walking the SAFE folder to find per-band JP2 paths.
 - Multi-resolution band alignment: each band has its native resolution; `out_res=` selects the output grid and bands at other native resolutions get resampled internally.
 - XML metadata parsing for sun/view angles, processing baseline, and per-band offsets.
 - Window focus delegation: `set_window` propagates to all underlying `RasterioReader`s for each JP2.
 
-`S2ImageL1C` ([S2_SAFE_reader.py:1000](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1000)) adds:
+`S2ImageL1C` ([S2_SAFE_reader.py:1000](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1000)) adds:
 
 - The B10 cirrus band.
-- DN-to-radiance conversion via `DN_to_radiance(s2obj, dn_data)` ([S2_SAFE_reader.py:1534](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1534)) — uses the per-band `solar_irradiance` and `quantification_value` constants from `MTD_MSIL1C.xml`.
+- DN-to-radiance conversion via `DN_to_radiance(s2obj, dn_data)` ([S2_SAFE_reader.py:1534](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1534)) — uses the per-band `solar_irradiance` and `quantification_value` constants from `MTD_MSIL1C.xml`.
 
-`S2ImageL2A` ([S2_SAFE_reader.py:918](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L918)) adds:
+`S2ImageL2A` ([S2_SAFE_reader.py:918](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L918)) adds:
 
 - The Scene Classification Layer (SCL) — a 20 m raster of integer class codes (0=NoData, 1=Saturated, 2=DarkArea, 3=CloudShadow, 4=Vegetation, 5=BareSoil, 6=Water, 7=Unclassified, 8=CloudMediumProb, 9=CloudHighProb, 10=ThinCirrus, 11=Snow). Useful for masking without running a separate cloud detector.
 
@@ -159,7 +159,7 @@ def s2loader(
 )
 ```
 
-Located at [S2_SAFE_reader.py:1603](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1603). The factory you should use 95% of the time:
+Located at [S2_SAFE_reader.py:1603](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1603). The factory you should use 95% of the time:
 
 - Detects whether the folder is L1C or L2A from the SAFE name (the second path segment encodes `MSIL1C` vs `MSIL2A`).
 - Returns the appropriate subclass.
@@ -175,7 +175,7 @@ Both wrap `s2loader` after extracting the SAFE path from the feature's assets.
 
 ## 7. The Google Cloud public bucket
 
-`gs://gcp-public-data-sentinel-2/` (constant: `FULL_PATH_PUBLIC_BUCKET_SENTINEL_2`) is a free, no-auth-required mirror of the entire Sentinel-2 archive. The `s2_public_bucket_path(...)` function ([S2_SAFE_reader.py:1739](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1739)) constructs paths from `(tile_number_field, datetime, processing_baseline)` — useful when you have a SAFE name from a catalog query and need to turn it into a `gs://` URL.
+`gs://gcp-public-data-sentinel-2/` (constant: `FULL_PATH_PUBLIC_BUCKET_SENTINEL_2`) is a free, no-auth-required mirror of the entire Sentinel-2 archive. The `s2_public_bucket_path(...)` function ([S2_SAFE_reader.py:1739](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1739)) constructs paths from `(tile_number_field, datetime, processing_baseline)` — useful when you have a SAFE name from a catalog query and need to turn it into a `gs://` URL.
 
 The standard "load any S2 scene from anywhere" recipe:
 
@@ -195,7 +195,7 @@ The lazy access pattern matches what you'd get with a single-file `RasterioReade
 
 ## 8. SRF reading
 
-`read_srf(s2obj=None, mission=None, ...)` ([S2_SAFE_reader.py:1411](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1411)) returns a `pd.DataFrame` with the **published S2 SRFs** — wavelength index, one column per band — exactly as ESA distributes them. Use this for the spectral-binning recipe in [Chapter 11 §8](11_reflectance.md):
+`read_srf(s2obj=None, mission=None, ...)` ([S2_SAFE_reader.py:1411](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1411)) returns a `pd.DataFrame` with the **published S2 SRFs** — wavelength index, one column per band — exactly as ESA distributes them. Use this for the spectral-binning recipe in [Chapter 11 §8](11_reflectance.md):
 
 ```python
 srf_df = read_srf(mission="S2A")            # or pass s2obj

--- a/projects/geotoolz/georeader_tutorial/14_sentinel2.md
+++ b/projects/geotoolz/georeader_tutorial/14_sentinel2.md
@@ -1,0 +1,271 @@
+# Chapter 14 — `readers/S2_SAFE_reader.py`: Sentinel-2 SAFE products
+
+> **Module:** `georeader/readers/S2_SAFE_reader.py` (1845 LOC — the largest file in the package)
+> **Role:** read Sentinel-2 imagery in the official SAFE product format. Both Level-1C (top-of-atmosphere reflectance) and Level-2A (atmospherically-corrected surface reflectance) are supported, from local folders or Google Cloud's free public bucket.
+
+---
+
+## 1. Why this module is so large
+
+A Sentinel-2 SAFE product is **not one file**. It's a folder hierarchy with:
+
+- 13 separate JPEG2000 (`.jp2`) files — one per spectral band — at three different native resolutions (10 m, 20 m, 60 m).
+- Two XML metadata files — product-level (`MTD_MSIL1C.xml`) and tile-level (`MTD_TL.xml`) — describing acquisition geometry, calibration coefficients, sun/viewing angles, cloud masks, and processing baseline.
+- Per-band Quality Indicators (QI) at multiple resolutions: cloud masks, MSI defective pixel flags, cirrus mask, etc.
+- A scene classification layer (SCL) for L2A products only.
+
+The module's job is to hide all of that behind a single class that behaves like a `GeoData` (Chapter 2) — `s2.shape`, `s2.transform`, `s2.read_from_bounds(...)`, `s2.load()` all work as if S2 were one file.
+
+The 1845 LOC accommodates: SAFE-folder discovery, XML parsing, granule resolution, per-band JP2 stacking via `RasterioReader`, DN→radiance conversion, SRF extraction, multi-resolution band alignment, and Google Cloud Storage path translation. All of that is invisible from the public API surface, which is essentially three classes (`S2Image`, `S2ImageL1C`, `S2ImageL2A`) and one factory (`s2loader`).
+
+---
+
+## 2. L1C vs L2A — the two product levels
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                 SENTINEL-2 PROCESSING LEVELS                             │
+│                                                                          │
+│   Level-1C (L1C)                      Level-2A (L2A)                     │
+│   ─────────────────                   ─────────────────                  │
+│                                                                          │
+│   ☀️ Sun                               ☀️ Sun                             │
+│    │                                   │                                 │
+│    ▼                                   ▼                                 │
+│   ┌─────────┐                        ┌─────────┐                        │
+│   │Atmosphere│ ◄─ NOT corrected      │Atmosphere│ ◄─ CORRECTED          │
+│   └────┬────┘                        └────┬────┘                        │
+│        │                                  │                              │
+│        ▼                                  ▼                              │
+│   ┌─────────┐                        ┌─────────┐                        │
+│   │ Surface │                        │ Surface │                        │
+│   └─────────┘                        └─────────┘                        │
+│        │                                  │                              │
+│        ▼ 🛰️                              ▼ 🛰️                           │
+│                                                                          │
+│   TOA Reflectance                     BOA Reflectance                   │
+│   - Includes atmospheric effects      - Surface reflectance             │
+│   - Globally available                - Atmospheric correction applied  │
+│   - Can convert to radiance           - Scene Classification (SCL)     │
+│   - 13 bands (incl. B10 cirrus)       - 12 bands (no B10)              │
+│                                                                          │
+│   Use for:                            Use for:                          │
+│   - Radiance-based analysis           - Land cover mapping              │
+│   - Custom atmospheric correction     - Vegetation indices (NDVI)       │
+│   - Cloud studies (B10)               - Change detection                │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The key technical differences:
+
+- **L1C** — values are *top-of-atmosphere* reflectance scaled to int16 with a factor of `1 / 10000`. To convert to radiance, the module's `DN_to_radiance` applies per-band physical calibration constants from the metadata.
+- **L2A** — values are *bottom-of-atmosphere* reflectance from ESA's Sen2Cor processor (or equivalent). Includes the SCL band — a per-pixel classification (cloud / snow / water / vegetation / bare ground / etc.). **B10 (cirrus, 1375 nm) is dropped** because Sen2Cor uses it in the correction process and doesn't produce a corrected surface value.
+
+For ML pipelines you almost always want **L2A** — the atmospheric correction is consistent across scenes and removes much of the haze/illumination variability that confuses CNN training. For radiative-transfer studies that need to handle their own correction, you want L1C.
+
+---
+
+## 3. Spectral bands — the canonical S2 table
+
+```text
+Band │ Central λ │ Bandwidth │ Resolution │ L1C │ L2A │ Description
+─────┼───────────┼───────────┼────────────┼─────┼─────┼─────────────────────
+B01  │   443 nm  │   20 nm   │    60m     │  ✓  │  ✓  │ Coastal/Aerosol
+B02  │   490 nm  │   65 nm   │    10m     │  ✓  │  ✓  │ Blue
+B03  │   560 nm  │   35 nm   │    10m     │  ✓  │  ✓  │ Green
+B04  │   665 nm  │   30 nm   │    10m     │  ✓  │  ✓  │ Red
+B05  │   705 nm  │   15 nm   │    20m     │  ✓  │  ✓  │ Red Edge 1
+B06  │   740 nm  │   15 nm   │    20m     │  ✓  │  ✓  │ Red Edge 2
+B07  │   783 nm  │   20 nm   │    20m     │  ✓  │  ✓  │ Red Edge 3
+B08  │   842 nm  │  115 nm   │    10m     │  ✓  │  ✓  │ NIR
+B8A  │   865 nm  │   20 nm   │    20m     │  ✓  │  ✓  │ NIR Narrow
+B09  │   945 nm  │   20 nm   │    60m     │  ✓  │  ✓  │ Water Vapour
+B10  │  1375 nm  │   30 nm   │    60m     │  ✓  │  ✗  │ Cirrus (L1C only)
+B11  │  1610 nm  │   90 nm   │    20m     │  ✓  │  ✓  │ SWIR 1
+B12  │  2190 nm  │  180 nm   │    20m     │  ✓  │  ✓  │ SWIR 2
+```
+
+This table is **the** reference you'll come back to. Three things worth highlighting:
+
+- **Three native resolutions: 10 m / 20 m / 60 m.** When you set `out_res=10`, the 20 m and 60 m bands are *upsampled* on read. When you set `out_res=20`, the 10 m bands are *downsampled* and the 60 m bands are *upsampled*. The `out_res=20` option is the practical sweet-spot when you don't strictly need 10 m resolution — you keep more bands at native resolution.
+- **B08 is the broad NIR (842 nm), B8A is the narrow NIR (865 nm).** These look interchangeable but aren't — atmospheric scientists prefer B8A (narrower bandpass = cleaner SWIR-NIR spectroscopy); ML practitioners often use B08 (10 m native + matches Landsat-8 NIR more closely).
+- **Bands 10/11/12 wavelength ordering looks weird.** B11 (1610 nm) is *between* B09 (945 nm) and B12 (2190 nm); B10 (1375 nm) is also between them. The naming follows ESA's historical band-ID scheme, not wavelength order. When constructing band lists for SRF binning or visualisation, use `BANDS_S2 = ["B01", "B02", ..., "B12"]` (the module-level constant) — that's the canonical order matching the array's band axis.
+
+The module exports the canonical lists as `BANDS_S2` (full 13 for L1C), `BANDS_S2_L1C` (alias), and `BANDS_S2_L2A` (12 bands; no B10).
+
+---
+
+## 4. The class hierarchy
+
+```python
+S2Image                    # base class — do not instantiate directly
+├── S2ImageL1C             # L1C-specific: DN→radiance, no SCL
+└── S2ImageL2A             # L2A-specific: SCL band, no B10
+```
+
+`S2Image` lives at [S2_SAFE_reader.py:295](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L295). It implements the `GeoData` protocol (Chapter 2 §3) plus S2-specific machinery:
+
+- Granule discovery: walking the SAFE folder to find per-band JP2 paths.
+- Multi-resolution band alignment: each band has its native resolution; `out_res=` selects the output grid and bands at other native resolutions get resampled internally.
+- XML metadata parsing for sun/view angles, processing baseline, and per-band offsets.
+- Window focus delegation: `set_window` propagates to all underlying `RasterioReader`s for each JP2.
+
+`S2ImageL1C` ([S2_SAFE_reader.py:1000](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1000)) adds:
+
+- The B10 cirrus band.
+- DN-to-radiance conversion via `DN_to_radiance(s2obj, dn_data)` ([S2_SAFE_reader.py:1534](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1534)) — uses the per-band `solar_irradiance` and `quantification_value` constants from `MTD_MSIL1C.xml`.
+
+`S2ImageL2A` ([S2_SAFE_reader.py:918](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L918)) adds:
+
+- The Scene Classification Layer (SCL) — a 20 m raster of integer class codes (0=NoData, 1=Saturated, 2=DarkArea, 3=CloudShadow, 4=Vegetation, 5=BareSoil, 6=Water, 7=Unclassified, 8=CloudMediumProb, 9=CloudHighProb, 10=ThinCirrus, 11=Snow). Useful for masking without running a separate cloud detector.
+
+---
+
+## 5. Constructor signature (common to both subclasses)
+
+```python
+S2ImageL2A(
+    s2folder,                    # path to .SAFE folder (local or gs://)
+    polygon=None,                # Shapely polygon (EPSG:4326) for AOI
+    granules=None,               # dict[band → JP2 path]; auto-discovered if None
+    out_res=10,                  # 10, 20, or 60 — output resolution in meters
+    window_focus=None,           # rasterio Window for sub-region (in out_res grid)
+    bands=None,                  # list[str] — band subset; defaults to all 12/13
+    metadata_msi=None,           # explicit path to MTD_MSI*.xml; auto-located if None
+)
+```
+
+A few non-obvious points:
+
+- **`s2folder`** can be a `gs://` path. The module recognises `gs://gcp-public-data-sentinel-2/...` URIs and uses `fsspec` to walk the folder structure.
+- **`polygon` is in `EPSG:4326`.** Almost always — most catalog queries return WGS84 polygons. The module reprojects internally to the tile's UTM zone.
+- **`out_res=20` is often the best choice** for ML — keeps red-edge and SWIR at native resolution, avoids upsampling.
+- **`bands=` lets you load a subset.** Memory-efficient for "just RGB" or "just NDVI" use cases. The default is all bands at the chosen `out_res`.
+- **`window_focus`** — same semantics as `RasterioReader.set_window` (Chapter 3 §4). Restricts subsequent reads to a sub-region.
+
+---
+
+## 6. The factory: `s2loader`
+
+```python
+def s2loader(
+    s2folder,
+    polygon=None,
+    out_res=10,
+    window_focus=None,
+    bands=None,
+    metadata_msi=None,
+)
+```
+
+Located at [S2_SAFE_reader.py:1603](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1603). The factory you should use 95% of the time:
+
+- Detects whether the folder is L1C or L2A from the SAFE name (the second path segment encodes `MSIL1C` vs `MSIL2A`).
+- Returns the appropriate subclass.
+
+Two related convenience functions for common catalog systems:
+
+- **`s2_load_from_feature_element84(feature, ...)`** — load from an Element84 STAC feature dict.
+- **`s2_load_from_feature_planetary_microsoft(feature, ...)`** — load from Microsoft Planetary Computer's STAC feature dict.
+
+Both wrap `s2loader` after extracting the SAFE path from the feature's assets.
+
+---
+
+## 7. The Google Cloud public bucket
+
+`gs://gcp-public-data-sentinel-2/` (constant: `FULL_PATH_PUBLIC_BUCKET_SENTINEL_2`) is a free, no-auth-required mirror of the entire Sentinel-2 archive. The `s2_public_bucket_path(...)` function ([S2_SAFE_reader.py:1739](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1739)) constructs paths from `(tile_number_field, datetime, processing_baseline)` — useful when you have a SAFE name from a catalog query and need to turn it into a `gs://` URL.
+
+The standard "load any S2 scene from anywhere" recipe:
+
+```python
+from georeader.readers.S2_SAFE_reader import s2loader
+
+path = "gs://gcp-public-data-sentinel-2/tiles/29/S/ND/.../S2A_MSIL2A_20240615T...SAFE"
+s2 = s2loader(path, out_res=10)
+
+# s2 is an S2ImageL2A — behaves like a GeoData
+gt = read.read_from_polygon(s2, my_aoi, crs_polygon="EPSG:4326")
+```
+
+The lazy access pattern matches what you'd get with a single-file `RasterioReader` — which is the design goal.
+
+---
+
+## 8. SRF reading
+
+`read_srf(s2obj=None, mission=None, ...)` ([S2_SAFE_reader.py:1411](../../../../tmp/georeader_src/georeader/readers/S2_SAFE_reader.py#L1411)) returns a `pd.DataFrame` with the **published S2 SRFs** — wavelength index, one column per band — exactly as ESA distributes them. Use this for the spectral-binning recipe in [Chapter 11 §8](11_reflectance.md):
+
+```python
+srf_df = read_srf(mission="S2A")            # or pass s2obj
+e_per_band = integrated_irradiance(srf_df)  # band-integrated solar irradiance
+toa_refl = radiance_to_reflectance(s2_radiance, e_per_band, ...)
+```
+
+The DataFrame uses the canonical band naming (`B01`, `B02`, ..., `B12`) so it lines up with the band axis of an S2 `GeoTensor` directly.
+
+---
+
+## 9. Function reference
+
+**Classes**
+- `S2Image` — base, do not instantiate directly
+- `S2ImageL1C(s2folder, polygon=None, out_res=10, ...)` — L1C reader
+- `S2ImageL2A(s2folder, polygon=None, out_res=10, ...)` — L2A reader
+
+**Loaders**
+- `s2loader(s2folder, ...)` — auto-detects L1C/L2A (the recommended entry point)
+- `s2_load_from_feature_element84(feature, ...)` — Element84 STAC adapter
+- `s2_load_from_feature_planetary_microsoft(feature, ...)` — MS Planetary Computer adapter
+
+**Helpers**
+- `s2_public_bucket_path(tile_number, datetime, processing_baseline) → str` — build `gs://` URL
+- `s2_name_split(s2file) → tuple` — parse a SAFE filename into 7 fields
+- `s2_old_format_name_split(...)` — legacy filename parser (pre-2017)
+- `normalize_band_names(bands) → list[str]` — accept various spellings (`b1`, `B01`, `band1`, ...) and canonicalise
+
+**Calibration**
+- `DN_to_radiance(s2obj: S2ImageL1C, dn_data=None) → GeoTensor` — L1C DN → radiance
+- `read_srf(s2obj=None, mission=None, ...) → pd.DataFrame` — published SRFs
+
+**File / cloud**
+- `islocalpath(path) → bool` — local vs cloud
+- `get_filesystem(path, requester_pays=None)` — fsspec filesystem
+- `get_file(remote_path, local_path)` — fetch a single file
+- `read_xml(xml_file) → ET.Element` — XML parsing helper
+
+**Constants**
+- `BANDS_S2 = ["B01", ..., "B12"]` — full 13-band list (L1C order)
+- `BANDS_S2_L1C` — alias for `BANDS_S2`
+- `BANDS_S2_L2A` — 12-band list (L1C order minus B10)
+- `PUBLIC_BUCKET_SENTINEL_2 = "gcp-public-data-sentinel-2"`
+- `FULL_PATH_PUBLIC_BUCKET_SENTINEL_2 = "gs://gcp-public-data-sentinel-2/"`
+
+---
+
+## 10. Sharp edges
+
+- **`out_res=10` upsamples 8 of 13 bands.** B01, B05–B07, B8A, B09, B10, B11, B12 are not natively at 10 m. Setting `out_res=10` makes them all `(10980, 10980)` via `Resampling.cubic_spline`; you don't get more information, just bigger files.
+- **L2A drops B10.** Code that hardcodes `bands=BANDS_S2_L1C` will fail on L2A. Use `BANDS_S2_L2A` or filter dynamically based on `s2.bands`.
+- **Old vs new SAFE names.** Pre-2017 products use a different naming convention (`s2_old_format_name_split`). The `s2loader` factory handles both; custom path parsing won't.
+- **Processing-baseline drift.** ESA reprocesses the archive every few years. `S2A_*_N0500_*` (baseline 5.00) and `S2A_*_N0510_*` (5.10) have subtly different radiometric calibration. Match baselines in time-series analyses or you'll see fake change signals.
+- **B10 in L1C is *only* useful for cloud detection.** It's centred on a strong water-vapour absorption — surface reflectance there is essentially zero, so any signal is from cirrus clouds in the upper atmosphere. Don't include B10 as a "regular" spectral feature.
+- **SCL is at 20 m.** When using L2A's SCL band as a cloud mask at `out_res=10`, the mask is upsampled — single-pixel cloud features can become 4-pixel features at 10 m.
+- **Requester-pays buckets.** The Microsoft / AWS S3 mirrors are requester-pays. Pass `requester_pays=True` to authenticate the read. The Google public bucket is free.
+- **JP2 reads are not parallel-safe in the SAFE-reader sense.** Each band is a separate `RasterioReader`, so each is independently parallel-safe (Chapter 3), but reading multiple bands of one S2 scene from multiple processes is fine.
+
+---
+
+## 11. Connection to `geotoolz`
+
+The whole `presets.s2` block in [`geotoolz.md` §1.2](../plans/geotoolz.md) sits on top of this module:
+
+- **`presets.s2.S2_L2A_RGB(brightness=...)`** — `Sequential([s2.isel(["B04","B03","B02"]), ToFloat32, PercentileClip, Gamma])`. Loads via `s2loader`, picks RGB bands, normalises.
+- **`presets.s2.S2_L2A_NDVI(...)`** — `Sequential([s2.load(), MaskClouds(scl_band), NDVI(red_idx=2, nir_idx=3)])`. Uses the SCL band for cloud masking — a free pass thanks to L2A.
+- **`presets.s2.S2_L1C_TO_BOA_NDVI(...)`** — the harder pipeline: `Sequential([DN_to_radiance, TOAToBOA, MaskClouds, NDVI])`. Hits `DN_to_radiance` from this module before the radiometric work in [Chapter 11](11_reflectance.md).
+- **`presets.s2.S2_QA60_CLOUD_MASK(...)`** — bit-flag extraction from the QA60 band on L1C.
+
+Sentinel-2 is the most-used sensor in the package's ecosystem, and this module's design (single class subclassing `GeoData`, lazy granule access, multi-resolution alignment) is the template the other big sensor readers (`emit`, `prisma`, `enmap`) follow.
+
+Next chapter: [15_hyperspectral.md](15_hyperspectral.md) — the curvilinear-sensor trio (EMIT, PRISMA, EnMAP) and their shared design pattern.

--- a/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
+++ b/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
@@ -1,4 +1,4 @@
-# Chapter 15 — `readers/{emit,prisma,enmap}.py`: the hyperspectral trio
+# Ch. 15 — hyperspectral
 
 > **Modules:**
 > - `georeader/readers/emit.py` (1102 LOC)

--- a/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
+++ b/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
@@ -1,0 +1,376 @@
+# Chapter 15 — `readers/{emit,prisma,enmap}.py`: the hyperspectral trio
+
+> **Modules:**
+> - `georeader/readers/emit.py` (1102 LOC)
+> - `georeader/readers/prisma.py` (571 LOC)
+> - `georeader/readers/enmap.py` (865 LOC)
+> **Role:** read three hyperspectral satellite sensors — EMIT (NASA, ISS, 285 bands), PRISMA (ASI, 239 bands), EnMAP (DLR, 224 bands). All cover ~400–2500 nm with ~10 nm spectral sampling. The three readers share a design pattern but diverge on georeferencing — that's the interesting part.
+
+---
+
+## 1. The three sensors at a glance
+
+| Sensor | Agency | Launched | Bands | Spectral range | GSD | Georeferencing |
+|---|---|---|---|---|---|---|
+| **EMIT** | NASA | 2022 (ISS) | 285 | 380–2500 nm | ~60 m | **GLT** (lookup table) |
+| **PRISMA** | ASI | 2019 | 239 | 400–2500 nm | 30 m | **per-pixel lat/lon** (interpolation) |
+| **EnMAP** | DLR | 2022 | 224 | 420–2450 nm | 30 m | **map-projected + RPCs** |
+
+The trio matters because they're the workhorses of the spaceborne hyperspectral era. They map onto three distinct georeferencing strategies — the structural axis along which the readers differ.
+
+---
+
+## 2. EMIT — NASA's GLT-equipped spectrometer
+
+### Data format
+
+```text
+Raw Data Structure (NetCDF file):
+┌─────────────────────────────────────┐
+│  radiance: (downtrack, crosstrack, bands)  │
+│  └── Shape: (~1280, ~1242, 285)            │
+│                                             │
+│  location/glt_x: (rows, cols)              │
+│  location/glt_y: (rows, cols)              │
+│  └── Geographic Lookup Table (GLT)         │
+└─────────────────────────────────────┘
+```
+
+EMIT ships data in **sensor coordinates** (raw pushbroom scan lines, not orthorectified), plus a Geographic Lookup Table that names — for each pixel of the *output* (orthorectified) grid — which sensor pixel to read from. This is the [`griddata.georreference` fast path from Chapter 7](07_griddata.md).
+
+### GLT orthorectification (top-of-module diagram)
+
+```text
+Geographic Grid (Output)          Sensor Grid (Raw Data)
+┌─────────────────────┐           ┌─────────────────────┐
+│ (0,0)               │           │ radiance array      │
+│   ┌───┬───┬───┐     │   GLT     │ ┌───────────────┐   │
+│   │ a │ b │ c │     │ ──────→   │ │ (5,2) (5,3)   │   │
+│   ├───┼───┼───┤     │ lookup    │ │ (6,1) (6,2)   │   │
+│   │ d │ e │ f │     │           │ │ ...           │   │
+│   └───┴───┴───┘     │           │ └───────────────┘   │
+│               (H,W) │           │                     │
+└─────────────────────┘           └─────────────────────┘
+
+For pixel (row=1, col=2) in geographic grid:
+    glt_x[1,2] = 5  →  raw_col = 5
+    glt_y[1,2] = 2  →  raw_row = 2
+    value = radiance[2, 5, :]  (all bands)
+
+GLT values of 0 indicate invalid/no-data pixels
+```
+
+This approach allows:
+
+1. Efficient storage (no wasted pixels from orthorectification padding).
+2. Preservation of original radiometric values (no resampling).
+3. Flexible reprojection to any target CRS.
+
+### Class-level diagram (preserved verbatim)
+
+```text
+GLT Orthorectification:
+┌────────────────────────────┐      ┌──────────────────────────┐
+│    Geographic Grid         │      │   Sensor Grid (raw)      │
+│  (orthorectified space)    │      │  (pushbroom scan)        │
+│  ┌───┬───┬───┬───┐        │      │  ┌───┬───┬───┬───┐      │
+│  │ · │ a │ b │ · │        │  GLT │  │ e │ a │ b │ · │      │
+│  ├───┼───┼───┼───┤        │  ──→ │  ├───┼───┼───┼───┤      │
+│  │ c │ d │ e │ f │        │      │  │ f │ c │ d │ · │      │
+│  └───┴───┴───┴───┘        │      │  └───┴───┴───┴───┘      │
+│  (pixels with data)        │      │  (original acquistion)   │
+└────────────────────────────┘      └──────────────────────────┘
+
+· = no data (GLT value = 0)
+
+For geographic pixel (row, col):
+    raw_x = glt_x[row, col]  
+    raw_y = glt_y[row, col]
+    value = radiance[raw_y, raw_x, :]
+```
+
+### Radiometric units & spectral
+
+- L1B radiance: `μW / (cm²·sr·nm)` — note the unusual unit (not `W/m²` SI base; convert by factor 100).
+- 285 bands, 380–2500 nm, FWHM ≈ 7–10 nm.
+- ~60 m GSD (coarser than PRISMA/EnMAP because the ISS flies higher than typical Earth-observation orbits).
+
+### Interface
+
+`EMITImage(path, ...)` — main class. Methods include `load_radiance()`, `load_reflectance(...)`, `load_wavelengths([w1, w2, ...])`. Helpers `download_product()`, `get_radiance_link()` use NASA Earthdata credentials from `~/.georeader/auth_emit.json`.
+
+---
+
+## 3. PRISMA — ASI's interpolation-required spectrometer
+
+### Data format
+
+```text
+PRISMA HDF5 File Structure:
+┌─────────────────────────────────────────────────────────┐
+│  /HDFEOS/SWATHS/PRS_L1_HCO/                             │
+│  ├── Data Fields/                                        │
+│  │   ├── VNIR_Cube: (bands, crosstrack, downtrack)      │
+│  │   │   └── 400-1010 nm, ~66 bands                     │
+│  │   └── SWIR_Cube: (bands, crosstrack, downtrack)      │
+│  │       └── 920-2500 nm, ~173 bands                    │
+│  ├── Geolocation Fields/                                 │
+│  │   ├── Latitude_SWIR, Longitude_SWIR                  │
+│  │   └── Latitude_VNIR, Longitude_VNIR                  │
+│  └── Attributes (solar/view angles, timing, etc.)       │
+│                                                          │
+│  /KDP_AUX/                                               │
+│  ├── Cw_Vnir_Matrix, Cw_Swir_Matrix (wavelengths)       │
+│  └── Fwhm_Vnir_Matrix, Fwhm_Swir_Matrix                 │
+└─────────────────────────────────────────────────────────┘
+```
+
+Unlike EMIT, **PRISMA L1 data is NOT orthorectified**. Instead, it ships per-pixel `Latitude_*` / `Longitude_*` arrays. Producing a regular grid from this requires **interpolation** — the slow path in [Chapter 7](07_griddata.md), using `read_to_crs(data, lons, lats, ...)` under the hood.
+
+### Sensor grid → geographic grid
+
+```text
+Sensor Grid (raw)                  Geographic Grid (output)
+┌─────────────────────┐            ┌─────────────────────┐
+│ pushbroom scan      │            │ regular grid        │
+│ ┌───┬───┬───┬───┐  │  gridding  │ ┌───┬───┬───┬───┐  │
+│ │ a │ b │ c │ d │  │  ───────→  │ │ a'│ b'│ c'│ d'│  │
+│ ├───┼───┼───┼───┤  │            │ ├───┼───┼───┼───┤  │
+│ │ e │ f │ g │ h │  │            │ │ e'│ f'│ g'│ h'│  │
+│ └───┴───┴───┴───┘  │            │ └───┴───┴───┴───┘  │
+│ + lat/lon per pixel│            │ + affine transform  │
+└─────────────────────┘            └─────────────────────┘
+```
+
+The `raw=True` / `raw=False` flag on PRISMA's load methods is the eject button: `raw=True` returns sensor coordinates (no interpolation, fast), `raw=False` runs `griddata` (slow, but produces a `GeoTensor` ready for downstream operators). For most ML workflows you want `raw=False`; for matched-filter retrievals that need exact radiometry, `raw=True` and handle gridding yourself if needed.
+
+### Dual-sensor configuration
+
+```text
+VNIR Sensor                          SWIR Sensor
+┌────────────────────┐               ┌────────────────────┐
+│ 400 - 1010 nm      │               │ 920 - 2500 nm      │
+│ ~66 bands          │               │ ~173 bands         │
+│ ~10 nm sampling    │               │ ~10 nm sampling    │
+│                    │               │                    │
+│ Shared 30m GSD     │               │ Shared 30m GSD     │
+└────────────────────┘               └────────────────────┘
+          │                                    │
+          └──────────── Overlap ───────────────┘
+                     920-1010 nm
+```
+
+PRISMA uses two separate sensors. The reader takes care of selecting the right one when you ask for a wavelength — `prisma.load_wavelengths([850, 1600])` gives you 850 nm from VNIR and 1600 nm from SWIR. The 920–1010 nm overlap is mostly used for cross-calibration; for analysis pick one source per wavelength.
+
+### Wavelength range diagram
+
+```text
+Wavelength Range:
+├──────────────────────────────────────────────────────────────┤
+400nm              1000nm                                 2500nm
+├───────── VNIR ──────────┤
+                  ├────────────────── SWIR ───────────────────┤
+                  └─ overlap ─┘
+                  920-1010nm
+```
+
+### Radiometric units
+
+- L1 radiance: `mW / (m²·sr·nm)` — the SI-ish unit, factor of 1000 from `W/m²/sr/nm`.
+- Calibration: DN → radiance via per-band scale + offset (applied automatically on load).
+
+### Interface
+
+`PRISMA(path)` — main class. Methods `load_wavelengths([w1, w2, ...], as_reflectance=False, raw=False)`, `load_rgb(as_reflectance=False, raw=False)`. The wavelength-list interface handles VNIR/SWIR routing transparently.
+
+---
+
+## 4. EnMAP — DLR's already-orthorectified spectrometer
+
+### Data format
+
+```text
+EnMAP Product Structure:
+┌─────────────────────────────────────────────────────────────────────┐
+│  ENMAP01-____L1B-DT0000000000_20220501T101523Z_001_V010110_...     │
+│  ├── *-METADATA.XML           ← Main metadata file (input)         │
+│  ├── *-SPECTRAL_IMAGE_VNIR.TIF   420-1000 nm, ~88 bands            │
+│  ├── *-SPECTRAL_IMAGE_SWIR.TIF   900-2450 nm, ~136 bands           │
+│  ├── *-QL_QUALITY_CLOUD.TIF      Cloud mask                        │
+│  ├── *-QL_QUALITY_CIRRUS.TIF     Cirrus mask                       │
+│  ├── *-QL_QUALITY_SNOW.TIF       Snow mask                         │
+│  ├── *-QL_QUALITY_HAZE.TIF       Haze mask                         │
+│  └── *-QL_PIXELMASK_*.TIF        Per-sensor pixel masks            │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+EnMAP differs from both: ships as **separate GeoTIFF files** with an XML metadata manifest. Importantly, **EnMAP L1B is already orthorectified** (map-projected) — no GLT, no per-pixel coords. Plus a set of RPCs (Rational Polynomial Coefficients) for refined geolocation if you need it.
+
+### Class diagram
+
+```text
+File Structure:
+┌────────────────────────────────────────────────────┐
+│  METADATA.XML  ──→  wavelengths, FWHM, angles,    │
+│                      gain/offset, RPCs             │
+│                                                    │
+│  SPECTRAL_IMAGE_VNIR.TIF  ──→  (88, H, W) bands   │
+│  SPECTRAL_IMAGE_SWIR.TIF  ──→  (136, H, W) bands  │
+│                                                    │
+│  QL_QUALITY_*.TIF  ──→  quality masks              │
+└────────────────────────────────────────────────────┘
+```
+
+The XML metadata file is the **input** — pass that path to the reader. The reader walks the sibling files for the actual band data and quality masks.
+
+### Dual-sensor + radiometric calibration
+
+```text
+VNIR Detector                        SWIR Detector
+┌────────────────────┐               ┌────────────────────┐
+│ 420 - 1000 nm      │               │ 900 - 2450 nm      │
+│ ~88 bands          │               │ ~136 bands         │
+│ 6.5 nm sampling    │               │ 10 nm sampling     │
+│ Si CCD             │               │ HgCdTe             │
+└────────────────────┘               └────────────────────┘
+          │                                    │
+          └──────────── Overlap ───────────────┘
+                     900-1000 nm
+```
+
+```text
+Wavelength: 420nm ──── 1000nm ──── 2450nm
+            ├── VNIR ────┤
+                      ├──── SWIR ──────────┤
+                      └ overlap┘
+                      900-1000nm
+```
+
+VNIR has *finer* spectral sampling (6.5 nm vs 10 nm) than the other two sensors — useful for narrow-feature spectroscopy. The DN-to-radiance formula is the most peculiar:
+
+```
+L_λ = (GAIN × DN + OFFSET) × 1000   [mW/(m²·sr·nm)]
+
+Note: DLR gains are multiplicative (not divisive as in some sensors)
+```
+
+The `× 1000` at the end is because DLR's spec gives the result in `W/(m²·sr·nm)` and the reader converts to `mW` units to match PRISMA / Thuillier conventions. **Don't double-multiply** — let the reader handle calibration.
+
+### RPCs
+
+```text
+Pixel (col, row) ──→ RPC Transform ──→ Geographic (lon, lat)
+
+RPCs model:
+- Satellite orbit and attitude
+- Sensor geometry  
+- Terrain elevation effects (when height_off is set appropriately)
+```
+
+EnMAP includes Rational Polynomial Coefficients in metadata for fine geolocation. The reader can apply RPCs during loading for refined geolocation; default uses the simple affine transform from the GeoTIFF (which is already pretty good — RPCs add ~1 pixel of refinement).
+
+### Interface
+
+`EnMAPImage(metadata_xml_path, ...)` — the main class, takes the XML manifest path. Plus quality-mask accessors that pair with the per-pixel masks shipped alongside.
+
+---
+
+## 5. Side-by-side comparison
+
+| | EMIT | PRISMA | EnMAP |
+|---|---|---|---|
+| **File format** | NetCDF (one) | HDF5 (one, `.he5`) | GeoTIFFs (many) + XML |
+| **Georeferencing** | GLT lookup (fast) | per-pixel lat/lon (slow interp) | already map-projected (cheap) |
+| **Radiance units** | `μW/(cm²·sr·nm)` | `mW/(m²·sr·nm)` | `W/(m²·sr·nm)` → `mW` after reader |
+| **Bands** | 285 | 239 (66 VNIR + 173 SWIR) | 224 (88 VNIR + 136 SWIR) |
+| **GSD** | ~60 m | 30 m | 30 m |
+| **Sensor split** | single | VNIR + SWIR | VNIR + SWIR |
+| **Module function used** | `griddata.georreference` | `griddata.read_to_crs` | regular `RasterioReader` |
+| **Auth** | NASA Earthdata | manual download | manual download |
+| **Reader cost (full scene)** | seconds | minutes (cubic interp) | seconds |
+
+The cost asymmetry is the operational reality: PRISMA scenes are ~60× slower to ortho-load than EMIT. For workflows that read scenes repeatedly (parameter sweeps, hyperparameter searches), `load()` once into a `GeoTensor` and reuse — don't ortho-on-demand.
+
+---
+
+## 6. Common workflow patterns
+
+### A — methane plume detection on EMIT
+
+```python
+from georeader.readers.emit import EMITImage
+from georeader import reflectance, hyperspectral_index  # hypothetical
+
+emit = EMITImage("EMIT_L1B_RAD_*.nc")
+radiance = emit.load_radiance()         # uses GLT — fast
+# (1, B=285, H, W) GeoTensor in μW/(cm²·sr·nm)
+# Pass to a matched filter targeting ch4 absorption features...
+```
+
+### B — RGB visualization across sensors
+
+```python
+# EMIT
+emit_rgb = emit.load_wavelengths([640, 550, 460], as_reflectance=True)
+
+# PRISMA — raw=False forces gridding to a regular UTM grid
+prisma_rgb = prisma.load_rgb(as_reflectance=True, raw=False)
+
+# EnMAP
+enmap_rgb = enmap.load_rgb(as_reflectance=True)
+```
+
+All three return a 3-band `GeoTensor` ready for `plot.show`. The interfaces deliberately converge despite the substrates diverging.
+
+### C — Spectral binning to S2 bands
+
+(Common to all three; used by `presets.enmap.ENMAP_TO_S2_BANDS` from the [`geotoolz` plan](../plans/geotoolz.md)):
+
+```python
+from georeader.readers.S2_SAFE_reader import read_srf
+from georeader.reflectance import transform_to_srf, integrated_irradiance
+
+s2_srf = read_srf(mission="S2A")                                  # S2 SRF DataFrame
+s2_equiv = transform_to_srf(enmap_radiance, s2_srf, wavelengths=enmap.wavelengths)
+# s2_equiv is now a 12-band cube with S2-shaped band responses
+```
+
+This recipe works identically for PRISMA and EMIT — the readers expose `wavelengths` and `fwhm` arrays as attributes.
+
+---
+
+## 7. Sharp edges
+
+### EMIT
+- **`μW/(cm²·sr·nm)` is unusual.** Convert by ÷100 to SI base or use `units="uW/cm^2/SR/nm"` to `radiance_to_reflectance` ([Chapter 11 §3](11_reflectance.md)). Wrong units silently produce wrong reflectance.
+- **GLT requires the file's `location` group.** Some legacy EMIT products on third-party mirrors strip it. Check `glt_x` / `glt_y` exist before using `load_radiance()`.
+- **NASA Earthdata auth.** Required for `download_product`. Stored in `~/.georeader/auth_emit.json` — make sure it's not world-readable (it's plaintext credentials).
+
+### PRISMA
+- **Cubic interpolation is the cost.** A full scene takes minutes. Use `raw=True` for radiometric work; only orthorectify when you need a regular grid for a downstream operator.
+- **VNIR/SWIR overlap (920–1010 nm).** The reader doesn't deduplicate; you can ask for 950 nm and get a different value depending on which sensor. Be explicit about which you want when documenting analyses.
+- **HDF5 path must end `.he5`.** Some catalog systems serve PRISMA as `.h5` — rename or symlink.
+
+### EnMAP
+- **Pass the `*-METADATA.XML` path, not the imagery path.** Easy to confuse since the SAFE-style folder contains many files.
+- **`× 1000` in the radiance formula.** Don't apply it twice. The reader handles this; if you re-implement, factor it correctly.
+- **RPCs are off by default.** Pass the appropriate flag to enable. Most analyses don't need them — the GeoTIFF affine is already accurate to ~10 m.
+
+### Cross-sensor
+- **Spectral sampling differs.** EMIT (~7–10 nm), PRISMA (~10 nm), EnMAP VNIR (6.5 nm) / SWIR (10 nm). Inter-sensor compatibility requires SRF binning (Chapter 11) — don't pixel-match across sensors directly.
+- **Reflectance conversion needs solar geometry.** All three readers have helpers for sun angle / Earth-sun distance from acquisition timestamps; double-check this is set when calling `as_reflectance=True`.
+
+---
+
+## 8. Connection to `geotoolz`
+
+The hyperspectral operators in [`geotoolz.md`](../plans/geotoolz.md) consume `GeoTensor`s produced by these readers:
+
+- **`hyperspectral.MatchedFilter(target_spectrum, axis=0)`** — works on any of the three (post-orthorectification). Standard Reed-Yu detector.
+- **`hyperspectral.ACEDetector` / `RXDetector` / `LinearUnmixing`** — same.
+- **`presets.emit.EMIT_METHANE_MF`** — relies on EMIT's GLT speed: read once, MF many times.
+- **`presets.enmap.ENMAP_TO_S2_BANDS`** — uses the SRF binning recipe (§6C above) for cross-sensor compatibility.
+
+The split-object pattern in `geotoolz` ([Ch §4 of geotoolz.md](../plans/geotoolz.md)) is especially relevant here: compute the scene mean / covariance / endmember spectrum once (slow), then apply per-band detectors fast. The hyperspectral cube is the canonical case where state-as-artifact pays off.
+
+Next chapter: [16_earth_engine.md](16_earth_engine.md) — Google Earth Engine integration (export tile splitting and parallel download).

--- a/projects/geotoolz/georeader_tutorial/16_earth_engine.md
+++ b/projects/geotoolz/georeader_tutorial/16_earth_engine.md
@@ -1,4 +1,4 @@
-# Chapter 16 — `readers/ee_image.py` + helpers: Google Earth Engine
+# Ch. 16 — Earth Engine
 
 > **Modules:**
 > - `georeader/readers/ee_image.py` (539 LOC)
@@ -88,15 +88,15 @@ This pattern handles arbitrary AOI sizes — the only practical limit is memory 
 | `export_image_getpixels(asset_id, ...)` | direct-asset export via `ee.data.getPixels` (when you have the asset ID, not a computed image) |
 | `export_cube(query, geometry, ...)` | time-series export — returns `(T, C, H, W)` `GeoTensor` |
 
-`export_image` is the one you'll use 95% of the time. Source: [ee_image.py:223](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L223).
+`export_image` is the one you'll use 95% of the time. Source: [ee_image.py:223](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L223).
 
-`export_cube` ([ee_image.py:392](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L392)) is built on top — accepts a GeoDataFrame of (acquisition_date, asset_id) rows, exports each row as a 3D image, and stacks them along a new time axis.
+`export_cube` ([ee_image.py:392](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L392)) is built on top — accepts a GeoDataFrame of (acquisition_date, asset_id) rows, exports each row as a 3D image, and stacks them along a new time axis.
 
 ---
 
 ## 4. The split helper
 
-`split_bounds(bounds) → list[bounds]` ([ee_image.py:211](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L211)) does the quadrant split:
+`split_bounds(bounds) → list[bounds]` ([ee_image.py:211](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L211)) does the quadrant split:
 
 ```text
    bounds = (minx, miny, maxx, maxy)
@@ -115,7 +115,7 @@ Always 4-way split (not adaptive based on aspect ratio). Adequate for the typica
 
 When you download S2 from GEE asking for 10 m resolution, GEE upsamples the 20 m and 60 m bands using **nearest neighbour**. That produces ugly blocky bands at 10 m — not what you want.
 
-`interpolate_20mbands_s2ee(geotensor, ...)` ([ee_image.py:476](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L476)) post-processes the result by re-resampling the affected bands with **bicubic** interpolation. The result looks like a real 10 m image rather than blocky pixels.
+`interpolate_20mbands_s2ee(geotensor, ...)` ([ee_image.py:476](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L476)) post-processes the result by re-resampling the affected bands with **bicubic** interpolation. The result looks like a real 10 m image rather than blocky pixels.
 
 This isn't a bug in this module — it's a quirk of GEE's S2 ingestion. The workaround is the kind of detail that takes you an afternoon to find on the GEE forum; having it as a one-line call makes the module pay for itself.
 

--- a/projects/geotoolz/georeader_tutorial/16_earth_engine.md
+++ b/projects/geotoolz/georeader_tutorial/16_earth_engine.md
@@ -156,7 +156,7 @@ ee.Authenticate()  # browser flow first time, cached afterwards
 ee.Initialize(project="my-gcp-project")
 ```
 
-The `[ee]` extra (`pip install georeader-spaceml[ee]`) installs `earthengine-api`. Without it, importing `readers.ee_image` raises `ImportError`.
+Install `georeader-spaceml` with the `[ee]` extra to pull in `earthengine-api`. Without it, importing `readers.ee_image` raises `ImportError`. In this repo the relevant install commands are `pixi add georeader-spaceml[ee]` or `uv add 'georeader-spaceml[ee]'` per the project's [CONTRIBUTING.md](../../../CONTRIBUTING.md) tooling conventions.
 
 The credentials live in `~/.config/earthengine/credentials` (managed by `ee.Authenticate()`); the module doesn't add its own credential file like EMIT does.
 

--- a/projects/geotoolz/georeader_tutorial/16_earth_engine.md
+++ b/projects/geotoolz/georeader_tutorial/16_earth_engine.md
@@ -1,0 +1,208 @@
+# Chapter 16 — `readers/ee_image.py` + helpers: Google Earth Engine
+
+> **Modules:**
+> - `georeader/readers/ee_image.py` (539 LOC)
+> - `georeader/readers/ee_query.py` (589 LOC)
+> - `georeader/readers/ee_utils.py` (58 LOC)
+> **Role:** export raster data from Google Earth Engine into `GeoTensor`s, handling GEE's request-size limits through recursive tile splitting and parallel downloads.
+
+---
+
+## 1. Why this module exists
+
+Google Earth Engine is the standard cloud platform for petabyte-scale remote-sensing analytics — it hosts every major archive (Landsat, Sentinel, MODIS, dozens more) and provides a JavaScript / Python API for server-side computation. But: **GEE export is constrained**.
+
+- `ee.data.computePixels()` and `ee.data.getPixels()` cap requests at ~32 MB per call.
+- A modest AOI at 10 m resolution easily exceeds this.
+- Manually splitting and stitching is annoying and the source of countless duct-tape scripts.
+
+This module's job is to take any `ee.Image` and any AOI, and return a `GeoTensor` — splitting and parallelising the GEE calls automatically, no matter how large.
+
+---
+
+## 2. The export workflow
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                  GEE EXPORT WORKFLOW                                     │
+│                                                                          │
+│   User Request                                                           │
+│   ┌──────────────────┐                                                  │
+│   │ export_image()   │                                                  │
+│   │ - ee.Image       │                                                  │
+│   │ - geometry       │                                                  │
+│   │ - bands          │                                                  │
+│   └────────┬─────────┘                                                  │
+│            │                                                             │
+│            ▼                                                             │
+│   ┌──────────────────────────────────────────────────────────┐          │
+│   │  Try ee.data.computePixels() / ee.data.getPixels()       │          │
+│   │  (Limited to ~32MB per request)                          │          │
+│   └────────┬─────────────────────────────────┬───────────────┘          │
+│            │ Success                         │ "Total request size"     │
+│            ▼                                 ▼ error                    │
+│   ┌──────────────────┐            ┌──────────────────────────┐          │
+│   │ Return GeoTensor │            │ RECURSIVE TILE SPLITTING │          │
+│   └──────────────────┘            │                          │          │
+│                                   │  ┌────┬────┐             │          │
+│                                   │  │ Q1 │ Q2 │ Split into  │          │
+│                                   │  ├────┼────┤ 4 quadrants │          │
+│                                   │  │ Q3 │ Q4 │             │          │
+│                                   │  └────┴────┘             │          │
+│                                   │       │                  │          │
+│                                   │       ▼                  │          │
+│                                   │  Process each in        │          │
+│                                   │  parallel (ThreadPool)  │          │
+│                                   │       │                  │          │
+│                                   │       ▼                  │          │
+│                                   │  spatial_mosaic()       │          │
+│                                   │  to combine tiles       │          │
+│                                   └──────────────────────────┘          │
+│                                            │                            │
+│                                            ▼                            │
+│                                   ┌──────────────────┐                  │
+│                                   │ Return GeoTensor │                  │
+│                                   └──────────────────┘                  │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The recursion logic:
+
+1. Try the full request via `ee.data.computePixels()`.
+2. If GEE returns a "Total request size" error, split the bbox into 4 quadrants.
+3. Process each quadrant in parallel via a `ThreadPoolExecutor`.
+4. Each quadrant may itself need splitting — recurse.
+5. Mosaic results back together with [`mosaic.spatial_mosaic`](08_mosaic.md).
+
+This pattern handles arbitrary AOI sizes — the only practical limit is memory (final `GeoTensor` has to fit in RAM) and time (GEE rate-limits requests per project).
+
+---
+
+## 3. The four export functions
+
+| Function | Use for |
+|---|---|
+| `export_image_fast(image, ...)` | quick single-call export — no splitting; raises if too big |
+| `export_image(image_or_asset_id, ...)` | the workhorse — recursive splitting, parallel download |
+| `export_image_getpixels(asset_id, ...)` | direct-asset export via `ee.data.getPixels` (when you have the asset ID, not a computed image) |
+| `export_cube(query, geometry, ...)` | time-series export — returns `(T, C, H, W)` `GeoTensor` |
+
+`export_image` is the one you'll use 95% of the time. Source: [ee_image.py:223](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L223).
+
+`export_cube` ([ee_image.py:392](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L392)) is built on top — accepts a GeoDataFrame of (acquisition_date, asset_id) rows, exports each row as a 3D image, and stacks them along a new time axis.
+
+---
+
+## 4. The split helper
+
+`split_bounds(bounds) → list[bounds]` ([ee_image.py:211](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L211)) does the quadrant split:
+
+```text
+   bounds = (minx, miny, maxx, maxy)
+   midx = (minx + maxx) / 2
+   midy = (miny + maxy) / 2
+
+   Q1: (minx, midy, midx, maxy)   Q2: (midx, midy, maxx, maxy)
+   Q3: (minx, miny, midx, midy)   Q4: (midx, miny, maxx, midy)
+```
+
+Always 4-way split (not adaptive based on aspect ratio). Adequate for the typical "moderately large AOI" case; can be inefficient for very long thin AOIs (a 10000:1 aspect ratio strip would need many splits before each chunk fits — but the typical RS AOI is roughly square).
+
+---
+
+## 5. The Sentinel-2 special case: `interpolate_20mbands_s2ee`
+
+When you download S2 from GEE asking for 10 m resolution, GEE upsamples the 20 m and 60 m bands using **nearest neighbour**. That produces ugly blocky bands at 10 m — not what you want.
+
+`interpolate_20mbands_s2ee(geotensor, ...)` ([ee_image.py:476](../../../../tmp/georeader_src/georeader/readers/ee_image.py#L476)) post-processes the result by re-resampling the affected bands with **bicubic** interpolation. The result looks like a real 10 m image rather than blocky pixels.
+
+This isn't a bug in this module — it's a quirk of GEE's S2 ingestion. The workaround is the kind of detail that takes you an afternoon to find on the GEE forum; having it as a one-line call makes the module pay for itself.
+
+---
+
+## 6. The query side — `ee_query.py`
+
+`ee_query.py` (589 LOC) handles the **discovery** side: given a polygon and a date range, return a GeoDataFrame of available scenes. Functions like `query_collection(collection_name, polygon, start_date, end_date)` for each major collection (Sentinel-2, Landsat, MODIS, etc.).
+
+The output GeoDataFrame is the input shape that `export_cube` consumes — so the pattern is:
+
+```python
+from georeader.readers import ee_query, ee_image
+
+# 1. Find scenes
+scenes = ee_query.query_s2_l2a(polygon=aoi, start_date="2024-01-01", end_date="2024-12-31")
+# scenes is a GeoDataFrame with one row per S2 scene over the AOI in 2024
+
+# 2. Filter
+scenes = scenes[scenes["cloud_cover"] < 20]
+
+# 3. Export as a time-series cube
+cube = ee_image.export_cube(scenes, geometry=aoi, bands=["B04", "B03", "B02"], scale=10)
+# cube is a (T, 3, H, W) GeoTensor
+```
+
+That's the whole "find S2 scenes over Madagascar in 2024 with < 20% cloud cover, get an RGB time series" pipeline in 6 lines of meaningful code.
+
+---
+
+## 7. Authentication
+
+GEE requires authentication. The package uses `ee.Authenticate()` and `ee.Initialize()` from the official `earthengine-api`. Standard setup:
+
+```python
+import ee
+ee.Authenticate()  # browser flow first time, cached afterwards
+ee.Initialize(project="my-gcp-project")
+```
+
+The `[ee]` extra (`pip install georeader-spaceml[ee]`) installs `earthengine-api`. Without it, importing `readers.ee_image` raises `ImportError`.
+
+The credentials live in `~/.config/earthengine/credentials` (managed by `ee.Authenticate()`); the module doesn't add its own credential file like EMIT does.
+
+---
+
+## 8. Function reference
+
+**Image export**
+- `export_image_fast(image, geometry, bands=None, scale=None, ...)` — single call, no splitting
+- `export_image(image_or_asset_id, geometry, bands=None, scale=None, crs=None, ...)` — recursive splitting + parallel download
+- `export_image_getpixels(asset_id, geometry, bands=None, ...)` — for direct-asset access via `getPixels`
+- `export_cube(query, geometry, bands=None, scale=None, ...)` — time-series export from a GeoDataFrame query
+
+**Helpers**
+- `split_bounds(bounds) → list[bounds]` — 4-way quadrant split
+- `_find_padding(v, divisor=8) → int` — pad to GEE-friendly multiples (internal)
+- `interpolate_20mbands_s2ee(geotensor, ...)` — fix S2 nearest-neighbour upsampling
+
+**Query side (separate file `ee_query.py`)**
+- `query_collection(collection, polygon, ...)` — generic collection query
+- `query_s2_l2a(...)`, `query_s2_l1c(...)`, `query_landsat(...)`, etc. — collection-specific helpers
+
+**Utilities (separate file `ee_utils.py`, 58 LOC)**
+- Auth helpers, GEE-version checks, small adapters between `ee.Geometry` and Shapely
+
+---
+
+## 9. Sharp edges
+
+- **GEE rate limits per project.** Recursive splitting can issue many concurrent requests; on a small AOI this is fine, on a continental one you might hit `quota_exceeded` errors. Tune via fewer parallel threads (`max_workers=2`) or stagger requests.
+- **`ee.Initialize(project=...)` is required.** GEE migrated to project-scoped quotas in 2024; old code that just called `ee.Initialize()` without a project ID will fail. Use a GCP project you have access to.
+- **Authenticated S3-style mirrors are different.** GEE's mirrors of Sentinel-2 are *not* the same as the AWS / GCS public buckets. The `gs://gcp-public-data-sentinel-2` URL works without GEE auth (Chapter 14). GEE access to S2 needs `ee.Initialize` + project quota.
+- **Nearest-neighbour upsampling for S2 20m bands.** Always run `interpolate_20mbands_s2ee` after exporting S2 at 10 m or your bands look terrible.
+- **`export_cube` aligns to the first scene's grid.** Heterogeneous resolutions across times need a `scale=` arg to be explicit. Mix-and-match Landsat-8 (30 m) + Sentinel-2 (10 m) without `scale=` will silently coerce to whatever the first scene was.
+- **Recursive splitting can OOM at the join.** The final `spatial_mosaic` call materialises all quadrants in memory. For petabyte-scale exports, `export_cube` with windowed writes to disk is more appropriate than `export_image` to a single `GeoTensor`.
+- **The `ee` import is hard.** `from georeader.readers import ee_image` requires `earthengine-api` to be installed. The package's `[ee]` extra makes this explicit; the import won't be silently skipped.
+
+---
+
+## 10. Connection to `geotoolz`
+
+GEE doesn't have a dedicated wrapper in [`geotoolz.md`](../plans/geotoolz.md), but it shows up as a substrate alternative:
+
+- **Catalog discovery via `ee_query`** is a sibling to `geotoolz.catalog_ops.CatalogPipeline(catalog, op).run()` from the geotoolz plan. The two could converge: `ee_query.query_*` produces a GeoDataFrame; `CatalogPipeline` consumes a `GeoCatalog`. A small adapter would let `geotoolz.catalog_ops` operate on GEE-discovered scenes directly.
+- **`export_cube` is the GEE analogue of `RasterioReader([paths], stack=True)`** — both produce `(T, C, H, W)`. Operators that consume time-stacks (e.g., `geotoolz.compositing.MedianComposite`) work on either substrate without modification.
+
+For users who already live on GEE, this module is the bridge that lets them move pipelines into the georeader / geotoolz operator world without abandoning the GEE archive.
+
+Next chapter: [17_legacy_sensors.md](17_legacy_sensors.md) — the legacy operational sensor readers (SPOT VGT, Proba-V).

--- a/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
+++ b/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
@@ -1,0 +1,161 @@
+# Chapter 17 — `readers/{spotvgt,probav}_image_operational.py`: legacy sensors
+
+> **Modules:**
+> - `georeader/readers/spotvgt_image_operational.py` (389 LOC)
+> - `georeader/readers/probav_image_operational.py` (701 LOC)
+> **Role:** read SPOT VGT and Proba-V — two coarse-resolution operational vegetation-monitoring sensors that pre-date the Sentinel-2 era. **No ASCII diagrams in either file.** They're operational readers built before the docstring-illustration push.
+
+---
+
+## 1. Why these readers exist at all
+
+SPOT VGT and Proba-V are vegetation-monitoring missions built around **daily global coverage** rather than high spatial resolution:
+
+| Sensor | Operator | Years | GSD | Bands | Coverage |
+|---|---|---|---|---|---|
+| **SPOT VGT** | CNES + VITO | 1998–2014 | 1 km | Blue, Red, NIR, SWIR | Daily global |
+| **Proba-V** | ESA + VITO | 2013–2020 | 100 m / 300 m / 1 km | Blue, Red, NIR, SWIR | Near-daily global |
+
+Both are 1 km–100 m sensors with 4 bands (Blue, Red, NIR, SWIR) — **vastly less rich** than the Sentinel-2-era spectrometers. So why include them?
+
+1. **Historical baseline.** Pre-2015 vegetation studies almost all use VGT. To build a multi-decadal time series you need to read VGT data the same way you read S2 data.
+2. **Continuity.** Proba-V was the explicit gap-filler between VGT (2014 end-of-life) and Sentinel-3 (operational 2018). Some climate datasets stitch all three.
+3. **Operational simplicity.** These products are tiled in WGS84 with simple GeoTIFFs — no SAFE complexity, no GLT, no per-pixel coords. They're useful as a "minimal sensor reader" reference.
+
+The headers explicitly call out that these are **unofficial readers** — built by the package authors against published user manuals, not certified by the agencies. Behaviour matches the manual but isn't guaranteed against future product-format changes.
+
+---
+
+## 2. The shared design pattern
+
+Both readers expose the same minimal `GeoData`-shaped surface:
+
+```python
+SpotVGT(path, ...)
+ProbaV(path, ...)
+ProbaVRadiometry(path, ...)   # subclass with band-level ToA reflectance
+ProbaVSM(path, ...)            # subclass for the Status Map (QA mask)
+```
+
+Each class implements:
+- **`transform`, `crs`, `shape`** — the standard `GeoData` triple.
+- **`load(boundless=True)`** — return a `GeoTensor`.
+- **`read_from_window(window, boundless=True)`** — window-restricted read.
+
+So you can drop a `SpotVGT` or `ProbaV` instance into any `read.read_from_polygon(reader, ...)` call. The `GeoData` protocol is the abstraction that makes this just work.
+
+---
+
+## 3. Internal helpers — `read_band_toa`
+
+Both modules have a `read_band_toa(dataset, band, slice_to_read)` function:
+
+- Reads the digital-number band data via rasterio.
+- Applies per-band ToA reflectance scale + offset from the band metadata.
+- Returns a calibrated array.
+
+Used internally by both readers — saves repeating the calibration boilerplate per call site.
+
+---
+
+## 4. SPOT VGT: `SpotVGT`
+
+The single class is at [spotvgt_image_operational.py:65](../../../../tmp/georeader_src/georeader/readers/spotvgt_image_operational.py#L65). Standard layout:
+
+- Detects band files in the SPOT VGT product folder via filename regex.
+- Parses acquisition date / sensor / processing version from the filename.
+- Aligns the per-band GeoTIFFs onto a common WGS84 grid.
+- Provides cloud-masking helpers via `sm_cloud_mask(sm, mask_undefined=False)` ([spotvgt_image_operational.py:365](../../../../tmp/georeader_src/georeader/readers/spotvgt_image_operational.py#L365)) — extracts cloud / cloud-shadow / land-water flags from the SM (Status Map) bit-encoded raster.
+- `mask_only_sm(sm)` is a more aggressive variant — drops anything not pristine clear sky.
+
+### SM bit decoding
+
+The SPOT VGT Status Map encodes 8 flags in one byte. The functions decode bits like:
+
+| Bit | Meaning |
+|---|---|
+| 0 | Clear |
+| 1 | Cloud shadow |
+| 2 | Undefined |
+| 3 | Cloud |
+| 4 | Ice / snow |
+| 5 | Water |
+| 6 | Land |
+| 7 | Mixed |
+
+`sm_cloud_mask(sm, mask_undefined=True)` returns a boolean mask of "definitely cloudy" pixels — `cloud OR cloud_shadow [OR undefined]`.
+
+---
+
+## 5. Proba-V: `ProbaV`, `ProbaVRadiometry`, `ProbaVSM`
+
+The Proba-V hierarchy is more elaborate ([probav_image_operational.py](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py)):
+
+- **`ProbaV`** ([line 64](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py#L64)) — base reader for the 4-band imagery.
+- **`ProbaVRadiometry`** ([line 507](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py#L507)) — subclass that loads ToA reflectance directly (handles per-band gain/offset internally).
+- **`ProbaVSM`** ([line 590](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py#L590)) — subclass that exposes the Status Map for cloud / shadow / quality.
+
+The Status Map decoder functions `sm_cloud_mask` and `mask_only_sm` are duplicated between the two modules — same names, same logic, different bit conventions. Proba-V's SM is a different format than VGT's despite both coming from VITO; the readers can't share decoder code.
+
+The Proba-V file also has compression-availability checks (`is_compression_available`, `assert_compression_available`) — Proba-V uses LZW or DEFLATE per acquisition, and pre-2017 readers without recent libtiff would silently fail to decode some files. The check raises a clear error before reading.
+
+---
+
+## 6. Why the readers are similar but not identical
+
+A code-deduplication argument would say "extract a shared `LegacyVITOReader` base." The package doesn't, for two pragmatic reasons:
+
+1. **The user manuals describe them as separate products.** A user navigating from the VGT manual to the code wants a `SpotVGT` class, not a `LegacyVITOReader.create(sensor="vgt")`.
+2. **Bit-flag conventions differ.** Even though both Status Maps look superficially similar (8 bits per pixel, one bit per quality flag), the bit→meaning mapping is different. Sharing a decoder would require a configuration map that obscures more than it saves.
+
+This is a recurring pattern in sensor readers: the surface area looks like it should generalise, but the per-sensor calibration / bit / metadata details bake in enough divergence that the de-duplication isn't worth the indirection.
+
+---
+
+## 7. Function reference
+
+### SPOT VGT (`spotvgt_image_operational.py`)
+- `SpotVGT(path, ...)` — main reader class
+- `read_band_toa(dataset, band, slice_to_read)` — internal calibration helper
+- `sm_cloud_mask(sm, mask_undefined=False) → np.ndarray` — boolean cloud mask
+- `mask_only_sm(sm) → np.ndarray` — strict clear-sky mask
+
+### Proba-V (`probav_image_operational.py`)
+- `ProbaV(path, ...)` — base reader
+- `ProbaVRadiometry(path, ...)` — ToA reflectance subclass
+- `ProbaVSM(path, ...)` — Status Map subclass
+- `read_band_toa(dataset, band, slice_to_read)` — internal calibration helper
+- `is_compression_available(dataset) → bool` — libtiff check
+- `assert_compression_available(dataset)` — raise if compression unavailable
+- `sm_cloud_mask(sm, mask_undefined=False) → np.ndarray` — Proba-V version
+- `mask_only_sm(sm) → np.ndarray` — Proba-V version
+
+---
+
+## 8. Sharp edges
+
+- **Filename-encoded metadata.** Both readers parse acquisition date / processing version from filenames via regex. Renamed files (or files served through path-rewriting CDNs) break the parser. Keep filenames intact.
+- **WGS84-tiled.** Output is in geographic coordinates (degrees), not projected UTM. For pixel-area work you need to convert or accept that 1 km at the equator is not 1 km at high latitudes.
+- **Small bands × big tiles.** The 1 km native resolution × global daily coverage means individual product files are large arrays of mostly-zeros (over oceans, deserts at night, etc.). Read with `boundless=False` if you want to detect coverage gaps.
+- **Two `sm_cloud_mask` functions exist.** They have the same name in the two modules. Be explicit: `from georeader.readers.spotvgt_image_operational import sm_cloud_mask as vgt_cloud_mask` to avoid confusion.
+- **Proba-V's compression check is silent until enabled.** If your libtiff is old, some files load partially zeros. Always call `assert_compression_available(dataset)` early in production code.
+- **Status Map bit-flag conventions are sensor-specific.** Don't port code from VGT to Proba-V (or vice versa) by copy-paste — the bit meanings differ.
+- **No GLT, no RPCs, no per-pixel coords.** These readers don't need [Chapter 7](07_griddata.md) — the products are already orthorectified to WGS84.
+
+---
+
+## 9. Why no diagrams
+
+The two modules predate the documentation push that added ASCII diagrams to the rest of the package. They're stable, used by a handful of climate-baseline pipelines, and the maintainers haven't added illustrations because there's not much to illustrate — these are simple band-stack readers without the structural complexity of EMIT (GLT) or PRISMA (curvilinear) or S2 SAFE (multi-resolution + JP2 stacking).
+
+Including them in this tutorial preserves the catalog completeness, but you can probably skip these if you're not specifically working with VGT or Proba-V. The readers are stable, well-named, and self-documenting in their docstrings.
+
+---
+
+## 10. Connection to `geotoolz`
+
+Neither sensor has a dedicated preset in [`geotoolz.md`](../plans/geotoolz.md). Proba-V and SPOT VGT are unlikely to grow new operators because they're discontinued. They'd live in `geotoolz.presets.legacy` if ever — a `presets.legacy.PROBAV_NDVI` operator would be `Sequential([ProbaVRadiometry.load(), MaskClouds(via SM), NDVI(red_idx=1, nir_idx=2)])`. Trivial to implement, but rare enough that no-one's asked.
+
+The general lesson: **operators are sensor-agnostic; readers are sensor-specific**. As long as a sensor's reader returns a `GeoData` with band semantics that match a downstream operator's `red_idx=` / `nir_idx=` arguments, the operator works without any sensor-specific code.
+
+Next chapter: [18_query_and_download.md](18_query_and_download.md) — query / catalog / download helpers (`scihubcopernicus_query`, `download_pv_product`, `query_utils`, `tileserver`, `download_utils`).

--- a/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
+++ b/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
@@ -1,4 +1,4 @@
-# Chapter 17 — `readers/{spotvgt,probav}_image_operational.py`: legacy sensors
+# Ch. 17 — legacy sensors
 
 > **Modules:**
 > - `georeader/readers/spotvgt_image_operational.py` (389 LOC)
@@ -60,12 +60,12 @@ Used internally by both readers — saves repeating the calibration boilerplate 
 
 ## 4. SPOT VGT: `SpotVGT`
 
-The single class is at [spotvgt_image_operational.py:65](../../../../tmp/georeader_src/georeader/readers/spotvgt_image_operational.py#L65). Standard layout:
+The single class is at [spotvgt_image_operational.py:65](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/spotvgt_image_operational.py#L65). Standard layout:
 
 - Detects band files in the SPOT VGT product folder via filename regex.
 - Parses acquisition date / sensor / processing version from the filename.
 - Aligns the per-band GeoTIFFs onto a common WGS84 grid.
-- Provides cloud-masking helpers via `sm_cloud_mask(sm, mask_undefined=False)` ([spotvgt_image_operational.py:365](../../../../tmp/georeader_src/georeader/readers/spotvgt_image_operational.py#L365)) — extracts cloud / cloud-shadow / land-water flags from the SM (Status Map) bit-encoded raster.
+- Provides cloud-masking helpers via `sm_cloud_mask(sm, mask_undefined=False)` ([spotvgt_image_operational.py:365](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/spotvgt_image_operational.py#L365)) — extracts cloud / cloud-shadow / land-water flags from the SM (Status Map) bit-encoded raster.
 - `mask_only_sm(sm)` is a more aggressive variant — drops anything not pristine clear sky.
 
 ### SM bit decoding
@@ -89,11 +89,11 @@ The SPOT VGT Status Map encodes 8 flags in one byte. The functions decode bits l
 
 ## 5. Proba-V: `ProbaV`, `ProbaVRadiometry`, `ProbaVSM`
 
-The Proba-V hierarchy is more elaborate ([probav_image_operational.py](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py)):
+The Proba-V hierarchy is more elaborate ([probav_image_operational.py](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/probav_image_operational.py)):
 
-- **`ProbaV`** ([line 64](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py#L64)) — base reader for the 4-band imagery.
-- **`ProbaVRadiometry`** ([line 507](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py#L507)) — subclass that loads ToA reflectance directly (handles per-band gain/offset internally).
-- **`ProbaVSM`** ([line 590](../../../../tmp/georeader_src/georeader/readers/probav_image_operational.py#L590)) — subclass that exposes the Status Map for cloud / shadow / quality.
+- **`ProbaV`** ([line 64](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/probav_image_operational.py#L64)) — base reader for the 4-band imagery.
+- **`ProbaVRadiometry`** ([line 507](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/probav_image_operational.py#L507)) — subclass that loads ToA reflectance directly (handles per-band gain/offset internally).
+- **`ProbaVSM`** ([line 590](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/probav_image_operational.py#L590)) — subclass that exposes the Status Map for cloud / shadow / quality.
 
 The Status Map decoder functions `sm_cloud_mask` and `mask_only_sm` are duplicated between the two modules — same names, same logic, different bit conventions. Proba-V's SM is a different format than VGT's despite both coming from VITO; the readers can't share decoder code.
 

--- a/projects/geotoolz/georeader_tutorial/18_query_and_download.md
+++ b/projects/geotoolz/georeader_tutorial/18_query_and_download.md
@@ -1,0 +1,174 @@
+# Chapter 18 — `readers/{scihubcopernicus_query, download_pv_product, query_utils, tileserver, download_utils}.py`: catalog query & download helpers
+
+> **Modules** (all small):
+> - `query_utils.py` (80 LOC) — generic spatial-overlap helpers
+> - `scihubcopernicus_query.py` (111 LOC) — Copernicus SciHub query (Sentinel-1/2/3)
+> - `download_utils.py` (61 LOC) — generic HTTP-with-auth download
+> - `download_pv_product.py` (328 LOC) — Proba-V product download from VITO
+> - `tileserver.py` (68 LOC) — XYZ tileserver consumer
+>
+> **Role:** the **discovery and acquisition** plumbing. Find scenes by AOI + time, download them, or read from a web tile server. **No ASCII diagrams in any of these.** They're all small utility modules.
+
+---
+
+## 1. The shape of the discovery layer
+
+Most users don't have raw paths to satellite scenes — they have an AOI and a date range. The work flow is:
+
+1. **Query a catalog** ("what scenes overlap my AOI in this date range?") → list of product metadata.
+2. **Filter** ("only ones with < 20% cloud cover") → narrower list.
+3. **Download** (or, increasingly, just construct cloud-bucket URLs and read lazily) → local files or paths.
+4. **Read** with one of the chapters 14–17 readers.
+
+The five small modules in this chapter cover steps 1–3. Step 4 is the rest of the package.
+
+---
+
+## 2. `query_utils.py` — generic spatial helpers
+
+Three functions, all collection-agnostic. The shared infrastructure that the per-collection query modules build on.
+
+| Function | What it does |
+|---|---|
+| `select_polygons_overlap(polygons, aoi)` | Return indices of polygons that maximally overlap an AOI. Used to rank candidate scenes by coverage. |
+| `filter_products_overlap(area, ...)` | Filter a list of products by spatial overlap with an area. |
+| `solar_datetime(area=None, ...)` | Compute local solar datetime for an AOI — useful for filtering scenes by daylight conditions or computing solar geometry. |
+
+Used by the per-collection query modules (`scihubcopernicus_query`, `ee_query`, etc.) as common machinery.
+
+---
+
+## 3. `scihubcopernicus_query.py` — Copernicus SciHub queries
+
+```python
+get_api(api_url='https://scihub.copernicus.eu/dhus/') -> SentinelAPI
+query(area, date_start, date_end, ...) -> gpd.GeoDataFrame
+```
+
+Wraps the [`sentinelsat`](https://sentinelsat.readthedocs.io/) library to issue spatial-temporal queries against the official Copernicus SciHub catalog. Returns a GeoDataFrame with one row per matched product, columns including `geometry`, `beginposition`, `cloudcoverpercentage`, `producttype`, `relativeorbitnumber`.
+
+This is the **legacy** way to query Sentinel scenes. The Copernicus Data Space (`https://catalogue.dataspace.copernicus.eu/`) replaced SciHub in 2023; for new workflows, prefer:
+
+- **GEE** ([Chapter 16](16_earth_engine.md)) — wider catalog, no auth complications.
+- **STAC catalogs** — Element84, Microsoft Planetary Computer (Chapter 14 mentions both). The corresponding `s2_load_from_feature_*` adapters in `S2_SAFE_reader.py` consume STAC features directly.
+
+The SciHub module remains for users with workflows that pre-date the 2023 transition. Authentication uses Copernicus credentials via `sentinelsat.SentinelAPI(user, password, api_url)`.
+
+---
+
+## 4. `download_utils.py` — generic HTTP download
+
+Single function:
+
+```python
+download_product(link_down, filename=None, auth=None, ...) -> str
+```
+
+Stream-downloads a URL to disk with optional HTTP basic auth. The base building block for all the per-source downloaders. Uses `requests` (which is a hard dep of this module — `import` raises `ImportError` if not installed).
+
+Notable: the `auth` argument is just `requests`-style — pass a `(user, password)` tuple or a `requests.auth.AuthBase` subclass. No package-specific auth abstraction.
+
+---
+
+## 5. `download_pv_product.py` — Proba-V VITO downloads
+
+Proba-V data lives on [VITO's product distribution portal](https://www.vito-eodata.be/PDF/datapool/). Authentication uses VITO credentials stored in `~/.georeader/auth_vito.json`.
+
+The module exposes a download workflow:
+
+| Function | Purpose |
+|---|---|
+| `get_auth()` | Read VITO credentials from disk |
+| `download_product(link_down, ...)` | Wraps `download_utils.download_product` with VITO auth |
+| `fetch_products_date_region(date, bounding_box, ...)` | Find Proba-V products for a date + bbox |
+| `download_L2A_date_region(date, bounding_box, dir_out, resolution="333M", ...)` | Find + download in one call |
+| `download_L2A_product(year, month, day, ...)` | Download a single product by ID |
+| `download_L2A_product_from_name(product_name, dir_out)` | Download by product name |
+| `download_L2A_xml_from_name(product_name, dir_out)` | Download metadata XML only |
+| `is_downloadable(url, auth=None)` | Check URL accessibility |
+| `exists_product_name(product_name, dir_out)` | Local existence check |
+| `extract_L2_file_naming_content(product_name)` | Parse fields from filename |
+| `read_L2A_xml(product_name, dir_out)` | Parse the XML metadata |
+
+The granularity is high because Proba-V's distribution is more rigid than modern STAC catalogs — there are specific URL patterns for `(year, month, day, camera, resolution)` tuples that the module encodes.
+
+This pairs with [`probav_image_operational.py`](17_legacy_sensors.md) — the download module fetches the files, the operational reader reads them. Together they cover the full Proba-V pipeline.
+
+---
+
+## 6. `tileserver.py` — XYZ tile server consumer
+
+```python
+read_from_tileserver(tile_server, geometry, ...) -> GeoTensor
+```
+
+Reads from a slippy-map XYZ tile server (Mapbox, Google Maps, OSM-style basemaps). Given a polygon AOI:
+
+1. Compute which `(x, y, z)` tiles cover the AOI via [`mercantile`](https://github.com/mapbox/mercantile).
+2. HTTP-GET each tile from the tileserver URL pattern (e.g., `https://tile.openstreetmap.org/{z}/{x}/{y}.png`).
+3. Decode the PNG/JPEG to a numpy array.
+4. Mosaic them via `mosaic.spatial_mosaic` (Chapter 8) into a single `GeoTensor` in Web Mercator (EPSG:3857).
+
+Useful for:
+
+- **Basemaps as raster context.** Drop OSM tiles under a derived layer for visualisation.
+- **Quick previews.** When you have an AOI but no archive access, a tileserver gives you something to work with.
+
+The output is in **Web Mercator**, not the native CRS of the satellite imagery you're typically processing. If you need it in another CRS, follow with `read.read_to_crs` ([Chapter 5 §4](05_read.md)).
+
+---
+
+## 7. Function reference (quick)
+
+| Module | Functions |
+|---|---|
+| `query_utils.py` | `select_polygons_overlap`, `filter_products_overlap`, `solar_datetime` |
+| `scihubcopernicus_query.py` | `get_api`, `query` |
+| `download_utils.py` | `download_product` |
+| `download_pv_product.py` | 11 functions covering Proba-V's full discovery + download flow |
+| `tileserver.py` | `read_from_tileserver` |
+
+---
+
+## 8. Sharp edges
+
+- **SciHub is deprecated.** Don't build new code against `scihubcopernicus_query`. Use Microsoft Planetary Computer or Element84 STAC catalogs instead.
+- **Credential files are plaintext JSON.** `~/.georeader/auth_emit.json`, `~/.georeader/auth_vito.json`. Make sure they're not in dotfile sync. The package doesn't encrypt them.
+- **Tileserver outputs are in EPSG:3857.** Web Mercator is *not* the same as UTM zones — don't `same_extent` against an S2 scene without reprojecting first.
+- **Tileserver licensing.** Pulling many tiles from OSM violates their tile-usage policy (rate limit, attribution). For production / research you'd want a self-hosted tileserver or a paid Mapbox account.
+- **Proba-V download URLs encode many fields.** A typo in the camera ID or resolution silently returns 404. The `exists_product_name` helper exists for the same reason.
+- **`requests` is a hard import for `download_utils`.** Other modules import lazily; this one fails on module load if `requests` isn't installed.
+
+---
+
+## 9. Connection to `geotoolz`
+
+The discovery layer is **explicitly out of scope** for `geotoolz` per [`geotoolz.md` §1.3](../plans/geotoolz.md):
+
+> **Not `georeader`.** No I/O, no CRS plumbing, no reader classes, no catalog construction. Those are `georeader`'s job.
+
+But there's a clean handoff: `geotoolz.catalog_ops.CatalogPipeline(catalog, op).run()` (from [§1.2 of the plan](../plans/geotoolz.md)) consumes a `georeader.catalog.GeoCatalog` — which (per [`geocatalog.md`](../plans/geocatalog.md) and [`geoduckdb.md`](../plans/geoduckdb.md)) is a planned addition to georeader that would unify all the per-collection query modules in this chapter.
+
+The future state, per the plans:
+
+- All per-collection query modules return GeoDataFrames in the same schema.
+- A `GeoCatalog` wraps any GeoDataFrame as a queryable, persistable spatial index.
+- `geotoolz.catalog_ops.CatalogPipeline` takes a `GeoCatalog`, applies a `Sequential` of operators per row, writes outputs.
+
+Today, you build that pipeline by hand — query, filter, loop, read, process, write. The chapters 14–18 give you the building blocks; the orchestration is your code.
+
+---
+
+## 10. Closing the tutorial
+
+This is the final chapter. The full coverage:
+
+- **Part I (Ch. 1–3):** core data model — `GeoTensor`, abstract reader protocols, `RasterioReader`.
+- **Part II (Ch. 4–6):** reading & windowing — `window_utils`, `read.py`, `slices`.
+- **Part III (Ch. 7–10):** geometry & gridding — `griddata`, `mosaic`, `rasterize`, `vectorize`.
+- **Part IV (Ch. 11–13):** radiometry & I/O — `reflectance`, `save`, miscellaneous utilities.
+- **Part V (Ch. 14–18):** sensor readers — Sentinel-2, hyperspectral trio, Earth Engine, legacy sensors, query/download.
+
+Total preserved: **all ASCII diagrams across 17 modules** that had them, plus the implementation walkthroughs (the 8-step `read_reproject` annotation in [Chapter 5](05_read.md)) that were also at risk of being cleaned up. The tutorial mirrors the package structure so a reader can navigate from "I want to do X" → which module → which chapter → the diagrams + prose explaining it.
+
+The closing observation: **georeader is a coherent stack, not a kitchen sink.** Every module builds on the layer below it. `GeoTensor` (Chapter 1) carries metadata; `window_utils` (Chapter 4) does pixel-geo math; `read.py` (Chapter 5) composes the two; `mosaic` / `rasterize` / `vectorize` (Chapters 8–10) build on `read.py`; the sensor readers (Chapters 14–17) plug into the `GeoData` protocol so all of the above just works on real-world products. That layering is what makes a `geotoolz` operator-composition library viable — it has a clean substrate to sit on.

--- a/projects/geotoolz/georeader_tutorial/18_query_and_download.md
+++ b/projects/geotoolz/georeader_tutorial/18_query_and_download.md
@@ -1,4 +1,4 @@
-# Chapter 18 — `readers/{scihubcopernicus_query, download_pv_product, query_utils, tileserver, download_utils}.py`: catalog query & download helpers
+# Ch. 18 — query & download
 
 > **Modules** (all small):
 > - `query_utils.py` (80 LOC) — generic spatial-overlap helpers

--- a/projects/geotoolz/plans/geocatalog.md
+++ b/projects/geotoolz/plans/geocatalog.md
@@ -1,5 +1,5 @@
 
-# Dataset-builder snippets — design report for georeader integration
+# Dataset builder (Phase 1)
 
 > **Scope:** evaluating the `remote_sensing/dataset*.py`, `sampler.py`, `operations.py`, and `rasterio_utils.py` files in [`jejjohnson/jej_vc_snippets`](https://github.com/jejjohnson/jej_vc_snippets) for promotion into [`jejjohnson/georeader`](https://github.com/jejjohnson/georeader).
 >

--- a/projects/geotoolz/plans/geocatalog.md
+++ b/projects/geotoolz/plans/geocatalog.md
@@ -1,0 +1,866 @@
+
+# Dataset-builder snippets — design report for georeader integration
+
+> **Scope:** evaluating the `remote_sensing/dataset*.py`, `sampler.py`, `operations.py`, and `rasterio_utils.py` files in [`jejjohnson/jej_vc_snippets`](https://github.com/jejjohnson/jej_vc_snippets) for promotion into [`jejjohnson/georeader`](https://github.com/jejjohnson/georeader).
+>
+> **Status:** design proposal, no code changed yet.
+
+---
+
+## 0. What I read
+
+I worked from the public-API view (signatures + docstrings) plus the algorithmic core of every function. The six files in `jej_vc_snippets/remote_sensing/` that are dataset-builder material are:
+
+| File | Lines | Top-level surface |
+| --- | ---: | --- |
+| `dataset.py` | 1835 | `build_spatiotemporal_index`, `load_and_merge_rasters_spatial`, `load_and_merge_spatiotemporal` |
+| `dataset_xarray.py` | 1758 | `build_xarray_spatiotemporal_index`, `load_xarray_datasets`, `merge_xarray_datasets`, `load_xarray_datasets_spatiotemporal`, `merge_xarray_datasets_spatiotemporal` |
+| `dataset_vector.py` | 1888 | `build_vector_spatiotemporal_index`, `load_and_rasterize_vectors_spatial`, `load_and_rasterize_vectors_spatiotemporal` (+ `_convert_poly_coords`) |
+| `sampler.py` | 1378 | `GeoSlice` dataclass + `random_geo_sampler`, `grid_geo_sampler`, `run_inference_with_grid_sampler`, `stitch_predictions`, helpers |
+| `operations.py` | ~1000 | `query_spatiotemporal_index`, `intersect_spatiotemporal_indexes`, `union_spatiotemporal_indexes` |
+| `rasterio_utils.py` | ~250 | `update_metadata`, `read_metadata`, `filter_by_metadata`, `get_tags`, `print_all_metadata`, `save_image_with_tags`, `append_tags_to_existing` |
+
+> ⚠️ Found two literal syntax errors in `dataset_vector.py` (`return_meta bool = True` missing colon at line ~416; `if return_meta` missing colon at line ~1076). The file has never been imported successfully. Tests are therefore sparse to non-existent.
+
+---
+
+## 1. Inventory: what these snippets actually are
+
+The six files form a small **catalog → query → load → sample → stitch** stack, with three storage backends (raster / xarray / vector) sharing one index format.
+
+### 1.1 The shared index format
+
+Every `build_*_spatiotemporal_index` function emits the *same* object: a `geopandas.GeoDataFrame` whose row label is a `pd.IntervalIndex(name='datetime', closed='both')` and whose `geometry` column holds reprojected file footprints (bounding-box `Polygon`s in a uniform target CRS). One row per file. Extra columns differ by backend (`filepath` always; for xarray, also `data_vars`, `time_var`, `time_resolution`, `n_timesteps`; for vector, `layer`).
+
+This is the central design choice and it's a good one: **pandas + geopandas already give you `O(log n)` interval-tree temporal lookup and `O(log n)` R-tree spatial lookup for free.** No custom data structures needed.
+
+### 1.2 The three backends
+
+- **Raster (`dataset.py`)** — file footprints come from `rasterio.open(...).bounds`, reprojected to `target_crs` via a lazy `WarpedVRT`. Loaders use `rasterio.merge.merge()` driven by query bounds and a target resolution; output is a numpy array `(bands, height, width)` plus a validity mask, plus an `Affine`.
+- **Xarray (`dataset_xarray.py`)** — opens each file with `xr.open_dataset(...)` (engine inferred from extension: `.zarr` → zarr, else netcdf4/h5netcdf), resolves CRS via `rio.crs` or a fallback, derives bounds from coordinate min/max, parses time from a `time_var` (default `'time'`). Loaders return `xr.Dataset` (or per-var numpy arrays); merging uses `rioxarray.merge.merge_datasets`.
+- **Vector (`dataset_vector.py`)** — opens each file with `geopandas.read_file(...)`, reprojects to target CRS, footprint = `total_bounds`. Loaders rasterize with `rasterio.features.rasterize` and return `torch.long` tensors keyed by ML task (`semantic_segmentation`, `object_detection`, `instance_segmentation`).
+
+### 1.3 The set algebra
+
+`operations.py` adds:
+
+- `query_spatiotemporal_index` — spatial + temporal filter on one catalog.
+- `intersect_spatiotemporal_indexes` — cross-catalog AND.
+- `union_spatiotemporal_indexes` — cross-catalog OR (a glorified `pd.concat`).
+
+All operate at the index level, never opening a file.
+
+### 1.4 The sampler / inference layer
+
+`sampler.py` is the ML-glue:
+
+- `GeoSlice` dataclass = `(xmin, xmax, ymin, ymax, tmin, tmax, x_res, y_res, crs)` is the unit of work passed between samplers and loaders.
+- `random_geo_sampler` and `grid_geo_sampler` are factory functions that return zero-arg callables yielding `GeoSlice` iterators.
+- `run_inference_with_grid_sampler` ties sampler → loader → model → stitcher into one call.
+- `stitch_predictions` reverses the chip operation (`average` / `max` / `first` / `last` over overlaps).
+
+### 1.5 Auxiliary
+
+`rasterio_utils.py` is *not* a dataset builder — it's GDAL tag read/write helpers. It does not belong in this migration; fold the read helpers into georeader's existing `rasterio_reader.py` and drop the rest.
+
+---
+
+## 2. User story
+
+**Persona.** A scientist or ML engineer with a folder (or bucket) of N satellite or model-output files spanning years and tiles. Possibly heterogeneous: S2 mixed with Landsat, NetCDF reanalysis mixed with ad-hoc Zarr stores, raster imagery alongside vector labels.
+
+**Goal arc:**
+
+1. *"I have 10 000 files. Make them queryable."* → `build_*_index(filepaths, regex, target_crs)` → one GeoDataFrame.
+2. *"Give me the data for this bbox + this date range."* → `query_index(...)` → filtered subset → `load_and_merge_*(...)` → mosaicked numpy/xarray.
+3. *"Stream me ML training chips."* → `random_geo_sampler(index, chip_size).__call__()` → iterator of `GeoSlice` → call loader per slice → batch.
+4. *"Run my model over the whole AOI for the whole year and write a georeferenced raster."* → `run_inference_with_grid_sampler(index, model, output_path, chip_size, stride)` → stitched output.
+5. *"My imagery is in catalog A, my labels are in catalog B; pair them."* → `intersect_spatiotemporal_indexes(A, B)` → joint catalog, queries return only spatiotemporally-paired tiles.
+6. *"Combine Landsat 7 + Landsat 8 into one virtual dataset."* → `union_spatiotemporal_indexes(L7, L8)`.
+
+The stack is therefore not "yet another dataloader" — it's a **lightweight, file-based, Pythonic STAC**. No JSON catalog format, no service, no pgSTAC. Just a GeoDataFrame you can pickle.
+
+---
+
+## 3. Motivation
+
+### 3.1 The gap this fills in georeader
+
+`georeader` today is excellent at the *single-file* level: open a Sentinel-2 SAFE, read a bbox, get a `GeoTensor`, reproject, save COG. But it has **no story for collections of files**. If the user has ten years of daily files across many tiles, they're on their own to write the catalog, the query, the mosaic, and the temporal stack. These snippets are exactly that missing layer.
+
+The georeader modules these would build on are:
+
+| Snippet capability | Existing georeader module to extend / call into |
+| --- | --- |
+| Per-file footprint + bounds extraction | `rasterio_reader.py`, `abstract_reader.py` |
+| Spatial windowing into queried bounds | `window_utils.py`, `read.read_from_bounds` |
+| Multi-file spatial mosaic | `mosaic.py` |
+| Vector → raster | `rasterize.py` |
+| Output container | `geotensor.GeoTensor` |
+| Per-band reflectance, etc. (out of scope) | `reflectance.py` |
+
+### 3.2 Compared with alternatives
+
+- **TorchGeo `RasterDataset`** has the same idea (regex-parsed filename, R-tree, `BoundingBox` query). The snippets are a **lighter, GeoDataFrame-native reimagining** of that pattern, without the torch dependency in the index layer. That's a feature, not a bug — it lets non-ML users (analysis, mosaicking, inference) use the same catalog.
+- **STAC / pystac-client** is heavier: requires a JSON spec, an API, network fetches. The snippets work on local files and return a Python object you can ship around.
+- **xbatcher / xarray-spatial / odc-geo** overlap with the *xarray* loader but not with the catalog/intersection logic.
+
+The concrete value-add over TorchGeo is therefore:
+
+1. GeoDataFrame instead of a custom R-tree wrapper.
+2. Backend-agnostic same-shape index for raster / xarray / vector.
+3. Explicit set algebra (intersect / union) at the catalog level.
+4. No torch in the core path.
+
+---
+
+## 4. Mathematics
+
+### 4.1 Footprint construction
+
+For each file, the spatial footprint is the rectangle of its bounds in the target CRS:
+
+```python
+with rasterio.open(filepath) as src:
+    with WarpedVRT(src, crs=target_crs) as vrt:
+        xmin, ymin, xmax, ymax = vrt.bounds
+        polygon = shapely.geometry.box(xmin, ymin, xmax, ymax)
+```
+
+`WarpedVRT` is a *lazy* virtual reprojection: bounds are computed analytically from the source's affine + CRS without resampling pixels. This is what makes indexing 10 000 files fast.
+
+### 4.2 Temporal interval construction
+
+For a single-date capture filename, the file is treated as covering the full UTC day:
+
+```python
+mint = pd.Timestamp(date_str).floor('D')          # 00:00:00.000000
+maxt = pd.Timestamp(date_str).ceil('D') - 1e-6    # 23:59:59.999999
+```
+
+For a `(start, stop)` filename, the interval is `[floor(start), ceil(stop) - 1µs]`. For files with no date, `(pd.Timestamp.min, pd.Timestamp.max)` — a point of contention; see [§7](#7-sharp-edges-to-fix-on-the-way-in).
+
+### 4.3 Combined query
+
+Spatial + temporal lookup is the composition of two index probes:
+
+```python
+query_interval = pd.Interval(tmin, tmax, closed='both')
+filtered = index[index.index.overlaps(query_interval)]   # interval tree, O(log n + k)
+filtered = filtered.cx[xmin:xmax, ymin:ymax]              # R-tree, O(log n + k)
+```
+
+`IntervalIndex.overlaps` uses scipy / sortedcontainers under the hood; `GeoDataFrame.cx` uses the rtree spatial index that geopandas builds on first access.
+
+### 4.4 Index intersection (`operations.py`)
+
+For two indexes A and B sharing a CRS, the spatiotemporal intersection is computed in two stages:
+
+**Spatial.** `gpd.overlay(A, B, how='intersection', keep_geom_type=True)` — for each pair of polygons `(a, b)`, produces the polygon `a ∩ b` (or drops the pair if empty).
+
+**Temporal.** For each surviving pair, the temporal intersection of intervals `[a₁, b₁]` and `[a₂, b₂]` is
+
+$$
+[\max(a_1, a_2),\ \min(b_1, b_2)]
+$$
+
+discarded if `min(b₁, b₂) < max(a₁, a₂)`. Vectorised:
+
+```python
+mint  = np.maximum(datetime_1.left,  datetime_2.left)
+maxt  = np.minimum(datetime_1.right, datetime_2.right)
+valid = maxt >= mint
+```
+
+The result's `IntervalIndex` is built from those two arrays with `closed='both'`.
+
+### 4.5 Random-sampler weighting
+
+Tiles big enough to contain a chip are kept. Each surviving tile gets weight proportional to its area:
+
+$$
+w_i = \frac{(x_{\max,i} - x_{\min,i}) \cdot (y_{\max,i} - y_{\min,i})}{\sum_j A_j}
+$$
+
+A tile is drawn with `numpy.random.Generator.choice(p=w)`, then a chip is placed uniformly inside the tile:
+
+```python
+x_offset = uniform(0, tile_width  - chip_width)
+y_offset = uniform(0, tile_height - chip_height)
+```
+
+The timestamp is sampled uniformly (in seconds) inside the tile's interval and assigned to both `tmin` and `tmax`.
+
+> **Bias to flag.** This weighting pushes samples *toward* large tiles. Fine for uniform-density imagery; biased for tiled mosaics with one giant tile and many small ones. Worth exposing `weight={'area','uniform'}`.
+
+### 4.6 Grid-sampler stride math
+
+For each tile of size `(W, H)` and chip `(w, h)` with stride `(s_x, s_y)`:
+
+$$
+n_{\text{cols}} = \left\lceil \frac{W - w}{s_x} \right\rceil + 1, \qquad
+n_{\text{rows}} = \left\lceil \frac{H - h}{s_y} \right\rceil + 1
+$$
+
+Final-row/column chips are clipped against tile bounds (the chip is *shifted*, not truncated, to keep chip size exact). Total chip count = sum over tiles. This matches the standard sliding-window convention used by `xrpatcher` / `xbatcher`.
+
+### 4.7 Prediction stitching
+
+For overlapping predictions, the four supported reductions on the output grid are:
+
+| Method | Update rule |
+| --- | --- |
+| `average` | `out += pred; counts += 1; out /= max(counts, 1)` |
+| `max`     | `out = np.maximum(out, pred)` |
+| `first`   | write only where `counts == 0`, then increment counts |
+| `last`    | unconditional overwrite |
+
+Pixel placement uses the output transform implicit in `(xmin, ymax, x_res, y_res)`:
+
+```python
+col = int((geoslice.xmin - xmin) / x_res)
+row = int((ymax - geoslice.ymax) / y_res)   # y-flip: rows count from north downward
+```
+
+---
+
+## 5. Coupling with georeader
+
+| Snippet | What in georeader it duplicates / extends |
+| --- | --- |
+| `build_spatiotemporal_index` | New capability — closest analog is nothing in georeader today. The per-file `WarpedVRT` bounds extraction is *not* in georeader; could leverage `rasterio_reader.RasterioReader` instead of opening raw rasterio. |
+| `load_and_merge_rasters_spatial` | Heavy overlap with `mosaic.py` — both do windowed reads + `rasterio.merge`. The snippet adds the index-driven query layer on top. |
+| `load_xarray_datasets*` | New territory; georeader doesn't really do xarray reads end-to-end. `dataarray.py` exists as a thin GeoTensor↔DataArray bridge; this would extend that. |
+| `load_and_rasterize_vectors*` | Overlaps `rasterize.py`. The snippet adds index-driven file selection and per-task label conventions. |
+| `sampler.py` / `GeoSlice` | New. But `GeoSlice` overlaps conceptually with `slices.py` and with `window_utils.py`'s window descriptors. Reconcile or alias. |
+| `run_inference_with_grid_sampler` | Could compose `read.read_from_bounds` instead of inlining `rasterio.merge` logic. |
+| `stitch_predictions` | New; nothing equivalent in georeader. |
+| `query` / `intersect` / `union` | New. Set algebra over a GeoDataFrame catalog — clean fit as a new module. |
+| `rasterio_utils.py` | Keep only `get_tags` / `print_all_metadata` and fold into existing readers. The xarray-tagging half should not live here; it's ad-hoc rioxarray plumbing. |
+
+---
+
+## 6. Proposed API surface in georeader
+
+A clean, opinionated public API. Three goals:
+
+1. One shape across backends.
+2. `GeoTensor` / `xr.Dataset` on output — never `dict[str, np.ndarray]`.
+3. ML deps stay optional.
+
+### 6.1 Module layout
+
+```text
+georeader/
+├── catalog/                    # NEW
+│   ├── __init__.py
+│   ├── base.py                 # GeoCatalog (wraps the GeoDataFrame index)
+│   ├── raster.py               # build_raster_catalog + raster loaders
+│   ├── xarray.py               # build_xarray_catalog + xarray loaders   [extra: xarray]
+│   ├── vector.py               # build_vector_catalog + rasterizers
+│   └── ops.py                  # query, intersect, union
+├── samplers/                   # NEW (or part of catalog/)
+│   ├── __init__.py
+│   ├── geoslice.py             # GeoSlice (or reuse slices.py)
+│   ├── random.py
+│   ├── grid.py
+│   └── stitch.py
+└── ...                         # existing modules unchanged
+```
+
+### 6.2 Core types
+
+```python
+@dataclass(frozen=True)
+class GeoSlice:
+    bounds: tuple[float, float, float, float]   # (xmin, ymin, xmax, ymax)
+    interval: pd.Interval                       # closed='both'
+    resolution: tuple[float, float]             # (x_res, y_res)
+    crs: pyproj.CRS
+
+    @property
+    def shape(self) -> tuple[int, int]: ...     # (h, w)
+
+
+class GeoCatalog:
+    """Thin wrapper around a GeoDataFrame with IntervalIndex + geometry."""
+    gdf: gpd.GeoDataFrame
+    backend: Literal["raster", "xarray", "vector"]
+
+    # set algebra
+    def query(self, slice: GeoSlice, *, t_step: int | None = None) -> "GeoCatalog": ...
+    def intersect(self, other: "GeoCatalog", *, spatial_only: bool = False) -> "GeoCatalog": ...
+    def union(self, other: "GeoCatalog") -> "GeoCatalog": ...
+
+    # introspection
+    @property
+    def total_bounds(self) -> tuple[float, float, float, float]: ...
+    @property
+    def temporal_extent(self) -> pd.Interval: ...
+    def __len__(self) -> int: ...
+```
+
+### 6.3 Builders (one per backend)
+
+```python
+def build_raster_catalog(
+    filepaths: Sequence[str | Path],
+    *,
+    filename_regex: str,
+    date_format: str = "%Y%m%d",
+    target_crs: CRS | str | None = None,        # default: first file's CRS
+    target_resolution: tuple[float, float] | None = None,
+) -> GeoCatalog: ...
+
+
+def build_xarray_catalog(
+    filepaths: Sequence[str | Path],
+    *,
+    target_crs: CRS | str | None = None,
+    target_resolution: tuple[float, float] | float | None = None,
+    data_vars: Sequence[str] | None = None,
+    time_var: str = "time",
+) -> GeoCatalog: ...
+
+
+def build_vector_catalog(
+    filepaths: Sequence[str | Path],
+    *,
+    filename_regex: str,
+    date_format: str = "%Y%m%d",
+    target_crs: CRS | str | None = None,
+    layer: str | int | None = None,
+) -> GeoCatalog: ...
+```
+
+### 6.4 Loaders return `GeoTensor` / `xr.Dataset`, not dicts
+
+```python
+def load_raster(
+    catalog: GeoCatalog,
+    slice: GeoSlice,
+    *,
+    band_indexes: Sequence[int] | None = None,
+    resampling: Resampling = Resampling.bilinear,
+    merge_method: Literal["first", "last", "min", "max", "sum", "count"] = "last",
+) -> GeoTensor: ...                          # (bands, h, w) + transform + crs
+
+
+def load_raster_timeseries(
+    catalog: GeoCatalog,
+    slice: GeoSlice,
+    *,
+    t_step: int = 1,
+    temporal_aggregation: Literal["nearest", "mean", "median", "first", "last"] = "nearest",
+    ...,
+) -> GeoTensor: ...                          # (time, bands, h, w)
+
+
+def load_xarray(catalog: GeoCatalog, slice: GeoSlice, ...) -> xr.Dataset: ...
+
+
+def load_vector(
+    catalog: GeoCatalog,
+    slice: GeoSlice,
+    *,
+    task: Literal["semantic_segmentation", "object_detection", "instance_segmentation"],
+    label_field: str | None = None,
+) -> GeoTensor: ...
+```
+
+The shift from `dict[str, np.ndarray]` to `GeoTensor` is the single biggest cleanup — it carries CRS + transform around so users don't lose georeferencing.
+
+### 6.5 Samplers
+
+```python
+def random_sampler(
+    catalog: GeoCatalog,
+    chip_size: tuple[int, int],
+    *,
+    length: int | None = None,
+    roi: shapely.Polygon | None = None,
+    toi: pd.Interval | None = None,
+    units: Literal["pixels", "crs"] = "pixels",
+    seed: int | None = None,
+    weight: Literal["area", "uniform"] = "area",   # NEW: address §4.5 bias
+) -> Iterator[GeoSlice]: ...
+
+
+def grid_sampler(
+    catalog: GeoCatalog,
+    chip_size: tuple[int, int],
+    *,
+    stride: tuple[int, int] | None = None,
+    roi: shapely.Polygon | None = None,
+    toi: pd.Interval | None = None,
+    units: Literal["pixels", "crs"] = "pixels",
+) -> Iterator[GeoSlice]: ...
+
+
+def stitch(
+    predictions: Sequence[np.ndarray],
+    slices: Sequence[GeoSlice],
+    *,
+    method: Literal["average", "max", "first", "last"] = "average",
+    roi: shapely.Polygon | None = None,
+) -> GeoTensor: ...                          # carry CRS through
+```
+
+### 6.6 What I'd cut
+
+- `run_inference_with_grid_sampler` — too opinionated. Replace with a 5-line cookbook example. Library shouldn't own the model loop.
+- The `dict[str, np.ndarray]` return contract.
+- Hardcoded `torch.long` in the vector loaders; make torch optional, default to numpy with `dtype=np.int64`.
+- `loguru` as a hard dependency — switch to stdlib `logging`.
+- `_convert_poly_coords` private helper — `rasterio.features.rasterize` already accepts `transform=`; this helper is redundant.
+
+---
+
+## 7. Sharp edges to fix on the way in
+
+1. **Two literal syntax errors in `dataset_vector.py`** — the file has never run. Tells you tests are sparse.
+2. **`pd.Timestamp.min` / `Timestamp.max` as fallback intervals** for date-less files will dominate `IntervalIndex` ranges and make logs misleading. Either require a date or carry an explicit `static` flag.
+3. **Bounds in unprojected lat/lon get distorted by `WarpedVRT`** — for files spanning the antimeridian or poles, `.bounds` is the *reprojected* envelope, not a great-circle hull. Document this; consider exposing a `densify=N` option that samples the boundary before reprojection.
+4. **`t_sample = interval.left.value / 1e9`** uses `Timestamp.value` (nanoseconds). Fine, but it'll silently break for `Timestamp.min` / `.max` (overflow on the float). Skip random temporal sampling when the interval is "infinite".
+5. **`gpd.overlay` is `O(n × m)`** worst-case despite the R-tree. For `10k × 10k` catalogs this is slow; document the cost or add a chunked variant.
+6. **Hardcoded `nodata=0`** in the xarray merge call. Should respect the source's `_FillValue` / `nodata`.
+7. **`merge_method='count'`** is listed in the raster loader signature but isn't a valid `rasterio.merge` method. Either implement or remove.
+8. **`use_cache=True` + `lru_cache`** on file handles in long-running processes — at fork time these break under multiprocessing dataloaders. Document or disable in worker contexts.
+9. **No tests, no examples** that exercise multi-CRS catalogs (e.g. mixing UTM zones). The most likely real-world failure mode.
+10. **`loguru` everywhere** — gives nice-looking logs but is a hard dep. Bury behind stdlib `logging` so georeader users aren't forced into it.
+
+---
+
+## 8. End-to-end examples
+
+A varied gallery, organized by intent. Each example uses only the proposed API; small extensions beyond §6 are flagged inline as `# extension:` comments. Imports are kept minimal per snippet — assume `numpy as np`, `pandas as pd` everywhere.
+
+| § | Example | Pattern |
+| --- | --- | --- |
+| 8.1 | A. Cloud-free monthly composite | mask + temporal-last reduction |
+| 8.1 | B. Daily NDVI series at one point | xarray, 1-pixel slice over long TOI |
+| 8.2 | C. Atmospheric correction ETL → Zarr | tiled load + per-chip transform + write |
+| 8.2 | D. Hyperspectral → S2-like band binning | per-chip spectral matrix product |
+| 8.2 | E. Uncertainty maps → vector anomalies | stitched postprocess + raster→vector |
+| 8.3 | F. Change detection across two epochs | siamese on `intersect(spatial_only)` |
+| 8.3 | G. Cloud detection write-back | per-tile inference, aligned QA output |
+| 8.4 | H. Image-label pairing (raster × vector) | cross-backend `intersect` |
+| 8.4 | I. SAR + optical fusion | multi-sensor pairing with interval padding |
+| 8.4 | J. Multi-resolution S2 + MODIS | one slice, two native resolutions |
+| 8.4 | K. Optical + DEM (static) + ERA5 (coarse) | three backends, mixed CRS |
+| 8.5 | L. Random chips for a torch `DataLoader` | basic ML adapter |
+| 8.5 | M. Self-supervised temporal-pair sampler | SimCLR-style positives |
+| 8.5 | N. Spatial-block cross-validation | leakage-safe folds via centroids |
+| 8.5 | O. Foundation-model embedding store | grid sampler → frozen encoder → Zarr |
+
+### 8.1 Simple pipelines
+
+#### A. Cloud-free monthly composite over an AOI
+
+Query a month + AOI, mask cloud bits from QA60, take the most recent valid pixel per band.
+
+```python
+from glob import glob
+from georeader.catalog import build_raster_catalog, GeoSlice, load_raster
+from georeader.save import save_cog
+
+catalog = build_raster_catalog(
+    filepaths=glob("/data/s2/T29SND_*.tif"),
+    filename_regex=r"T29SND_(?P<date>\d{8})_.*\.tif",
+    target_crs="EPSG:32629",
+    target_resolution=(10.0, 10.0),
+)
+
+aoi = GeoSlice(
+    bounds=(500_000, 4_000_000, 540_000, 4_040_000),
+    interval=pd.Interval(pd.Timestamp("2023-06-01"), pd.Timestamp("2023-06-30"), closed="both"),
+    resolution=(10.0, 10.0),
+    crs="EPSG:32629",
+)
+
+rgbn = load_raster(catalog, aoi, band_indexes=[2, 3, 4, 8], merge_method="last")
+qa   = load_raster(catalog, aoi, band_indexes=["QA60"],     merge_method="last")
+cloud = (qa.values.astype(np.uint16) & ((1 << 10) | (1 << 11))) > 0   # opaque + cirrus
+rgbn.values[:, cloud[0]] = 0
+save_cog(rgbn, "/out/s2_2023-06_composite.tif", descriptions=["B02", "B03", "B04", "B08"])
+```
+
+#### B. Daily NDVI series at one point (xarray archive)
+
+A 1-pixel `GeoSlice` plus a long TOI degenerates to a 1-D series.
+
+```python
+from glob import glob
+from georeader.catalog import build_xarray_catalog, GeoSlice, load_xarray
+
+catalog = build_xarray_catalog(
+    filepaths=glob("/data/modis/MOD13A2_*.nc"),
+    target_crs="EPSG:4326",
+    data_vars=["NDVI"],
+    time_var="time",
+)
+
+madrid = GeoSlice(
+    bounds=(-3.7038, 40.4168, -3.7028, 40.4178),
+    interval=pd.Interval(pd.Timestamp("2010-01-01"), pd.Timestamp("2023-12-31"), closed="both"),
+    resolution=(0.005, 0.005),
+    crs="EPSG:4326",
+)
+
+ds     = load_xarray(catalog, madrid)
+series = ds["NDVI"].mean(("x", "y")).to_pandas()
+series.to_csv("/out/madrid_ndvi.csv")
+```
+
+### 8.2 Heavy preprocessing & postprocessing
+
+#### C. Atmospheric correction → cloud mask → monthly composite → Zarr
+
+A full ETL: tiled load of a multi-year archive, georeader's reflectance helpers, monthly aggregation, sharded Zarr output.
+
+```python
+import xarray as xr
+from georeader.catalog import build_raster_catalog, load_raster
+from georeader.samplers import grid_sampler
+from georeader import reflectance
+
+catalog = build_raster_catalog(...)
+chips = list(grid_sampler(catalog, chip_size=(2048, 2048), stride=(2048, 2048)))
+
+monthly: dict[pd.Period, list] = {}
+for sl in chips:
+    toa = load_raster(catalog, sl, band_indexes=list(range(1, 14)))
+    boa = reflectance.toa_to_boa(toa, ...)                              # GeoTensor
+    qa  = load_raster(catalog, sl, band_indexes=["QA60"])
+    bad = (qa.values & ((1 << 10) | (1 << 11))) > 0
+    boa.values[:, bad[0]] = np.nan
+    monthly.setdefault(sl.interval.left.to_period("M"), []).append(boa)
+
+for month, parts in monthly.items():
+    da = xr.concat([p.to_xarray() for p in parts], dim="chip").mean("chip", skipna=True)
+    da.to_zarr(f"/out/s2_{month}.zarr", mode="w", consolidated=True)
+```
+
+#### D. Hyperspectral → S2-like band binning (per chip)
+
+Apply Sentinel-2 spectral response functions (SRFs) on each EnMAP / PRISMA cube to produce a 13-band multispectral output that drops straight into models trained for S2.
+
+```python
+from georeader.catalog import build_raster_catalog, load_raster
+from georeader.geotensor import GeoTensor
+from georeader.samplers import grid_sampler
+
+srf = np.load("/data/s2a_srf.npy")                  # (13 s2 bands, 224 enmap bands)
+
+enmap = build_raster_catalog(
+    enmap_files,
+    filename_regex=r"ENMAP_L2A_(?P<date>\d{8}).*\.tif",
+    target_crs="EPSG:32629",
+)
+
+for sl in grid_sampler(enmap, chip_size=(512, 512)):
+    cube  = load_raster(enmap, sl)                          # GeoTensor (224, 512, 512)
+    multi = np.einsum("ij,jhw->ihw", srf, cube.values)      # (13, 512, 512)
+    out   = GeoTensor(values=multi, transform=cube.transform, crs=cube.crs)
+    out.save(f"/out/enmap_as_s2/{sl.interval.left.date()}_{sl.bounds}.tif")
+```
+
+#### E. Postprocess: stitched uncertainty maps → vector anomalies
+
+Run a model with an uncertainty head, stitch, threshold on `μ` *and* `σ`, vectorise.
+
+```python
+from georeader.catalog import build_raster_catalog, load_raster
+from georeader.samplers import grid_sampler, stitch
+from georeader.vectorize import polygons_from_mask
+
+catalog = build_raster_catalog(...)
+slices  = list(grid_sampler(catalog, chip_size=(256, 256), stride=(192, 192)))
+
+mu_chips, sigma_chips = [], []
+for sl in slices:
+    x = load_raster(catalog, sl, band_indexes=[1, 2, 3, 4]).values
+    mu, sigma = model_with_uncertainty(x)
+    mu_chips.append(mu); sigma_chips.append(sigma)
+
+mu    = stitch(mu_chips,    slices, method="average")
+sigma = stitch(sigma_chips, slices, method="average")
+flag  = (mu.values[0] > 0.7) & (sigma.values[0] > 0.2)
+
+gdf = polygons_from_mask(flag, transform=mu.transform, crs=mu.crs)
+gdf.to_file("/out/anomalies.geojson", driver="GeoJSON")
+```
+
+### 8.3 Inference patterns
+
+#### F. Change detection across two epochs (siamese on intersected catalogs)
+
+`intersect(spatial_only=True)` keeps only tiles whose footprints overlap; you then evaluate each chip's "before" and "after" load with explicit time windows.
+
+```python
+import dataclasses
+from georeader.catalog import build_raster_catalog, load_raster
+from georeader.samplers import grid_sampler, stitch
+
+before = build_raster_catalog(pre_event_files,  filename_regex=PRE_REGEX)
+after  = build_raster_catalog(post_event_files, filename_regex=POST_REGEX)
+shared = before.intersect(after, spatial_only=True)
+
+chips = list(grid_sampler(shared, chip_size=(256, 256), stride=(256, 256)))
+deltas = []
+for sl in chips:
+    sl_b = dataclasses.replace(sl, interval=pd.Interval(pd.Timestamp("2023-08-15"),
+                                                         pd.Timestamp("2023-08-25"), closed="both"))
+    sl_a = dataclasses.replace(sl, interval=pd.Interval(pd.Timestamp("2023-09-15"),
+                                                         pd.Timestamp("2023-09-25"), closed="both"))
+    deltas.append(siamese_change_model(load_raster(before, sl_b).values,
+                                       load_raster(after,  sl_a).values))
+
+stitch(deltas, chips, method="max").save("/out/change.tif")
+```
+
+#### G. Cloud detection: write aligned QA bands per source tile
+
+For each tile in the catalog, predict a cloud mask and write a sidecar `.cloud.tif` with the *same* affine and shape as the input.
+
+```python
+from pathlib import Path
+from georeader.catalog import build_raster_catalog, GeoSlice, load_raster
+from georeader.geotensor import GeoTensor
+
+catalog = build_raster_catalog(s2_files, filename_regex=S2_REGEX)
+
+for row in catalog.gdf.itertuples():
+    sl = GeoSlice(
+        bounds=row.geometry.bounds,
+        interval=row.Index,
+        resolution=(10.0, 10.0),
+        crs=catalog.gdf.crs,
+    )
+    rgbn  = load_raster(catalog, sl, band_indexes=[2, 3, 4, 8])
+    cloud = cloud_model(rgbn.values)                                       # (1, H, W) prob
+    out   = GeoTensor(values=cloud, transform=rgbn.transform, crs=rgbn.crs,
+                      fill_value_default=255)
+    out.save(Path(row.filepath).with_suffix(".cloud.tif"))                 # COG aligned to input
+```
+
+### 8.4 Heterogeneous / multi-sensor pairing
+
+#### H. Image-label pairing across two backends (raster × vector)
+
+```python
+from georeader.catalog import build_raster_catalog, build_vector_catalog, load_raster, load_vector
+from georeader.samplers import random_sampler
+
+imagery = build_raster_catalog(image_files, filename_regex=IMG_REGEX)
+labels  = build_vector_catalog(label_files, filename_regex=LBL_REGEX)
+paired  = imagery.intersect(labels)               # spatially AND temporally aligned
+
+for sl in random_sampler(paired, chip_size=(512, 512)):
+    x = load_raster(imagery, sl, band_indexes=[1, 2, 3])
+    y = load_vector(labels,  sl, task="semantic_segmentation", label_field="class_id")
+    train_step(x.values, y.values)
+```
+
+#### I. SAR + optical fusion (Sentinel-1 GRD + Sentinel-2 L2A)
+
+Different acquisition cadences. Pad each S1 row's interval by ±3 days so `intersect` allows loose temporal pairing, then fuse on load.
+
+```python
+from georeader.catalog import build_raster_catalog
+from georeader.samplers import random_sampler
+
+opt = build_raster_catalog(s2_files, filename_regex=S2_REGEX, target_crs="EPSG:32629")
+sar = build_raster_catalog(s1_files, filename_regex=S1_REGEX, target_crs="EPSG:32629")
+
+# extension: pad each row's interval by ±3 days
+sar.gdf.index = pd.IntervalIndex.from_arrays(
+    sar.gdf.index.left  - pd.Timedelta(days=3),
+    sar.gdf.index.right + pd.Timedelta(days=3),
+    closed="both", name="datetime",
+)
+
+paired = opt.intersect(sar)
+
+for sl in random_sampler(paired, chip_size=(256, 256), length=20_000, seed=0):
+    rgbn = load_raster(opt, sl, band_indexes=[2, 3, 4, 8]).values        # (4, 256, 256)
+    vvvh = load_raster(sar, sl, band_indexes=[1, 2]).values              # (2, 256, 256) linear
+    sar_db = 10 * np.log10(np.clip(vvvh, 1e-6, None))
+    yield np.concatenate([rgbn, sar_db], axis=0)                          # (6, 256, 256)
+```
+
+#### J. Multi-resolution: Sentinel-2 (10 m) + MODIS (500 m) at one slice
+
+The slice declares the *target* resolution; coarser data is upsampled, finer is downsampled — both arrive with identical `(H, W)` and transform.
+
+```python
+from rasterio.enums import Resampling
+from georeader.catalog import build_raster_catalog, GeoSlice, load_raster
+
+s2    = build_raster_catalog(s2_files,    filename_regex=S2_REGEX,    target_crs="EPSG:32629")
+modis = build_raster_catalog(modis_files, filename_regex=MODIS_REGEX, target_crs="EPSG:32629")
+
+sl = GeoSlice(bounds=AOI, interval=DAY_INTERVAL,
+              resolution=(10.0, 10.0), crs="EPSG:32629")
+
+x_high = load_raster(s2,    sl, band_indexes=[1, 2, 3, 4])                              # native
+x_low  = load_raster(modis, sl, band_indexes=[1, 2], resampling=Resampling.bilinear)    # upsampled
+combined = np.concatenate([x_high.values, x_low.values], axis=0)                         # same H, W
+```
+
+#### K. Multi-modal stack: optical + DEM (static) + ERA5 (coarse, lat/lon)
+
+Three backends and two CRSs. DEM has no time → `spatial_only=True`. ERA5 is xarray in EPSG:4326 → reproject the slice on the fly.
+
+```python
+from georeader.catalog import build_raster_catalog, build_xarray_catalog, load_raster, load_xarray
+from georeader.samplers import random_sampler
+
+opt  = build_raster_catalog(s2_files,  filename_regex=S2_REGEX,  target_crs="EPSG:32629")
+dem  = build_raster_catalog(dem_files, filename_regex=DEM_REGEX, target_crs="EPSG:32629")
+era5 = build_xarray_catalog(era5_files, target_crs="EPSG:4326",
+                            data_vars=["t2m", "tp"], time_var="time")
+
+opt_dem = opt.intersect(dem, spatial_only=True)
+
+for sl in random_sampler(opt_dem, chip_size=(128, 128), length=5_000):
+    rgbn   = load_raster(opt, sl, band_indexes=[2, 3, 4, 8]).values    # (4, 128, 128)
+    elev   = load_raster(dem, sl, band_indexes=[1]).values              # (1, 128, 128)
+    sl_ll  = sl.to_crs("EPSG:4326")                                     # extension on GeoSlice
+    weather = load_xarray(era5, sl_ll)                                  # very coarse cube
+    yield {
+        "rgbn":    rgbn,
+        "dem":     elev,
+        "weather": weather[["t2m", "tp"]].mean(("x", "y", "time")).to_array().values,  # (2,)
+    }
+```
+
+### 8.5 Special ML patterns
+
+#### L. Random chips for a torch `DataLoader` (basic adapter)
+
+```python
+import torch
+from georeader.catalog import build_raster_catalog, load_raster
+from georeader.samplers import random_sampler
+
+catalog = build_raster_catalog(...)
+
+
+class GeoDataset(torch.utils.data.IterableDataset):
+    def __init__(self, catalog, chip_size, length, seed=0):
+        self.iter_factory = lambda: random_sampler(catalog, chip_size, length=length, seed=seed)
+        self.catalog = catalog
+
+    def __iter__(self):
+        for sl in self.iter_factory():
+            yield load_raster(self.catalog, sl, band_indexes=[1, 2, 3, 4]).values
+
+
+loader = torch.utils.data.DataLoader(GeoDataset(catalog, (256, 256), 10_000),
+                                     batch_size=32, num_workers=4)
+```
+
+#### M. Self-supervised: temporal-pair sampler (SimCLR-style positives)
+
+Anchor and positive are the *same* spatial chip at *different* dates within the same tile interval.
+
+```python
+import dataclasses
+import shapely.geometry
+from georeader.samplers import random_sampler
+
+def temporal_pair_sampler(catalog, chip_size, length, *, min_gap_days=10, seed=0):
+    """Yield (anchor, positive) GeoSlice pairs from the same tile, far apart in time."""
+    rng  = np.random.default_rng(seed)
+    base = random_sampler(catalog, chip_size, length=length * 2, seed=seed)
+    for anchor in base:
+        chip_box = shapely.geometry.box(*anchor.bounds)
+        tile = catalog.gdf[catalog.gdf.geometry.contains(chip_box)].iloc[0]
+        lo, hi = tile.name.left.value, tile.name.right.value
+        t_pos = pd.Timestamp(rng.integers(lo, hi), unit="ns")
+        if abs((t_pos - anchor.interval.left).days) < min_gap_days:
+            continue
+        positive = dataclasses.replace(
+            anchor, interval=pd.Interval(t_pos, t_pos, closed="both"),
+        )
+        yield anchor, positive
+
+
+for a, p in temporal_pair_sampler(catalog, (224, 224), 100_000):
+    x_a = load_raster(catalog, a).values
+    x_p = load_raster(catalog, p).values
+    loss = simclr_loss(encoder(x_a), encoder(x_p))
+```
+
+#### N. Spatial-block cross-validation (no spatial leakage)
+
+Cluster tile centroids into K spatial blocks; fold by block, never by row. Critical for honest generalization estimates on geospatial models.
+
+```python
+from sklearn.cluster import KMeans
+
+cents = np.column_stack([catalog.gdf.geometry.centroid.x,
+                         catalog.gdf.geometry.centroid.y])
+catalog.gdf["block"] = KMeans(n_clusters=5, random_state=0).fit_predict(cents)
+
+for fold in range(5):
+    train = catalog.where("block != @fold")     # extension: pandas-like filter on gdf
+    val   = catalog.where("block == @fold")
+    train_one_fold(model, make_loader(train), make_loader(val))
+```
+
+#### O. Foundation-model embedding store
+
+Encode every chip in the catalog with a frozen vision encoder; persist `(N, D)` embeddings + chip metadata to a Zarr store for downstream retrieval, clustering, or weak supervision.
+
+```python
+import zarr
+from georeader.catalog import build_raster_catalog, load_raster
+from georeader.samplers import grid_sampler
+
+catalog = build_raster_catalog(...)
+slices  = list(grid_sampler(catalog, chip_size=(224, 224), stride=(224, 224)))
+N, D    = len(slices), 1024
+
+z   = zarr.open("/out/embeddings.zarr", mode="w")
+emb = z.zeros("emb", shape=(N, D), chunks=(1024, D), dtype="float32")
+meta = z.create_dataset("meta", shape=(N,), dtype=[
+    ("xmin", "f8"), ("ymin", "f8"), ("xmax", "f8"), ("ymax", "f8"),
+    ("tmin", "M8[ns]"), ("tmax", "M8[ns]"),
+])
+
+for i, sl in enumerate(slices):
+    x = load_raster(catalog, sl, band_indexes=[2, 3, 4, 8]).values
+    emb[i]  = frozen_encoder(x)
+    meta[i] = (*sl.bounds,
+               np.datetime64(sl.interval.left), np.datetime64(sl.interval.right))
+```
+
+### 8.6 API extensions implied by these examples
+
+The new examples lean on a small set of conveniences that aren't in §6's minimal surface but are natural to add:
+
+- `GeoSlice.to_crs(target_crs)` — reproject the bbox + resolution into another CRS (used in K).
+- `GeoCatalog.where(query: str)` — pandas-`.query()` passthrough on `gdf` (used in N).
+- `GeoCatalog.with_interval_padding(days=N)` — vectorised interval shift; in I we inlined it for clarity.
+- `GeoTensor.to_xarray()` — already implied by `georeader/dataarray.py`; used in C.
+- `polygons_from_mask(mask, transform, crs)` — likely already lives near `georeader/vectorize.py`; used in E.
+- Mask-aware reductions in `load_raster` (e.g. drop pixels where a paired QA band sets a bit) — for now we load QA explicitly and apply the mask in user code (A, C).
+
+---
+
+## 9. Verdict
+
+The snippets are the **right idea, executed roughly**. The shared GeoDataFrame index is genuinely good — the algebra (`intersect` / `union` / `query`) falls out for free, three backends share one shape, and the math is sound (modulo the sharp edges in [§7](#7-sharp-edges-to-fix-on-the-way-in)). The samplers and stitching are textbook but correct.
+
+What needs work before promotion to a public georeader API:
+
+- [ ] Replace dict returns with `GeoTensor` / `xr.Dataset` so georeferencing is preserved.
+- [ ] Wrap the GeoDataFrame in a `GeoCatalog` class — it makes `intersect` / `union` / `query` discoverable and lets us evolve the index format later.
+- [ ] Make `torch` and `loguru` optional. Keep the core import surface to numpy + pandas + geopandas + shapely + rasterio (already georeader's deps) + pyproj.
+- [ ] Fix the two syntax errors and add at least smoke tests for build → query → load on each backend, and for cross-CRS catalogs.
+- [ ] Drop `run_inference_with_grid_sampler` from the library surface; ship it as a docs example instead.
+- [ ] Decide if `GeoSlice` should reuse / extend `georeader.slices.py` or be a new sibling — I'd reuse and extend.
+
+If you do those six things, this becomes a real `georeader.catalog` module — the dataset-collection layer that georeader is currently missing — without bloating the dependency footprint.

--- a/projects/geotoolz/plans/geoduckdb.md
+++ b/projects/geotoolz/plans/geoduckdb.md
@@ -1,4 +1,4 @@
-# Dataset-builder snippets — Phase 2 design report (DuckDB backend)
+# Dataset builder (Phase 2 — DuckDB)
 
 > **Scope:** adding a DuckDB-backed catalog backend, GeoParquet-as-artifact, and SQL-native cross-catalog operations to the [`jejjohnson/georeader`](https://github.com/jejjohnson/georeader) `catalog` module proposed in Phase 1.
 >

--- a/projects/geotoolz/plans/geoduckdb.md
+++ b/projects/geotoolz/plans/geoduckdb.md
@@ -1,0 +1,784 @@
+# Dataset-builder snippets — Phase 2 design report (DuckDB backend)
+
+> **Scope:** adding a DuckDB-backed catalog backend, GeoParquet-as-artifact, and SQL-native cross-catalog operations to the [`jejjohnson/georeader`](https://github.com/jejjohnson/georeader) `catalog` module proposed in Phase 1.
+>
+> **Status:** design proposal, no code changed yet. Assumes Phase 1 (the in-memory `GeoCatalog`, builders, loaders, samplers, and `to_geoparquet`/`from_geoparquet` round-trip) has shipped.
+
+---
+
+## 0. What's in place from Phase 1
+
+The Phase 1 report proposed and (assume) shipped:
+
+| Component | Provides |
+| --- | --- |
+| `GeoCatalog` protocol | one shape across raster / xarray / vector |
+| `InMemoryGeoCatalog` | Phase 1 implementation: `gpd.GeoDataFrame` with `IntervalIndex` + `geometry` |
+| `build_{raster,xarray,vector}_catalog` | per-backend builders |
+| `load_{raster,xarray,vector}` | loaders that return `GeoTensor` / `xr.Dataset` |
+| `random_sampler`, `grid_sampler`, `stitch` | ML glue |
+| `GeoSlice` | unit of work passed between samplers and loaders |
+| `query`, `intersect`, `union` | set algebra over catalogs |
+| `to_geoparquet` / `from_geoparquet` | round-trip the catalog as a portable artifact |
+
+What Phase 1 cannot do well:
+
+- Catalogs much beyond ~10⁵ rows: `gpd.overlay` becomes painful, the gdf eats RAM.
+- Sharing without re-running the build step: a pickled gdf is fragile across versions.
+- Querying a catalog without loading the whole thing into Python.
+- Catalog analytics ("monthly file count by tile, weighted by useful area inside this AOI").
+- Streaming a catalog *during* construction so 10M files don't sit in RAM.
+
+Phase 2 fills these gaps by adding a second backend behind the same `GeoCatalog` protocol.
+
+---
+
+## 1. Inventory: what DuckDB brings
+
+DuckDB is an in-process columnar OLAP engine with a `spatial` extension that gives us everything we need at the index layer.
+
+### 1.1 Core engine
+
+- Single-binary, in-process (no server). ~30 MB.
+- Native Parquet read/write with **predicate and projection pushdown** driven by row-group min/max statistics.
+- Reads transparently from local filesystem, S3, GCS, Azure, HTTPS, HuggingFace via the `httpfs` extension.
+- Arrow-native: zero-copy to `pyarrow`, then to `pandas` / `polars` / `geopandas`.
+- Multi-threaded execution; vectorized columnar engine.
+- A persistent file format (`.duckdb`) for storing tables + indexes when needed.
+
+### 1.2 Spatial extension
+
+GEOS-backed, GeoParquet 1.x compatible. The functions Phase 2 leans on:
+
+| Category | Functions used |
+| --- | --- |
+| Constructors | `ST_MakeEnvelope`, `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_AsWKB` |
+| Predicates | `ST_Intersects`, `ST_Contains`, `ST_Within`, `ST_Overlaps` |
+| Set ops | `ST_Intersection`, `ST_Union`, `ST_Difference` |
+| Measures | `ST_Area`, `ST_Centroid`, `ST_Distance` |
+| CRS | `ST_Transform` (requires the `spatial` extension's bundled PROJ data) |
+| Indexing | `CREATE INDEX ... USING RTREE` (on `.duckdb` table files only) |
+
+Spatial joins build an in-memory R-tree on the smaller side per query. Persistent on-disk R-trees are limited to materialized DuckDB tables, not Parquet — see [§7](#7-sharp-edges).
+
+### 1.3 GeoParquet support
+
+- Reads any GeoParquet 1.0/1.1 file produced by `geopandas.to_parquet` (or by DuckDB itself).
+- Writes via `COPY ... TO 'file.parquet' (FORMAT 'parquet', COMPRESSION 'zstd')` — schema includes WKB geometry + GeoParquet-style column metadata when the spatial extension is loaded.
+- GeoParquet **1.1** introduces a per-row `bbox` covering struct that lets the engine push spatial filters down to the row-group level *without parsing WKB*. For 10⁷-row catalogs this is roughly an order-of-magnitude speedup on selective queries.
+
+> ⚠️ The `spatial` extension's GeoParquet *write* path is more recent than the read path. Pin a known-good DuckDB version (≥ 1.1) and add a smoke test that round-trips a small catalog.
+
+---
+
+## 2. User story
+
+**Persona shift.** Phase 1's user has hundreds to thousands of files in one project. Phase 2's user has *too many to load eagerly*, or *wants to publish* a catalog so a collaborator (or a CI job, or a notebook on a different machine) can query it without rebuilding.
+
+**Goal arc:**
+
+1. *"I built a 1M-row catalog yesterday. Reload it instantly."* → `open_catalog("cat.parquet")` (no `build_*_catalog` needed).
+2. *"My collaborator wants to query my catalog from her laptop."* → I push to `s3://bucket/cat.parquet`; she runs `open_catalog("s3://bucket/cat.parquet")`. Only the row groups her query touches get downloaded.
+3. *"Intersect 200k imagery rows with 500k label rows."* → SQL spatial join, parallel, minutes instead of an OOM.
+4. *"How does my coverage break down by month, by tile, by cloud %?"* → one SQL query against the catalog, no loop.
+5. *"Stream candidate slices into the random sampler without materializing the join."* → DuckDB cursor → `iter_rows()` → sampler.
+6. *"Append today's new acquisitions to yesterday's catalog without rebuilding."* → drop a new shard into a directory; `open_catalog("cat_dir/")` reads them as one virtual table.
+7. *"Build the catalog directly into DuckDB during ingest so I never hold 10M rows in RAM."* → `build_raster_catalog(..., backend="duckdb", out_path="cat.parquet")` streams rows to disk.
+
+The framing: **DuckDB doesn't replace Phase 1, it extends the working envelope by 2–3 orders of magnitude**, and turns the catalog into a first-class shareable artifact.
+
+---
+
+## 3. Motivation
+
+### 3.1 The walls Phase 1 hits
+
+| Dimension | Phase 1 ceiling | Why |
+| --- | --- | --- |
+| Catalog size in RAM | ~10⁵–10⁶ rows | each gdf row is ~1 KB; a 10M-row gdf is ~10 GB |
+| `intersect` (overlay) | ~10⁴ × 10⁴ comfortable, 10⁵ × 10⁵ painful | `gpd.overlay` is `O(n × m)` worst case, single-threaded |
+| Build cost | re-run every Python session | nothing is cached; rasterio metadata extraction is 1–10 ms/file |
+| Sharing | pickled gdfs are fragile across versions | no canonical interchange format |
+| Analytics | Python loops over the gdf | aggregations at scale need a query engine |
+| Remote | "rsync the whole archive" | no lazy/partial access |
+
+### 3.2 What DuckDB unlocks
+
+| Need | DuckDB mechanism |
+| --- | --- |
+| Scale past memory | columnar parquet + row-group pushdown; nothing materializes until you ask |
+| Persistence | GeoParquet is the artifact; the catalog is now a file you can version, hash, sign |
+| Sharing | `httpfs` extension reads S3/GCS/HTTPS GeoParquet; predicate pushdown means low egress |
+| Fast joins | spatial-join operator with parallel R-tree probe; band-join on temporal intervals |
+| Analytics | full SQL surface |
+| Streaming build | `INSERT ... SELECT` from a Python iterator into a DuckDB-managed Parquet writer |
+
+### 3.3 Compared with alternatives
+
+- **STAC + pgSTAC / stac-fastapi.** Heavier: needs Postgres, a schema, an HTTP service. Wins on standardization and federated discovery. Loses on dev velocity for single-user / single-team workflows.
+- **PostGIS + GeoAlchemy.** Real database. More features (transactions, advanced indexes, triggers). Far more setup. Best when you already run Postgres for other reasons.
+- **xstac + intake-stac.** Library-only, no server. But STAC items are JSON-per-file, so a 1M-item catalog is 1M JSON files or one giant blob — both worse than one Parquet file for the queries we care about.
+- **Plain `gpd.read_parquet` + Python.** What Phase 1 already gives via `from_geoparquet`. Fine until you need joins or analytics at scale.
+
+The unique slot DuckDB occupies: **zero-server, single-file, parallel, SQL, with native Parquet + spatial**. Nothing else hits all five.
+
+---
+
+## 4. Mathematics
+
+### 4.1 Predicate pushdown via Parquet zone maps
+
+A Parquet file is a sequence of *row groups*; each row group has, per column, min/max statistics. GeoParquet adds a per-row-group geometry bbox (and, in 1.1, an optional per-row bbox column).
+
+For a query
+
+```sql
+WHERE tmax >= $T_lo AND tmin <= $T_hi
+  AND ST_Intersects(geometry, ST_MakeEnvelope($x0,$y0,$x1,$y1))
+```
+
+a row group is pruned without reading any of its data when **any** of these holds:
+
+$$
+\text{group}.t_{\max\text{-max}} < T_{\text{lo}}, \quad
+\text{group}.t_{\min\text{-min}} > T_{\text{hi}}, \quad
+\text{group.bbox} \cap \text{query.bbox} = \emptyset.
+$$
+
+If the catalog is sorted by `tmin` (or, even better, written via a Hilbert/R-curve sort on geometry centroids), the fraction of row groups read for a narrow query approaches the fraction of rows that match. For a 10⁷-row catalog with 10k rows per group and a 0.1%-selective query, expect to read ~10 row groups, not 1000.
+
+Practical recipe: sort the catalog by `(tmin, ST_Hilbert(centroid))` before writing.
+
+### 4.2 Spatial-join algorithm
+
+DuckDB's spatial join builds an R-tree on the smaller relation and probes with the larger one:
+
+$$
+\text{cost} \;\approx\; \underbrace{n \log n}_{\text{R-tree build on A}} \;+\; \underbrace{m \log n}_{\text{probes from B}} \;+\; \underbrace{k}_{\text{candidate refinement}}
+$$
+
+where `k` is the candidate match count after bbox filtering, refined by the exact `ST_Intersects` predicate. Compare with `gpd.overlay`'s effective `O(n + m + n × m')` (R-tree filter then per-pair intersection check), which dominates for dense overlap.
+
+Empirically, on the same machine: a 200 k × 500 k spatial join takes minutes in DuckDB, hours in geopandas, and OOMs at 1M × 1M in geopandas while completing in DuckDB.
+
+### 4.3 Temporal band-join
+
+The interval-overlap predicate
+
+```sql
+a.tmax >= b.tmin AND a.tmin <= b.tmax
+```
+
+is recognized by DuckDB's optimizer as a **range join** (a.k.a. band join). The algorithm sorts both sides by `tmin`, then sweeps:
+
+```
+sort A by tmin, B by tmin
+maintain a sliding window W of B-rows whose tmax >= current A.tmin
+for each a in A:
+    advance W: drop b where b.tmax < a.tmin; add b where b.tmin <= a.tmax
+    emit (a, b) for b in W
+```
+
+Cost: $O(n \log n + m \log m + |\text{matches}|)$. No nested-loop blow-up.
+
+### 4.4 Combined spatiotemporal join cost
+
+For a query that joins on both space and time, DuckDB's planner picks the more selective predicate first based on column statistics. Typical plan:
+
+1. Spatial join via R-tree (filters out 99%+ of pairs in most workloads).
+2. Apply temporal predicate as a post-filter.
+3. Compute `ST_Intersection` only for surviving pairs.
+
+You can verify with `EXPLAIN`. The win versus Phase 1 is **2–3 orders of magnitude on real-world catalog sizes**.
+
+### 4.5 GeoParquet bbox column (1.1)
+
+GeoParquet 1.1 introduces an optional per-row covering struct:
+
+```text
+bbox: STRUCT<xmin DOUBLE, ymin DOUBLE, xmax DOUBLE, ymax DOUBLE>
+```
+
+For a spatial filter, DuckDB can evaluate
+
+```sql
+WHERE bbox.xmax >= $x0 AND bbox.xmin <= $x1
+  AND bbox.ymax >= $y0 AND bbox.ymin <= $y1
+  AND ST_Intersects(geometry, ST_MakeEnvelope($x0,$y0,$x1,$y1))
+```
+
+The first four conjuncts are pure double-comparison — no WKB parsing, fully vectorized. The exact `ST_Intersects` runs only on rows that pass the bbox filter. For very selective queries this is roughly 10× faster than calling `ST_Intersects` directly on every row.
+
+The catalog writer should always emit the bbox column.
+
+### 4.6 Streaming build cost model
+
+Phase 1's `build_raster_catalog` materializes the whole gdf. For 10M files at ~1 KB/row, that's 10 GB plus Python overhead.
+
+The streaming variant batches `B` rows into Arrow record batches and appends to a Parquet writer:
+
+$$
+\text{peak memory} \;\approx\; B \cdot \text{row\_size} \;+\; \text{open-file-handles} \cdot \text{rasterio overhead}
+$$
+
+For `B = 10 000` and ~1 KB/row, peak is ~10 MB plus rasterio's per-file overhead (tens of MB). Build time is dominated by `rasterio.open` calls, which can be parallelized with a `ThreadPoolExecutor` (GIL-friendly because rasterio releases the GIL during I/O).
+
+---
+
+## 5. Coupling with Phase 1
+
+The whole point of the Phase 1 protocol design was to make Phase 2 transparent. Here's the seam:
+
+| Operation | `InMemoryGeoCatalog` (Phase 1) | `DuckDBGeoCatalog` (Phase 2) |
+| --- | --- | --- |
+| `query(slice)` | `gdf.cx[...]` + `IntervalIndex.overlaps` | SQL `WHERE` with predicate pushdown |
+| `intersect(other)` | `gpd.overlay` | SQL `JOIN ... ON ST_Intersects(...) AND <interval-overlap>` |
+| `union(other)` | `pd.concat` | SQL `UNION ALL` |
+| `iter_rows()` | `gdf.itertuples()` | Arrow batch iterator over the relation |
+| `to_geoparquet(path)` | `gdf.to_parquet(...)` | `COPY ... TO ... (FORMAT 'parquet')` |
+| `materialize()` | identity | execute the relation, return `InMemoryGeoCatalog` |
+| `__len__` | `len(gdf)` | `SELECT COUNT(*)` (cached) |
+| Backend-specific escape hatch | `.gdf` (full geopandas surface) | `.relation` (full SQL surface) |
+
+**Loaders unchanged.** `load_raster(catalog, slice, ...)` only needs `catalog.iter_rows()` (or a single `query` + `iter_rows`) — it never touches the underlying gdf or relation.
+
+**Samplers** need the smallest tweak: replace `catalog.gdf.iloc[i]` patterns with `catalog.iter_rows()` or `catalog.query(slice).iter_rows()`. Once that's done, samplers work identically against either backend.
+
+**`stitch` unchanged.** It only consumes `GeoSlice` + `np.ndarray`, no catalog.
+
+The catalog is the only seam. Get the protocol right and Phase 2 is purely additive.
+
+---
+
+## 6. Proposed API surface
+
+### 6.1 Module layout
+
+```text
+georeader/
+├── catalog/
+│   ├── __init__.py
+│   ├── base.py           # GeoCatalog protocol, CatalogRow, GeoSlice (re-export)
+│   ├── memory.py         # InMemoryGeoCatalog (Phase 1)
+│   ├── duckdb_backend.py # DuckDBGeoCatalog (Phase 2)        [extra: duckdb]
+│   ├── parquet.py        # GeoParquet read/write helpers
+│   ├── streaming.py      # StreamingParquetWriter for direct-to-disk builds
+│   └── ops.py            # query / intersect / union dispatch
+└── cli/
+    └── catalog.py        # `georeader catalog ...` subcommands
+```
+
+### 6.2 Protocol additions
+
+The Phase 1 `GeoCatalog` protocol stays mostly intact. Phase 2 adds:
+
+```python
+class GeoCatalog(Protocol):
+    # ... Phase 1 surface ...
+
+    # NEW: explicit construction from a parquet artifact (works for both backends)
+    @classmethod
+    def open(
+        cls,
+        source: str | Path | list[str | Path],
+        *,
+        backend: Literal["memory", "duckdb"] = "duckdb",
+        table: str = "files",
+    ) -> "GeoCatalog": ...
+
+    # NEW: lazy / eager bridge (no-op on InMemory; executes on DuckDB)
+    def materialize(self) -> "InMemoryGeoCatalog": ...
+
+    # NEW: structured row iteration that both backends implement
+    def iter_rows(self, *, batch_size: int = 1024) -> Iterator["CatalogRow"]: ...
+```
+
+Note `open` is a *factory*: it returns whichever backend the caller asked for, defaulting to DuckDB once Phase 2 ships because the lazy backend is almost always the right choice for an artifact-on-disk.
+
+### 6.3 `CatalogRow`
+
+```python
+@dataclass(frozen=True)
+class CatalogRow:
+    filepath: str
+    geometry: shapely.geometry.base.BaseGeometry   # decoded from WKB
+    interval: pd.Interval                          # built from (tmin, tmax)
+    crs: pyproj.CRS
+    extras: dict[str, Any]                         # backend-specific extras (data_vars, layer, ...)
+```
+
+Loaders consume `CatalogRow`. Whether the row came from a gdf or a DuckDB cursor is invisible.
+
+### 6.4 `DuckDBGeoCatalog`
+
+```python
+class DuckDBGeoCatalog(GeoCatalog):
+    """Lazy, SQL-backed catalog. Operations return new relations; nothing
+    runs until iter_rows() / materialize() / aggregate() is called."""
+    relation: duckdb.DuckDBPyRelation
+    con: duckdb.DuckDBPyConnection
+    backend: Literal["raster", "xarray", "vector"]
+    crs: pyproj.CRS
+
+    @classmethod
+    def open(cls, source: str | Path | list[str | Path],
+             *, table: str = "files") -> "DuckDBGeoCatalog":
+        """Open a parquet file, a list of parquet files, a directory of
+        parquet shards, or a .duckdb file. Local or remote URIs."""
+
+    @classmethod
+    def from_memory(cls, mem: InMemoryGeoCatalog) -> "DuckDBGeoCatalog":
+        """Register an in-memory catalog as a DuckDB view."""
+
+    # Set algebra — all return DuckDBGeoCatalog (still lazy)
+    def query(self, slice: GeoSlice, *, t_step: int | None = None) -> "DuckDBGeoCatalog": ...
+    def intersect(self, other: "GeoCatalog", *, spatial_only: bool = False) -> "DuckDBGeoCatalog": ...
+    def union(self, other: "GeoCatalog") -> "DuckDBGeoCatalog": ...
+
+    # Persistence
+    def to_geoparquet(self, path: str | Path, *,
+                      partition_by: list[str] | None = None,
+                      sort_by: list[str] | None = None,
+                      compression: str = "zstd") -> None: ...
+    def to_duckdb_file(self, path: str | Path, *,
+                       with_rtree: bool = True) -> None: ...
+
+    # Analytics escape hatch — return a DataFrame (eager)
+    def aggregate(self, sql: str, **params) -> pd.DataFrame: ...
+    def explain(self) -> str: ...   # debug
+
+    # Underlying surface
+    def sql(self, sql: str, **params) -> "DuckDBGeoCatalog": ...   # arbitrary SQL filter
+```
+
+### 6.5 Builders gain a `backend=` parameter
+
+```python
+def build_raster_catalog(
+    filepaths: Sequence[str | Path],
+    *,
+    filename_regex: str,
+    date_format: str = "%Y%m%d",
+    target_crs: CRS | str | None = None,
+    target_resolution: tuple[float, float] | None = None,
+
+    # NEW
+    backend: Literal["memory", "duckdb"] = "memory",
+    out_path: str | Path | None = None,    # required if backend="duckdb"
+    write_bbox: bool = True,               # GeoParquet 1.1 bbox column
+    sort_by: tuple[str, ...] = ("tmin", "geometry_hilbert"),
+    n_workers: int = 1,
+) -> GeoCatalog: ...
+```
+
+When `backend="duckdb"`, the builder streams metadata into an Arrow record-batch writer and lands directly in `out_path` as GeoParquet. The returned object is a `DuckDBGeoCatalog` opened on that file. Memory stays bounded regardless of file count.
+
+Same surface for `build_xarray_catalog` and `build_vector_catalog`.
+
+### 6.6 GeoParquet schema (canonical)
+
+```text
+filepath        VARCHAR     NOT NULL
+tmin            TIMESTAMP   NULL              -- NULL means "no date known"
+tmax            TIMESTAMP   NULL
+geometry        BLOB (WKB)  NOT NULL          -- GeoParquet column metadata = CRS + encoding
+bbox            STRUCT      NOT NULL          -- xmin, ymin, xmax, ymax  (GeoParquet 1.1)
+crs             VARCHAR     NOT NULL          -- usually one value per file; per-row allowed
+backend         VARCHAR     NOT NULL          -- 'raster' | 'xarray' | 'vector'
+
+-- raster-specific (NULL for other backends)
+n_bands         INTEGER     NULL
+dtype           VARCHAR     NULL
+nodata          DOUBLE      NULL
+
+-- xarray-specific
+data_vars       VARCHAR[]   NULL
+time_var        VARCHAR     NULL
+n_timesteps     INTEGER     NULL
+
+-- vector-specific
+layer           VARCHAR     NULL
+
+-- optional analytics columns (recommended)
+area_m2         DOUBLE      NULL
+cloud_pct       DOUBLE      NULL
+sensor          VARCHAR     NULL
+processing_ver  VARCHAR     NULL
+```
+
+Per-file extras land in additional columns (typed when the schema knows them, JSON-encoded otherwise).
+
+### 6.7 CLI
+
+```bash
+$ georeader catalog inspect    cat.parquet
+$ georeader catalog stats      cat.parquet --by month --by sensor
+$ georeader catalog query      s3://bucket/cat.parquet \
+                                --aoi AOI.geojson --tmin 2023-06-01 --tmax 2023-06-30 \
+                                --out subset.parquet
+$ georeader catalog intersect  imagery.parquet labels.parquet --out joint.parquet
+$ georeader catalog union      l7.parquet l8.parquet         --out landsat.parquet
+$ georeader catalog optimize   cat.parquet --sort tmin,hilbert --bbox --rewrite
+```
+
+The CLI is a thin wrapper around `DuckDBGeoCatalog`; everything it does is callable from Python too.
+
+### 6.8 What I'd *not* add in Phase 2
+
+- A query DSL that abstracts over pandas vs SQL. Just expose `.gdf` and `.relation` as escape hatches.
+- A persistent server (HTTP API). That's STAC's job.
+- Auto-conversion between CRSs at query time. Catalogs should be written in one CRS; `ST_Transform` is available but slow and a footgun.
+- Materialized R-tree indexes on Parquet. They don't exist; if you need persistent indexes, write to `.duckdb` (see [§7](#7-sharp-edges)).
+
+---
+
+## 7. Sharp edges
+
+1. **GeoParquet 1.0 vs 1.1.** 1.1 adds the per-row bbox column — order-of-magnitude speedup for spatial filters at scale. Default to writing 1.1; provide a `--geoparquet-version=1.0` opt-out for compatibility with older readers.
+2. **DuckDB spatial extension version pinning.** APIs are stable but evolving. Pin a minimum DuckDB version (e.g. ≥ 1.1) and document the install (`INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;`).
+3. **No persistent R-tree on Parquet.** Persistent R-tree indexes only exist in `.duckdb` table files. If a catalog will be queried thousands of times with the same predicate shapes, materialize to `.duckdb`:
+   ```sql
+   CREATE TABLE files AS SELECT * FROM 'cat.parquet';
+   CREATE INDEX idx_geom ON files USING RTREE (geometry);
+   ```
+   Otherwise, rely on bbox + zone-map pushdown — usually fast enough.
+4. **Multi-CRS catalogs.** Same problem as Phase 1, more visible because SQL doesn't auto-reproject. Strong recommendation: **write all GeoParquet in EPSG:4326**, store the native CRS in a column, reproject on load. `ST_Transform` works but requires PROJ data and is slow per call.
+5. **NULL temporal sentinels.** Don't write `pd.Timestamp.min/.max` — they overflow `TIMESTAMP`. Write `NULL` and require explicit `OR tmin IS NULL` for queries that should include date-less files.
+6. **Cursor lifecycle on `iter_rows()`.** The DuckDB connection must outlive the iterator. Use a context manager:
+   ```python
+   with catalog.cursor() as rows:
+       for row in rows:
+           ...
+   ```
+   Document that storing the iterator beyond the `with` block is unsupported.
+7. **WKB → shapely deserialization cost.** Per-row `shapely.from_wkb` is fine at 10⁴ rows/s, painful at 10⁶. For tight inner loops, batch with `shapely.from_wkb(arr)` (vectorized, uses `pygeos` / shapely 2.x).
+8. **Sampler weighting on lazy catalogs.** Phase 1's area-weighted random sampler ([§4.5 of Phase 1 report](#45-random-sampler-weighting)) needs all candidate areas. With DuckDB, either (a) maintain a precomputed `area_m2` column at build time (recommended), (b) use `USING SAMPLE 10%` to estimate, or (c) stream the area column once and cache.
+9. **Parquet schema evolution.** Parquet is immutable. Add a column → rewrite the file. Mitigate by storing the catalog as a directory of dated shards with consistent schema; DuckDB reads them as one virtual table via `read_parquet('shards/*.parquet')`. Document the canonical schema and bump a version column.
+10. **Authentication for remote.** `httpfs` picks up env vars, `~/.aws/credentials`, GCS service accounts automatically. Document this and provide one-line recipes per provider. Surface clear errors when auth fails (DuckDB's default messages are cryptic).
+11. **Streaming builder + multiprocessing.** When `n_workers > 1`, the rasterio metadata extraction parallelizes well, but Arrow record-batch writes must serialize. Use a single writer thread fed by a queue. Don't try to parallelize the Parquet writer itself.
+12. **Connection-per-thread.** DuckDB connections are *not* thread-safe; use `con.cursor()` in worker threads or open a fresh connection per process. The `DuckDBGeoCatalog` should expose a `.cursor()` method, not pass `con` around.
+
+---
+
+## 8. End-to-end examples
+
+A varied gallery, organized by what's *new* in Phase 2 — persistence, analytics, scale, federation, and lazy ML pipelines. All examples assume the Phase 1 surface exists.
+
+| § | Example | Pattern |
+| --- | --- | --- |
+| 8.1 | A. Save and reload a catalog locally | round-trip via GeoParquet |
+| 8.1 | B. Publish a catalog to S3, query remotely | `httpfs` + predicate pushdown |
+| 8.2 | C. Coverage histogram by month | `aggregate()` SQL |
+| 8.2 | D. Per-tile statistics | grouped SQL |
+| 8.2 | E. Custom SQL filter (low cloud, recent) | `.sql()` escape hatch |
+| 8.3 | F. Million-row spatial join | DuckDB `intersect` at scale |
+| 8.3 | G. Streaming build directly into GeoParquet | `backend="duckdb"` builder |
+| 8.4 | H. Federated query across monthly shards | one virtual table from many files |
+| 8.4 | I. Mix raster + vector catalogs in one SQL view | union via SQL |
+| 8.4 | J. Cross-CRS catalog join with `ST_Transform` | when harmonization isn't possible |
+| 8.5 | K. Lazy iterator from filtered catalog → sampler | DuckDB cursor → `random_sampler` |
+| 8.5 | L. Stratified sampling via SQL window functions | balanced training set |
+| 8.5 | M. Active learning with persistent uncertainty column | round-trip uncertainty back into the catalog |
+
+### 8.1 Persistence and sharing
+
+#### A. Save and reload a catalog locally
+
+```python
+from georeader.catalog import build_raster_catalog, open_catalog
+
+catalog = build_raster_catalog(
+    filepaths=glob("/data/s2/T29SND_*.tif"),
+    filename_regex=r"T29SND_(?P<date>\d{8})_.*\.tif",
+    target_crs="EPSG:4326",
+    target_resolution=(0.0001, 0.0001),
+)
+catalog.to_geoparquet("/cat/s2_T29SND.parquet", sort_by=["tmin", "geometry_hilbert"])
+
+# Tomorrow, in a fresh process:
+catalog = open_catalog("/cat/s2_T29SND.parquet")    # DuckDBGeoCatalog (lazy)
+print(len(catalog), catalog.total_bounds, catalog.temporal_extent)
+```
+
+#### B. Publish a catalog to S3, query remotely
+
+```python
+from georeader.catalog import open_catalog, GeoSlice
+
+# Producer
+catalog.to_geoparquet("s3://my-bucket/catalogs/s2_eu_2023.parquet")
+
+# Consumer, on a different machine:
+remote = open_catalog("s3://my-bucket/catalogs/s2_eu_2023.parquet")
+
+aoi = GeoSlice(
+    bounds=(-3.8, 40.3, -3.6, 40.5),
+    interval=pd.Interval(pd.Timestamp("2023-06-01"), pd.Timestamp("2023-06-30"), closed="both"),
+    resolution=(0.0001, 0.0001),
+    crs="EPSG:4326",
+)
+sub = remote.query(aoi).materialize()              # only relevant row groups downloaded
+print(f"Matched {len(sub)} files; downloaded ~{sub.bytes_read_estimate} bytes from S3.")
+```
+
+### 8.2 Catalog analytics
+
+#### C. Coverage histogram by month
+
+```python
+from georeader.catalog import open_catalog
+
+catalog = open_catalog("/cat/s2_T29SND.parquet")
+
+df = catalog.aggregate("""
+    SELECT
+        date_trunc('month', tmin)              AS month,
+        COUNT(*)                                AS n_files,
+        AVG(cloud_pct)                          AS mean_cloud,
+        SUM(area_m2) / 1e6                      AS total_area_km2
+    FROM files
+    GROUP BY 1
+    ORDER BY 1
+""")
+df.plot.bar(x="month", y="n_files")
+```
+
+#### D. Per-tile statistics, restricted to an AOI
+
+```python
+df = catalog.aggregate("""
+    SELECT
+        substr(filepath, 12, 6)                 AS tile_id,
+        COUNT(*)                                AS n_acquisitions,
+        MIN(tmin)                               AS first_seen,
+        MAX(tmax)                               AS last_seen,
+        AVG(cloud_pct)                          AS mean_cloud
+    FROM files
+    WHERE ST_Intersects(geometry, ST_GeomFromText($aoi_wkt))
+    GROUP BY 1
+    ORDER BY n_acquisitions DESC
+""", aoi_wkt=aoi_polygon.wkt)
+```
+
+#### E. Custom SQL filter (recent, low-cloud, large enough)
+
+```python
+fresh = catalog.sql("""
+    SELECT * FROM files
+    WHERE tmin >= '2023-01-01'
+      AND cloud_pct < 10
+      AND area_m2  > 1e8
+""")     # returns DuckDBGeoCatalog (still lazy)
+
+print(len(fresh))
+fresh.to_geoparquet("/cat/s2_T29SND_clean_2023.parquet")
+```
+
+### 8.3 Scale operations
+
+#### F. Million-row spatial join (intersect at scale)
+
+```python
+imagery = open_catalog("s3://my-bucket/imagery_eu.parquet")          # 1.2M rows
+labels  = open_catalog("s3://my-bucket/labels_eu.parquet")           # 0.5M rows
+
+joint = imagery.intersect(labels)                                     # lazy, no execution yet
+joint.to_geoparquet("/cat/eu_imagery_x_labels.parquet",
+                    partition_by=["sensor"], sort_by=["tmin"])
+
+# DuckDB plan (printed for transparency):
+print(joint.explain())
+# │  ► HASH_JOIN  ON ST_Intersects(...) AND a.tmax >= b.tmin AND a.tmin <= b.tmax
+# │  ├── PARQUET_SCAN  imagery_eu.parquet  [bbox + tmin/tmax pushdown]
+# │  └── PARQUET_SCAN  labels_eu.parquet   [bbox + tmin/tmax pushdown]
+```
+
+#### G. Streaming build directly into GeoParquet
+
+```python
+from georeader.catalog import build_raster_catalog
+
+# 8.5M files; would never fit in a gdf.
+catalog = build_raster_catalog(
+    filepaths=iter_files_from("/very_large_archive/"),     # any iterable
+    filename_regex=FILENAME_REGEX,
+    target_crs="EPSG:4326",
+    target_resolution=(0.0001, 0.0001),
+    backend="duckdb",
+    out_path="/cat/global_archive.parquet",
+    write_bbox=True,
+    sort_by=("tmin", "geometry_hilbert"),
+    n_workers=8,                                           # parallel rasterio metadata extraction
+)
+print(len(catalog))            # 8_532_104, peak RAM stayed under 1 GB
+```
+
+### 8.4 Federation and heterogeneity
+
+#### H. Federated query across monthly shards
+
+```python
+# /cat/s2_2023/ contains 12 monthly parquet shards with the same schema
+catalog = open_catalog("/cat/s2_2023/")           # DuckDB reads all shards as one table
+
+aoi = GeoSlice(bounds=AOI, interval=pd.Interval("2023-04-01", "2023-09-30", closed="both"),
+               resolution=(0.0001, 0.0001), crs="EPSG:4326")
+sub = catalog.query(aoi)                           # touches only 6 shards (Apr–Sep)
+```
+
+Same pattern works for `s3://bucket/s2_2023/*.parquet` or HuggingFace datasets.
+
+#### I. Mix raster and vector catalogs in one SQL view
+
+```python
+imagery_cat = open_catalog("/cat/s2.parquet")
+labels_cat  = open_catalog("/cat/labels.parquet")
+
+con = imagery_cat.con
+con.register("img", imagery_cat.relation)
+con.register("lab", labels_cat.relation)
+
+paired = con.sql("""
+    SELECT  img.filepath  AS img_fp,
+            lab.filepath  AS lab_fp,
+            ST_Intersection(img.geometry, lab.geometry) AS geometry,
+            GREATEST(img.tmin, lab.tmin) AS tmin,
+            LEAST   (img.tmax, lab.tmax) AS tmax
+    FROM img
+    JOIN lab
+      ON ST_Intersects(img.geometry, lab.geometry)
+     AND img.tmax >= lab.tmin AND img.tmin <= lab.tmax
+    WHERE img.cloud_pct < 5
+""")
+
+paired_cat = DuckDBGeoCatalog.from_relation(paired, backend="raster", crs="EPSG:4326")
+```
+
+#### J. Cross-CRS catalog join (last resort)
+
+If you really can't harmonize CRSs at write time, push `ST_Transform` into the join:
+
+```python
+joint = catalog.sql("""
+    SELECT a.*, b.filepath AS dem_path
+    FROM files a
+    JOIN 'dem_utm.parquet' b
+      ON ST_Intersects(
+           a.geometry,
+           ST_Transform(b.geometry, 'EPSG:32629', 'EPSG:4326')
+         )
+""")
+```
+
+Slower and PROJ-dependent. Document the cost.
+
+### 8.5 Sampler / inference patterns at scale
+
+#### K. Lazy iterator from a filtered catalog into the random sampler
+
+The sampler doesn't care that the catalog is DuckDB-backed; it just calls `iter_rows()`.
+
+```python
+from georeader.catalog import open_catalog
+from georeader.samplers import random_sampler
+
+catalog = open_catalog("s3://bucket/imagery_eu.parquet")
+clean   = catalog.sql("WHERE cloud_pct < 10 AND area_m2 > 1e8")     # still lazy
+
+# random_sampler internally does clean.iter_rows() + reservoir sampling
+for sl in random_sampler(clean, chip_size=(256, 256), length=100_000, seed=42):
+    x = load_raster(catalog, sl, band_indexes=[2, 3, 4, 8]).values
+    train_step(x)
+```
+
+DuckDB streams candidate rows; the sampler reservoir-samples without ever materializing the full filtered set.
+
+#### L. Stratified sampling via SQL window functions
+
+Balance a training set across, say, agro-ecological zones:
+
+```python
+catalog = open_catalog("/cat/s2_with_zones.parquet")    # has a `zone` column
+
+stratified = catalog.sql("""
+    SELECT * FROM (
+        SELECT *,
+               ROW_NUMBER() OVER (PARTITION BY zone ORDER BY random()) AS rn
+        FROM files
+        WHERE cloud_pct < 5
+    )
+    WHERE rn <= 1000      -- 1000 chips per zone
+""")
+
+for sl in random_sampler(stratified, chip_size=(256, 256)):
+    ...
+```
+
+#### M. Active learning with a persistent uncertainty column
+
+Round-trip the model's uncertainty back into the catalog to drive the next labeling round.
+
+```python
+catalog = open_catalog("/cat/al_round_3.parquet")
+
+# Score current candidates
+scores = []
+for row in catalog.iter_rows():
+    sl = GeoSlice(bounds=row.geometry.bounds, interval=row.interval,
+                  resolution=(10.0, 10.0), crs=row.crs)
+    x = load_raster(catalog, sl).values
+    _, sigma = model_with_uncertainty(x)
+    scores.append((row.filepath, float(sigma.mean())))
+
+# Persist back as a derived catalog
+con = catalog.con
+con.execute("""
+    CREATE OR REPLACE TABLE al_round_4 AS
+    SELECT files.*, scores.uncertainty
+    FROM files
+    JOIN (SELECT * FROM (VALUES ($values)) AS t(filepath, uncertainty)) scores
+      USING (filepath)
+""", values=scores)
+con.execute("COPY al_round_4 TO '/cat/al_round_4.parquet' (FORMAT 'parquet', COMPRESSION 'zstd')")
+
+# The next round: pick the top-N most uncertain
+next_round = open_catalog("/cat/al_round_4.parquet").sql(
+    "SELECT * FROM files ORDER BY uncertainty DESC LIMIT 500"
+)
+```
+
+### 8.6 Phase 2 API extensions implied by these examples
+
+The new examples lean on a small set of additions that aren't strictly in §6:
+
+- `DuckDBGeoCatalog.from_relation(...)` — wrap an arbitrary DuckDB relation as a catalog (used in I).
+- `GeoCatalog.bytes_read_estimate` — telemetry surface from DuckDB's stats (used in B).
+- `geometry_hilbert` virtual sort key — computed at write time from the geometry centroid (used in A, G).
+- `catalog.cursor()` context manager around `iter_rows()` (mentioned in §7).
+
+None require new dependencies; all are thin wrappers over DuckDB or geopandas.
+
+---
+
+## 9. Verdict
+
+Phase 2 is a **clean, additive upgrade** that costs almost nothing for users on the in-memory path and unlocks 2–3 orders of magnitude more catalog scale, plus a real sharing story, for users who need it. The Phase 1 protocol design pays off here: loaders, samplers, and stitchers are unchanged.
+
+What needs to happen to ship Phase 2:
+
+- [ ] Implement `DuckDBGeoCatalog` behind a `[duckdb]` extra, satisfying the `GeoCatalog` protocol from Phase 1.
+- [ ] Canonicalize the GeoParquet schema (§6.6) — types, NULL conventions, bbox column, sort order. Bump a `schema_version` column so future migrations are tractable.
+- [ ] Add the streaming-write builders (`backend="duckdb"`) so multi-million-file ingest doesn't materialize a gdf.
+- [ ] Round-trip tests on every backend at three scales: 10², 10⁴, 10⁶ rows.
+- [ ] Cross-CRS smoke test (mixed-UTM-zone catalog harmonized to EPSG:4326 at write time).
+- [ ] A `georeader catalog` CLI surface (§6.7) with the half-dozen subcommands above.
+- [ ] One worked example per category in the docs, mirroring §8.
+
+What I'd defer to Phase 3:
+
+- A federated discovery layer (STAC bridge: produce a STAC catalog from a `GeoCatalog`, or open a STAC endpoint as a `GeoCatalog`).
+- Persistent on-disk R-trees with automatic materialization based on query patterns.
+- Distributed query (DuckDB has nothing here; this is the Iceberg / Delta Lake territory).
+- A web UI for catalog inspection.
+
+If we get §6 + §7 right, Phase 2 turns the catalog from "a Python object you build at the start of every script" into "a file you build once, version, share, and query lazily from anywhere." That's the upgrade.

--- a/projects/geotoolz/plans/georeader.md
+++ b/projects/geotoolz/plans/georeader.md
@@ -1,5 +1,5 @@
 
-# Reader reconciliation — `RasterioReader`, `LazyCOGReader`, `AsyncGeoTIFFReader`
+# Reader reconciliation
 
 > **Scope:** rough class-level signatures showing how the three readers share one metadata surface and split into sync vs async read interfaces. Same level of granularity as the `GeoSlice` / `GeoCatalog` design sketches — types and method shapes, not full implementations.
 >

--- a/projects/geotoolz/plans/georeader.md
+++ b/projects/geotoolz/plans/georeader.md
@@ -1,0 +1,846 @@
+
+# Reader reconciliation — `RasterioReader`, `LazyCOGReader`, `AsyncGeoTIFFReader`
+
+> **Scope:** rough class-level signatures showing how the three readers share one metadata surface and split into sync vs async read interfaces. Same level of granularity as the `GeoSlice` / `GeoCatalog` design sketches — types and method shapes, not full implementations.
+>
+> **Status:** reference document, design-shaped. The exact field names, transports, and decoder choices may differ in the actual implementations.
+
+---
+
+## Overview
+
+Three readers, one shared metadata surface, two read interfaces:
+
+| Reader | Lives in | Sync / async | Transport | Driver |
+| --- | --- | --- | --- | --- |
+| `RasterioReader` | `georeader` | sync | GDAL / VSI | every GDAL driver |
+| `LazyCOGReader` | external (`lazy-cogs`) | sync API, lazy semantics | `obstore` / `fsspec` | TIFF / COG only |
+| `AsyncGeoTIFFReader` | external (`async-geotiff`) | async | `obstore` | TIFF / COG only |
+
+The metadata properties (`crs`, `transform`, `bounds`, `shape`, `count`, `dtype`, `nodata`, `res`) and the read-method names (`read_window`, `read_bounds`, `read_geoslice`, `load`) are identical across all three. The only divergence is whether reads are sync or async.
+
+---
+
+## Shared protocol
+
+```python
+from typing import Protocol, Sequence
+import numpy as np
+import pyproj
+from rasterio import Affine
+from rasterio.windows import Window
+from georeader.geotensor import GeoTensor
+from georeader.geoslice import GeoSlice
+
+
+class _ReaderMeta(Protocol):
+    """Metadata surface shared by every georeader reader.
+
+    All properties are cheap after construction (header-only). Subclasses
+    decide *when* the header is fetched — eagerly in __init__ (sync readers)
+    or via an async classmethod (async readers).
+    """
+    path_or_url: str
+    indexes: tuple[int, ...] | None        # bands to read; None = all
+
+    @property
+    def crs(self) -> pyproj.CRS: ...
+    @property
+    def transform(self) -> Affine: ...
+    @property
+    def bounds(self) -> tuple[float, float, float, float]: ...   # (xmin, ymin, xmax, ymax)
+    @property
+    def shape(self) -> tuple[int, int, int]: ...                  # (count, height, width)
+    @property
+    def count(self) -> int: ...
+    @property
+    def height(self) -> int: ...
+    @property
+    def width(self) -> int: ...
+    @property
+    def dtype(self) -> np.dtype: ...
+    @property
+    def nodata(self) -> float | None: ...
+    @property
+    def res(self) -> tuple[float, float]: ...                     # (x_res, y_res)
+
+
+class SyncReader(_ReaderMeta, Protocol):
+    """Sync read interface — RasterioReader and LazyCOGReader."""
+
+    def read_window(self, window: Window) -> GeoTensor: ...
+    def read_bounds(
+        self,
+        bounds: tuple[float, float, float, float],
+        *,
+        target_resolution: tuple[float, float] | None = None,
+        target_crs: pyproj.CRS | str | None = None,
+    ) -> GeoTensor: ...
+    def read_geoslice(self, slice: GeoSlice) -> GeoTensor: ...
+    def load(self) -> GeoTensor: ...
+    def close(self) -> None: ...
+
+    def __enter__(self) -> "SyncReader": ...
+    def __exit__(self, *exc) -> None: ...
+
+
+class AsyncReader(_ReaderMeta, Protocol):
+    """Async read interface — AsyncGeoTIFFReader."""
+
+    async def read_window(self, window: Window) -> GeoTensor: ...
+    async def read_bounds(
+        self,
+        bounds: tuple[float, float, float, float],
+        *,
+        target_resolution: tuple[float, float] | None = None,
+        target_crs: pyproj.CRS | str | None = None,
+    ) -> GeoTensor: ...
+    async def read_geoslice(self, slice: GeoSlice) -> GeoTensor: ...
+    async def load(self) -> GeoTensor: ...
+    async def aclose(self) -> None: ...
+
+    async def __aenter__(self) -> "AsyncReader": ...
+    async def __aexit__(self, *exc) -> None: ...
+```
+
+Both `SyncReader` and `AsyncReader` share the entire metadata surface. The only thing that diverges is whether the read methods return a `GeoTensor` or a `Coroutine[GeoTensor]`.
+
+---
+
+## `RasterioReader` (sync, GDAL-backed) — lives in `georeader`
+
+```python
+class RasterioReader(SyncReader):
+    """Sync, GDAL-backed reader. The default in georeader.
+
+    Opens a rasterio dataset on construction (cheap — header + IFD). The
+    file handle is cached for the lifetime of the reader so repeated reads
+    don't pay the open cost. Closes on context-exit or explicit .close().
+
+    Reads happen via rasterio.read(window=...). The bytes path *under*
+    the rasterio call has three modes — see "Inside RasterioReader" below:
+
+      1. opener=None and fs=None  → GDAL VSI (libcurl in C); the default.
+                                     Cloud paths /vsis3/, /vsigs/, /vsiaz/, /vsicurl/.
+      2. opener=callable          → GDAL calls the callable for each byte range.
+      3. fs=fsspec_filesystem     → shortcut: equivalent to opener=fs.open.
+
+    On-the-fly reprojection in read_bounds() is done via rasterio.warp.WarpedVRT.
+    """
+    path_or_url: str
+    indexes: tuple[int, ...] | None
+    _dataset: "rasterio.DatasetReader | None"        # cached open handle
+    _opener: "Callable[[str, str], BinaryIO] | None"
+    _fs: "fsspec.AbstractFileSystem | None"
+    _rio_open_kwargs: dict
+
+    def __init__(
+        self,
+        path_or_url: str,
+        indexes: int | Sequence[int] | None = None,
+        *,
+        opener: "Callable[[str, str], BinaryIO] | None" = None,    # custom file opener
+        fs: "fsspec.AbstractFileSystem | None" = None,              # shortcut: opener=fs.open
+        rio_open_kwargs: dict | None = None,                        # other rasterio.open kwargs
+    ): ...
+
+    # internal
+    def _ensure_open(self) -> "rasterio.DatasetReader":
+        """Open the dataset if not already open; return the handle."""
+        ...
+
+    # metadata — straight passthrough to rasterio dataset attrs
+    @property
+    def crs(self) -> pyproj.CRS: ...
+    # ... (the rest of _ReaderMeta surface)
+
+    # reads
+    def read_window(self, window: Window) -> GeoTensor:
+        """ds.read(indexes=..., window=...) → GeoTensor with windowed transform."""
+        ...
+    def read_bounds(self, bounds, *, target_resolution=None, target_crs=None) -> GeoTensor:
+        """Wrap in WarpedVRT if target_crs differs from native; window the
+        VRT to the requested bounds; read."""
+        ...
+    def read_geoslice(self, slice: GeoSlice) -> GeoTensor:
+        """Convenience: read_bounds(slice.bounds, target_resolution=slice.resolution,
+                                    target_crs=slice.crs)."""
+        ...
+    def load(self) -> GeoTensor: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> "RasterioReader": ...
+    def __exit__(self, *exc) -> None: ...
+```
+
+### Inside `RasterioReader` — the three bytes paths
+
+`RasterioReader` ultimately delegates to `rasterio.open(...).read(window=...)`. Under that delegation, GDAL's byte-fetching loop can run in three modes depending on what the constructor was given:
+
+```text
+              ┌──────────────────────┐
+              │   RasterioReader     │
+              │   __init__(...)      │
+              └──────────┬───────────┘
+                         │
+              ┌──────────┼──────────────────┐
+              ▼          ▼                  ▼
+       opener=None  opener=fs.open   opener=<custom>
+       fs=None      (or fs=…)        (e.g. obstore-aware)
+            │              │                   │
+            ▼              ▼                   ▼
+       ┌──────────┐ ┌──────────────┐ ┌──────────────────┐
+       │ GDAL VSI │ │ Python       │ │ Python adapter   │
+       │ (libcurl)│ │ file-like    │ │ over obstore     │
+       │  in C    │ │ via fsspec   │ │ get_range        │
+       └────┬─────┘ └──────┬───────┘ └────────┬─────────┘
+            │              │                  │
+            └──────────────┴──────────────────┘
+                           │
+                           ▼
+                  S3 / GCS / Azure / …
+```
+
+#### Path resolution in `__init__`
+
+```python
+def _resolve_open_kwargs(self) -> dict:
+    """Translate the constructor's opener/fs knobs into rasterio.open kwargs."""
+    kwargs = dict(self._rio_open_kwargs or {})
+    if self._opener is not None:
+        kwargs["opener"] = self._opener
+    elif self._fs is not None:                       # fs= shortcut
+        kwargs["opener"] = self._fs.open
+    # else: no opener key → rasterio uses GDAL VSI for cloud paths
+    return kwargs
+
+def _ensure_open(self) -> "rasterio.DatasetReader":
+    if self._dataset is None or self._dataset.closed:
+        self._dataset = rasterio.open(
+            self.path_or_url, **self._resolve_open_kwargs(),
+        )
+    return self._dataset
+```
+
+#### Per-path summary
+
+| Path | Trigger | Bytes fetched by | Speed | Driver coverage |
+| --- | --- | --- | --- | --- |
+| **GDAL VSI** | `opener=None`, `fs=None` (default) | libcurl inside GDAL | fastest sync option | every GDAL driver |
+| **fsspec** | `fs=fsspec_fs` or `opener=fs.open` | Python file-like via fsspec; GDAL calls back per range | slower (Python ↔ C trip per range) | every GDAL driver, Python boundary added |
+| **obstore** (custom callback) | `opener=<callback wrapping obstore.get_range>` | Python adapter over `obstore.ObjectStore` | similar to fsspec — same Python ↔ C bottleneck | every GDAL driver, but only for what obstore can serve |
+
+#### Usage
+
+```python
+# Default — GDAL VSI handles s3:// directly; fastest option
+reader = RasterioReader("s3://bucket/scene.tif")
+
+# fsspec shortcut — for niche backends or custom auth
+import fsspec
+fs = fsspec.filesystem(
+    "s3", endpoint_url="https://my-minio:9000", key=..., secret=...,
+)
+reader = RasterioReader("s3://bucket/scene.tif", fs=fs)
+
+# Equivalent: explicit opener
+reader = RasterioReader(
+    "s3://bucket/scene.tif",
+    rio_open_kwargs={"opener": fs.open},
+)
+
+# obstore via custom callable — possible but rarely the right tool;
+# at this point you'd use LazyCOGReader or AsyncGeoTIFFReader instead
+def obstore_opener(path: str, mode: str) -> "BinaryIO":
+    """Return a file-like wrapping obstore range fetches."""
+    ...
+reader = RasterioReader("s3://bucket/scene.tif", opener=obstore_opener)
+```
+
+The three options share the metadata surface and the public API — **only the bytes path differs underneath**, and `_resolve_open_kwargs` is the only Python code that knows which path is active.
+
+---
+
+## `LazyCOGReader` (sync API, lazy-on-open + on-slice fetch)
+
+```python
+class LazyCOGReader(SyncReader):
+    """Lazy COG reader (TIFF/COG only, no GDAL).
+
+    Open is one or two HTTP range requests for the TIFF IFD chain — the
+    file is *not* downloaded. Reads are sync (the API matches RasterioReader)
+    but every read_window / read_bounds call issues exactly the range
+    requests needed for the COG tiles overlapping the requested region.
+
+    No file handle to close; obstore manages connection pooling.
+    """
+    path_or_url: str
+    indexes: tuple[int, ...] | None
+    _store: "obstore.ObjectStore"            # constructed from URL if not passed
+    _header: "COGHeader"                      # parsed IFD chain (tile offsets, sizes, layout)
+
+    def __init__(
+        self,
+        path_or_url: str,
+        indexes: int | Sequence[int] | None = None,
+        *,
+        store: "obstore.ObjectStore | None" = None,
+    ):
+        """Sync constructor — fetches the IFD chain immediately."""
+        ...
+
+    # internal
+    def _fetch_header_sync(self) -> "COGHeader":
+        """One or two sync range requests to pull and parse the TIFF IFDs."""
+        ...
+    def _tiles_for_window(self, window: Window) -> list["TileSpec"]:
+        """COG tiles overlapping the window: byte offset + length + (i, j) grid pos."""
+        ...
+    def _decompress_and_assemble(
+        self,
+        tile_bytes: list[bytes],
+        tiles: list["TileSpec"],
+        window: Window,
+    ) -> np.ndarray:
+        """Per-tile DEFLATE/LZW/JPEG decompress, paste into the output window."""
+        ...
+
+    # metadata — populated by __init__'s header fetch
+    @property
+    def crs(self) -> pyproj.CRS: ...
+    # ... (the rest of _ReaderMeta surface)
+
+    # reads — same shape as RasterioReader, different bytes path
+    def read_window(self, window: Window) -> GeoTensor:
+        """Identify overlapping COG tiles, fetch each via store.get_range_sync,
+        decompress, paste into the windowed array, wrap as GeoTensor."""
+        ...
+    def read_bounds(self, bounds, *, target_resolution=None, target_crs=None) -> GeoTensor:
+        """Bounds → window via inverse transform; reproject via scipy/skimage
+        if target_crs differs (no GDAL); read_window."""
+        ...
+    def read_geoslice(self, slice: GeoSlice) -> GeoTensor: ...
+    def load(self) -> GeoTensor:
+        """Read every tile. Discouraged — use RasterioReader if you want the whole file."""
+        ...
+
+    # numpy-style sugar — defers to read_window
+    def __getitem__(self, key: tuple[slice, slice] | tuple[slice, slice, slice]) -> GeoTensor:
+        """gt = reader[100:356, 200:456] → exactly the tiles for that bbox."""
+        ...
+
+    def close(self) -> None: ...                     # no-op; obstore is pooled
+    def __enter__(self) -> "LazyCOGReader": ...
+    def __exit__(self, *exc) -> None: ...
+```
+
+### Inside `LazyCOGReader` — IFD parsing and tile fetching
+
+The pure-Python reader has two halves: **header parsing** (once, on `__init__`) and **tile fetching** (once per `read_*` call). Both are sync; the async sibling is `AsyncGeoTIFFReader` below.
+
+#### Header parsing — what happens at construction time
+
+```text
+LazyCOGReader("s3://bucket/scene.tif")
+        │
+        ▼
+1. store.get_range(url, 0, 16_384)              # one HTTP range request
+        │
+        ▼
+2. Parse TIFF magic + first IFD pointer
+        │
+        ▼
+3. Walk IFD chain (one or two more range requests if it spills past 16 KB)
+        │
+        ▼
+4. Cache COGHeader: per-IFD tile size, tile_offsets[],
+   tile_byte_counts[], compression, dtype, photometric,
+   transform, crs (from GeoKeys), nodata
+        │
+        ▼
+self._header = COGHeader(...)                   # ~few KB total fetched
+```
+
+A TIFF stores file-level metadata in an *IFD* (Image File Directory). A COG has one IFD per resolution level (full-res + overviews); each IFD lists tile byte offsets and lengths in its `TileOffsets` / `TileByteCounts` tags. Parsing all IFDs lets the reader decide, for any output window, exactly which tiles to fetch and from which IFD (overview level).
+
+#### Tile fetching — what happens on `read_window(window)`
+
+Window-to-tiles mapping. For COG tile size `(T_x, T_y)` and a window `w = (col_off, row_off, width, height)`:
+
+$$
+\begin{aligned}
+i \in \,&\bigl[\,\lfloor w_{\text{col\_off}} / T_x \rfloor,\; \lceil (w_{\text{col\_off}} + w_{\text{width}}) / T_x \rceil\,\bigr) \\
+j \in \,&\bigl[\,\lfloor w_{\text{row\_off}} / T_y \rfloor,\; \lceil (w_{\text{row\_off}} + w_{\text{height}}) / T_y \rceil\,\bigr)
+\end{aligned}
+$$
+
+Tile sizes are typically 512×512 or 256×256 px.
+
+```python
+def _tiles_for_window(self, window: Window) -> list["TileSpec"]:
+    """Compute the (i, j) tile indices that cover the window, then look up
+    each tile's byte offset/length from the cached IFD."""
+    Tx, Ty = self._header.tile_size                          # px
+    i0 = window.col_off // Tx
+    i1 = ceil((window.col_off + window.width)  / Tx)
+    j0 = window.row_off // Ty
+    j1 = ceil((window.row_off + window.height) / Ty)
+    n_cols = self._header.n_cols_in_tiles                    # ceil(W / Tx)
+
+    tiles = []
+    for j in range(j0, j1):
+        for i in range(i0, i1):
+            idx = j * n_cols + i
+            tiles.append(TileSpec(
+                grid=(i, j),
+                offset=self._header.tile_offsets[idx],
+                length=self._header.tile_byte_counts[idx],
+                compression=self._header.compression,
+            ))
+    return tiles
+```
+
+Then the read itself batches every range request into one parallel call:
+
+```python
+def read_window(self, window: Window) -> GeoTensor:
+    tiles = self._tiles_for_window(window)
+
+    # Batch all tile range requests; obstore can coalesce close-by ranges.
+    tile_bytes = self._store.get_ranges(
+        self.path_or_url,
+        [(t.offset, t.length) for t in tiles],
+    )
+
+    # Decompress each tile (DEFLATE / LZW / JPEG / Zstd / none) and paste
+    # into the output buffer.
+    out = np.empty(self._output_shape(window), dtype=self._header.dtype)
+    for t, raw_bytes in zip(tiles, tile_bytes):
+        tile_arr = decompress_tile(
+            raw_bytes, t.compression, self._header.tile_size, self._header.dtype,
+        )
+        self._paste_tile_into_window(out, tile_arr, t.grid, window)
+
+    return GeoTensor(
+        values=out,
+        transform=self._header.window_transform(window),
+        crs=self._header.crs,
+        fill_value_default=self._header.nodata,
+    )
+```
+
+#### Decompression
+
+Per-tile decompression is dispatched on the `Compression` IFD tag:
+
+| Compression code | Codec | Decoder |
+| --- | --- | --- |
+| `1` | none | `np.frombuffer(...).reshape(...)` |
+| `8` | DEFLATE | `zlib.decompress` |
+| `5` | LZW | `imagecodecs.lzw_decode` |
+| `7` | JPEG | `imagecodecs.jpeg_decode` |
+| `34925` | LZMA | `lzma.decompress` |
+| `50000` / `50001` | Zstd | `imagecodecs.zstd_decode` (or `zstandard`) |
+
+`imagecodecs` is the canonical fast decoder for all of these and is usually a hard dep.
+
+#### Why this is fast
+
+For a 1 GB COG with 256×256 px tiles, a `read_window` for a 1024×1024 px output area touches **at most 25 tiles** (a 5×5 grid). At ~256 KB compressed each, that's ~6 MB of bytes fetched in **one parallel `get_ranges` call**. The other 994 MB of the file is never read.
+
+Compare to:
+
+- **Downloading the whole file:** 1 GB.
+- **GDAL VSI for the same window:** also fetches just the right tiles, *but* via 25 sequential range requests (libcurl reuses the connection but doesn't natively coalesce). With HTTP/2 multiplexing this gap narrows.
+- **Naive `cat` then slice:** the worst path; never do this.
+
+The win for `LazyCOGReader` over `RasterioReader`-via-VSI is mostly **per-tile Python overhead saved** (no GDAL state, no PROJ init per call) and **range coalescing** when obstore identifies close-by ranges.
+
+#### What this loses vs `RasterioReader`
+
+- **No GDAL warping.** `read_bounds(target_crs=...)` has to be done in Python — typically `scipy.ndimage.map_coordinates` or `skimage.transform.warp`. Slower and less accurate than GDAL/PROJ for difficult projections.
+- **TIFF/COG only.** No JP2, NetCDF, HDF5, GRIB, ENVI. Use `RasterioReader` for those.
+- **Limited compression set.** Whatever `imagecodecs` ships. Old `JPEG2000` tiles in some legacy COGs may not decode.
+- **No CRS-quirk handling.** GDAL has a long tail of CRS fixes (Web Mercator latitude clamp, ESRI WKT variants, datum-shift grids) that a pure-Python reader doesn't replicate.
+
+The trade is intentional: skip GDAL for speed and concurrency-friendliness, accept narrower scope.
+
+---
+
+## `AsyncGeoTIFFReader` (async, obstore-backed)
+
+```python
+class AsyncGeoTIFFReader(AsyncReader):
+    """Async COG reader (TIFF/COG only, no GDAL).
+
+    Open is async because the IFD fetch is async. After open, every read
+    method dispatches `len(tiles)` parallel range requests via obstore and
+    awaits all of them before assembling the array. Designed for high
+    concurrency — e.g. a tile server fetching 1000 windows concurrently.
+    """
+    path_or_url: str
+    indexes: tuple[int, ...] | None
+    _store: "obstore.ObjectStore"
+    _header: "COGHeader | None"                      # populated after .open()
+    _max_concurrent_tiles: int
+
+    def __init__(
+        self,
+        path_or_url: str,
+        indexes: int | Sequence[int] | None = None,
+        *,
+        store: "obstore.ObjectStore | None" = None,
+        max_concurrent_tiles: int = 32,
+    ):
+        """Cheap. Does NOT fetch the header — call .open() first."""
+        ...
+
+    @classmethod
+    async def open(
+        cls,
+        path_or_url: str,
+        indexes: int | Sequence[int] | None = None,
+        *,
+        store: "obstore.ObjectStore | None" = None,
+        max_concurrent_tiles: int = 32,
+    ) -> "AsyncGeoTIFFReader":
+        """Async constructor: build instance, fetch and parse the IFD chain.
+        Most users call this rather than __init__."""
+        ...
+
+    # internal
+    async def _fetch_header(self) -> None:
+        """One or two async range requests to pull and parse the TIFF IFDs."""
+        ...
+    def _tiles_for_window(self, window: Window) -> list["TileSpec"]: ...
+    def _decompress_and_assemble(
+        self,
+        tile_bytes: list[bytes],
+        tiles: list["TileSpec"],
+        window: Window,
+    ) -> np.ndarray: ...
+
+    # metadata — sync after .open() has been awaited
+    @property
+    def crs(self) -> pyproj.CRS:
+        """Raises RuntimeError if .open() hasn't been awaited yet."""
+        ...
+    # ... (the rest of _ReaderMeta surface)
+
+    # reads — same shape as the sync readers, but coroutines
+    async def read_window(self, window: Window) -> GeoTensor:
+        """tiles = self._tiles_for_window(window)
+           bytes_list = await asyncio.gather(*[
+               self._store.get_range_async(self.path_or_url, t.offset, t.length)
+               for t in tiles
+           ])  # parallel
+           return self._decompress_and_assemble(bytes_list, tiles, window) → GeoTensor."""
+        ...
+    async def read_bounds(self, bounds, *, target_resolution=None, target_crs=None) -> GeoTensor: ...
+    async def read_geoslice(self, slice: GeoSlice) -> GeoTensor: ...
+    async def load(self) -> GeoTensor:
+        """Fetches every tile in parallel. Use sparingly."""
+        ...
+
+    async def aclose(self) -> None: ...               # no-op; obstore is pooled
+    async def __aenter__(self) -> "AsyncGeoTIFFReader": ...
+    async def __aexit__(self, *exc) -> None: ...
+```
+
+---
+
+## How they're swappable in `geotoolz`
+
+Because the metadata surface and read-method names are identical, downstream code only branches on sync vs async:
+
+```python
+# Sync path — RasterioReader or LazyCOGReader
+def apply_to_chip(reader: SyncReader, slice_: GeoSlice, op: Operator) -> GeoTensor:
+    with reader as r:
+        gt = r.read_geoslice(slice_)
+        return op(gt)
+
+# Async path — AsyncGeoTIFFReader
+async def apply_to_chip_async(reader: AsyncReader, slice_: GeoSlice, op: Operator) -> GeoTensor:
+    async with reader as r:
+        gt = await r.read_geoslice(slice_)
+        return op(gt)                                   # op itself stays sync
+
+
+# In geotoolz, the pipeline picks which world it lives in:
+geotoolz.catalog_ops.CatalogPipeline(
+    catalog,
+    op,
+    reader_class=georeader.RasterioReader,         # sync default
+    # reader_class=georeader.LazyCOGReader,         # sync, lazy-on-open
+    # reader_class=georeader.AsyncGeoTIFFReader,    # async, fan-out
+)
+```
+
+---
+
+## Strategy axis at a glance
+
+| Reader | Open cost | Read cost (small bbox) | Concurrent reads | Driver coverage |
+| --- | --- | --- | --- | --- |
+| `RasterioReader` | header + IFD via GDAL | one VSI call | sync (threadpool) | every GDAL driver |
+| `LazyCOGReader` | one or two range requests | one tile-batch fetch | sync (threadpool) | TIFF/COG only |
+| `AsyncGeoTIFFReader` | one or two async range requests | parallel tile fetch | native asyncio | TIFF/COG only |
+
+Same metadata surface, same `read_*` method names, three different bytes paths underneath. The only tax on swapping is `await` — which is unavoidable as long as the cloud HTTP world is fundamentally async.
+
+---
+
+## Transport reconciliation — `obstore` vs `fsspec`
+
+One layer below the readers, the bytes themselves are fetched by one of two transports. Both can serve the same use case (range reads from S3 / GCS / Azure) but they have very different shapes:
+
+| Library | API style |
+| --- | --- |
+| `obstore` | Object store: `store.get(key)`, `store.get_range(key, off, len)`, `store.put(key, data)`, `store.list(prefix)`. Async-native. |
+| `fsspec` | Filesystem: `fs.open(path, "rb").seek(off).read(n)`, `fs.cat(path)`, `fs.glob(pattern)`. Sync-native, async via `asynchronous=True`. |
+
+For COG-tile-shaped reads (`get_range` / read at offset N for length L), both libraries can serve the same need. A unified `ByteStore` Protocol lets the readers stay agnostic.
+
+### The shared protocol
+
+```python
+from typing import Iterator, Protocol
+
+
+class ByteStore(Protocol):
+    """Unified byte-store API. Both obstore.ObjectStore and fsspec
+    AbstractFileSystem can satisfy this via thin adapters.
+
+    Every method comes in sync + async pairs. Adapter implementations
+    can leave one pair as best-effort (e.g. fsspec's async path is
+    only fast on async-capable backends like s3fs / gcsfs / adlfs)."""
+
+    # whole-object reads
+    def get(self, key: str) -> bytes: ...
+    async def get_async(self, key: str) -> bytes: ...
+
+    # range reads — the hot path for COG tile fetches
+    def get_range(self, key: str, offset: int, length: int) -> bytes: ...
+    async def get_range_async(self, key: str, offset: int, length: int) -> bytes: ...
+
+    # parallel range reads — the BIG win for tile fan-out
+    def get_ranges(
+        self, key: str, ranges: list[tuple[int, int]],
+    ) -> list[bytes]: ...
+    async def get_ranges_async(
+        self, key: str, ranges: list[tuple[int, int]],
+    ) -> list[bytes]: ...
+
+    # writes
+    def put(self, key: str, data: bytes) -> None: ...
+    async def put_async(self, key: str, data: bytes) -> None: ...
+
+    # listing
+    def list(self, prefix: str = "") -> Iterator[str]: ...
+    async def list_async(self, prefix: str = "") -> Iterator[str]: ...
+```
+
+### `ObstoreByteStore` — wraps `obstore.ObjectStore`
+
+```python
+class ObstoreByteStore(ByteStore):
+    """Wrap an obstore.ObjectStore as a ByteStore.
+
+    Async path is the native one — sync methods are thin wrappers that
+    block on the async path via the obstore sync runtime.
+    """
+    _store: "obstore.ObjectStore"
+
+    def __init__(self, store: "obstore.ObjectStore"):
+        self._store = store
+
+    @classmethod
+    def from_url(cls, url: str, **kwargs) -> "ObstoreByteStore":
+        """Auto-pick the right obstore backend from URL scheme:
+        s3:// → S3Store, gs:// → GCSStore, az:// → AzureStore,
+        http(s):// → HTTPStore, file:// → LocalStore, memory:// → MemoryStore."""
+        ...
+
+    # whole object
+    def get(self, key: str) -> bytes:
+        return self._store.get(key).bytes()
+    async def get_async(self, key: str) -> bytes:
+        result = await self._store.get_async(key)
+        return await result.bytes_async()
+
+    # single range
+    def get_range(self, key: str, offset: int, length: int) -> bytes:
+        return self._store.get_range(key, offset, length).bytes()
+    async def get_range_async(self, key: str, offset: int, length: int) -> bytes:
+        result = await self._store.get_range_async(key, offset, length)
+        return await result.bytes_async()
+
+    # parallel ranges — obstore's get_ranges is native; coalesces close ranges
+    def get_ranges(self, key, ranges):
+        return [b.bytes() for b in self._store.get_ranges(key, ranges)]
+    async def get_ranges_async(self, key, ranges):
+        results = await self._store.get_ranges_async(key, ranges)
+        return [await r.bytes_async() for r in results]
+
+    # writes
+    def put(self, key, data): self._store.put(key, data)
+    async def put_async(self, key, data): await self._store.put_async(key, data)
+
+    # listing
+    def list(self, prefix=""):
+        for entry in self._store.list(prefix=prefix):
+            yield entry.path
+    async def list_async(self, prefix=""):
+        async for entry in self._store.list_async(prefix=prefix):
+            yield entry.path
+```
+
+### `FsspecByteStore` — wraps an `fsspec.AbstractFileSystem`
+
+```python
+class FsspecByteStore(ByteStore):
+    """Wrap an fsspec filesystem as a ByteStore.
+
+    Sync methods always work. Async methods require an async-capable
+    filesystem (constructed with asynchronous=True or a backend that
+    supports it like s3fs / adlfs / gcsfs). Parallel ranges have no
+    native fsspec equivalent — the adapter falls back to asyncio.gather
+    over single-range fetches, which is throughput-limited by the
+    backend."""
+    _fs: "fsspec.AbstractFileSystem"
+    _root: str                                       # bucket / container prefix
+
+    def __init__(self, fs: "fsspec.AbstractFileSystem", root: str = ""):
+        self._fs = fs
+        self._root = root.rstrip("/")
+
+    @classmethod
+    def from_url(cls, url: str, **kwargs) -> "FsspecByteStore":
+        """Build via fsspec.url_to_fs(url)."""
+        ...
+
+    def _path(self, key: str) -> str:
+        return f"{self._root}/{key}" if self._root else key
+
+    # whole object
+    def get(self, key: str) -> bytes:
+        return self._fs.cat_file(self._path(key))
+    async def get_async(self, key: str) -> bytes:
+        return await self._fs._cat_file(self._path(key))
+
+    # single range
+    def get_range(self, key: str, offset: int, length: int) -> bytes:
+        with self._fs.open(self._path(key), "rb") as f:
+            f.seek(offset)
+            return f.read(length)
+    async def get_range_async(self, key: str, offset: int, length: int) -> bytes:
+        return await self._fs._cat_file(
+            self._path(key), start=offset, end=offset + length,
+        )
+
+    # parallel ranges — no native parallel; serial fallback for sync,
+    # asyncio.gather for async (effective only on async-capable backends)
+    def get_ranges(self, key, ranges):
+        with self._fs.open(self._path(key), "rb") as f:
+            out = []
+            for offset, length in ranges:
+                f.seek(offset)
+                out.append(f.read(length))
+            return out
+    async def get_ranges_async(self, key, ranges):
+        return await asyncio.gather(*[
+            self.get_range_async(key, o, l) for (o, l) in ranges
+        ])
+
+    # writes
+    def put(self, key, data):
+        with self._fs.open(self._path(key), "wb") as f:
+            f.write(data)
+    async def put_async(self, key, data):
+        await self._fs._pipe_file(self._path(key), data)
+
+    # listing
+    def list(self, prefix=""):
+        return iter(self._fs.ls(self._path(prefix)))
+    async def list_async(self, prefix=""):
+        for p in await self._fs._ls(self._path(prefix)):
+            yield p
+```
+
+### Unified factory
+
+```python
+def open_store(
+    url: str,
+    *,
+    prefer: Literal["obstore", "fsspec", "auto"] = "auto",
+    **backend_kwargs,
+) -> ByteStore:
+    """Build a ByteStore for the given URL.
+
+    Selection:
+      "auto"   — obstore for s3:// / gs:// / az:// / http(s):// / file:// / memory://;
+                 fsspec for any other scheme (ftp://, sftp://, github://, …).
+      "obstore" — force obstore; raise if backend not supported.
+      "fsspec" — force fsspec; useful when the rest of the pipeline expects an
+                 fsspec-shaped object (zarr 2, geopandas, etc.).
+    """
+    ...
+```
+
+### How readers consume it
+
+Every reader that needs cloud byte access takes an optional `store: ByteStore | None = None`. If `None`, the reader calls `open_store(url)` internally:
+
+```python
+class LazyCOGReader(SyncReader):
+    def __init__(
+        self,
+        path_or_url: str,
+        indexes: int | Sequence[int] | None = None,
+        *,
+        store: ByteStore | None = None,
+    ):
+        self.path_or_url = path_or_url
+        self._store = store or open_store(path_or_url, prefer="auto")
+        # ...
+
+    def read_window(self, window):
+        tiles = self._tiles_for_window(window)
+        # one call into the unified protocol — adapter handles obstore vs fsspec
+        tile_bytes = self._store.get_ranges(
+            self.path_or_url,
+            [(t.offset, t.length) for t in tiles],
+        )
+        return self._decompress_and_assemble(tile_bytes, tiles, window)
+
+
+class AsyncGeoTIFFReader(AsyncReader):
+    def __init__(
+        self,
+        path_or_url: str,
+        indexes: int | Sequence[int] | None = None,
+        *,
+        store: ByteStore | None = None,
+        max_concurrent_tiles: int = 32,
+    ):
+        # same as above, async path
+        ...
+
+    async def read_window(self, window):
+        tiles = self._tiles_for_window(window)
+        tile_bytes = await self._store.get_ranges_async(
+            self.path_or_url,
+            [(t.offset, t.length) for t in tiles],
+        )
+        return self._decompress_and_assemble(tile_bytes, tiles, window)
+```
+
+### The strategy axis
+
+| Backend | Hot-path throughput | Niche backends | Sync API | Ecosystem fit |
+| --- | --- | --- | --- | --- |
+| `ObstoreByteStore` | very high (HTTP/2, parallel ranges) | S3, GCS, Azure, HTTP, file, memory | sync helpers, async-native | new code (zarr 3, async-geotiff, lazy-cogs) |
+| `FsspecByteStore` | moderate (per-backend) | everything (FTP, SFTP, GitHub, Dropbox, …) | sync-native, async on capable backends | older code (pandas, xarray, geopandas, zarr ≤ 2) |
+
+Same `ByteStore` protocol, same reader code, two transports underneath. The only thing that differs is which compiled artefact handles `GET /bucket/key Range: bytes=offset-end`.

--- a/projects/geotoolz/plans/geostack.md
+++ b/projects/geotoolz/plans/geostack.md
@@ -1,4 +1,4 @@
-# RS / cloud-native geospatial stack — tools, layers, and how they fit together
+# RS cloud-native stack
 
 > **Scope:** a rundown of `obstore`, `RasterioReader`, `async-geotiff`, `lazy-cogs`, `georeader`, `geotoolz`, `titiler`, and `lonboard` — what each is for, how they depend on one another, and which combinations match common workflows. Assumes `geotoolz` is built per its design report (composable Operator library on `GeoTensor`).
 >

--- a/projects/geotoolz/plans/geostack.md
+++ b/projects/geotoolz/plans/geostack.md
@@ -1,0 +1,491 @@
+# RS / cloud-native geospatial stack — tools, layers, and how they fit together
+
+> **Scope:** a rundown of `obstore`, `RasterioReader`, `async-geotiff`, `lazy-cogs`, `georeader`, `geotoolz`, `titiler`, and `lonboard` — what each is for, how they depend on one another, and which combinations match common workflows. Assumes `geotoolz` is built per its design report (composable Operator library on `GeoTensor`).
+>
+> **Status:** reference document, not a design proposal.
+
+---
+
+## The layered diagram
+
+There's a clean six-layer stack across this set, much of which is shipped by DevSeed / Kyle Barron.
+
+```text
+                ┌──────────────────┐    ┌────────────────┐
+                │    lonboard      │    │    titiler     │
+   viz / UX  →  │  Jupyter/deck.gl │    │  HTTP tile API │
+                └────────┬─────────┘    └────────┬───────┘
+                         │                       │
+                         │ GeoTensor / Arrow     │ XYZ tiles (PNG/JPEG)
+                         │                       │
+                ┌────────▼───────────────────────┴───────┐
+   compute   →  │              geotoolz                  │
+                │   Operator · Sequential · Graph        │
+                └────────────────┬───────────────────────┘
+                                 │ GeoTensor in / GeoTensor out
+                                 │
+                ┌────────────────▼───────────────────────┐
+   substrate →  │     georeader (carriers + index)       │
+                │   GeoTensor · GeoSlice · GeoData       │
+                │   GeoCatalog                           │
+                └─────┬─────────────┬───────────────┬────┘
+                      │             │               │
+                      ▼             ▼               ▼
+              ┌─────────────┐ ┌──────────┐  ┌──────────────┐
+   readers →  │ Rasterio-   │ │ async-   │  │  lazy-cogs   │
+              │ Reader      │ │ geotiff  │  │              │
+              │ (sync,      │ │ (async,  │  │ (lazy,       │
+              │ in georead.)│ │ external)│  │  external)   │
+              └──────┬──────┘ └────┬─────┘  └──────┬───────┘
+                     │             │               │
+                     ▼             └───────┬───────┘
+              ┌──────────┐                 │
+   transport →│  GDAL /  │                 ▼
+              │  VSI     │      ┌──────────────────────────┐
+              └─────┬────┘      │   obstore  /  fsspec     │
+                    │           │  (Rust async / Py hybrid)│
+                    │           └────────────┬─────────────┘
+                    │                        │
+                    └──────────┬─────────────┘
+                               ▼
+                     ┌─────────────────┐
+   storage   →       │  S3/GCS/Azure   │
+                     └─────────────────┘
+```
+
+Bottom-up dependency direction. Anything above can call anything below; nothing reaches up. The substrate box (`georeader`) carries only the *types* — `GeoTensor`, `GeoSlice`, `GeoData`, `GeoCatalog`. The reader implementations sit one layer down. `RasterioReader` is in `georeader`'s own source tree but functionally peers with `async-geotiff` and `lazy-cogs`. (georeader also ships sensor-specific readers — `S2_SAFE_reader`, EMIT, EnMAP, etc. — those live alongside `RasterioReader` and produce `GeoTensor` the same way.)
+
+> **Note on `RasterioReader`'s bytes path.** The diagram shows `RasterioReader` going through GDAL VSI by default. That's the common path, but `RasterioReader` can also delegate to `obstore` or `fsspec` via rasterio's `opener=` parameter — so it isn't strictly bound to the GDAL/VSI lane. See [§ "What's actually inside `RasterioReader`"](#whats-actually-inside-rasterioreader) below.
+
+---
+
+## Per-tool rundown
+
+### 1. `obstore` (transport)
+
+**What it is.** Python bindings to the Rust `object_store` crate. A unified async API for S3, GCS, Azure Blob, and local filesystems — plus HTTP. Made by DevSeed.
+
+**Why it matters.** It's roughly 10× faster than `fsspec` + `aiobotocore` for parallel cloud reads, because the Rust runtime handles HTTP/2, connection pooling, and range coalescing properly. Drop-in for anywhere you'd reach for `s3fs` or `fsspec`.
+
+**Deps.** `pyo3` runtime; nothing in Python land.
+
+**Use cases.**
+
+- Bulk read of millions of small Parquet shards from S3.
+- Range-request-driven COG reads (the layer above this one).
+- Catalog hosting — when `georeader.GeoCatalog` opens a remote `.parquet`, `obstore` is the path your bytes travel.
+
+**Talks to.** Everything above it that does cloud I/O. `async-geotiff` and `lazy-cogs` both build on it directly. `georeader.RasterioReader` historically uses GDAL's VSI for cloud, but moving its remote path onto `obstore` is on the table.
+
+### 2. `RasterioReader` (file reading — sync, in `georeader`)
+
+**What it is.** The default sync reader in `georeader`. Wraps `rasterio.open` with lazy-but-windowed semantics: opening the file is cheap (header + metadata only); calling `.load()` or reading a window via `read.read_from_bounds(...)` triggers the actual pixel fetch. Lives in `georeader/rasterio_reader.py`.
+
+**Why it matters.** This is where 90% of users land by default, because (a) GDAL is the universal raster reader (handles every driver, every CRS quirk, every weird sensor product), (b) it works with both local files and cloud URLs out of the box via GDAL's VSI virtual file system (`/vsis3/`, `/vsigs/`, `/vsicurl/`), and (c) it's what every existing tutorial, notebook, and downstream tool expects.
+
+**Key surface.**
+
+- `RasterioReader(filepath, indexes=None, ...)` — opens lazily.
+- `.load()` — read all configured bands into a `GeoTensor`.
+- `.read_from_window(window)` — read a sub-window.
+- Composed with `georeader.read.read_from_bounds(reader, bounds, ...)` for the bbox-driven path.
+- Opens the file fresh on every `read()` call (process-safe; pickleable for parallel workers).
+
+**Deps.** `rasterio`, `GDAL`, `numpy`, `shapely`, `pyproj`. No async runtime.
+
+**Use cases.**
+
+- Single-scene workflows (RGB visualisation, NDVI, save COG).
+- Anything with non-COG drivers: `RasterioReader` reads ENVI HDR, NetCDF subdatasets, JPEG2000 (Sentinel-2 SAFE), HDF5 (EnMAP, EMIT), GRIB. async-geotiff and lazy-cogs are TIFF-only.
+- Local-disk batch jobs where async I/O wouldn't help.
+- Workflows where rasterio's CRS handling, masked-array support, or per-driver creation options matter (warping, COG profile generation, etc.).
+
+**Talks to.** Below: `rasterio` + `GDAL`, which by default uses GDAL's own libcurl-based VSI handlers (`/vsis3/`, `/vsigs/`, `/vsiaz/`, `/vsicurl/`) for cloud paths — **no Python in the byte-fetching loop**. Optionally delegates to `fsspec` or `obstore` via rasterio's `opener=` parameter when the user passes a custom file opener (see [§ "What's actually inside `RasterioReader`"](#whats-actually-inside-rasterioreader)). Above: produces `GeoTensor`s consumed by `geotoolz`, `titiler` (via `rio-tiler` which is also rasterio-based), and any user code holding a `georeader` object.
+
+### 3. `async-geotiff` (file reading — async, external)
+
+**What it is.** An async GeoTIFF / COG reader. Reads tiles via HTTP range requests, parses TIFF IFDs concurrently, returns numpy arrays. By DevSeed.
+
+**Why it matters.** GDAL is sync and process-bound. For workloads that need to fan out 1000 simultaneous tile reads (e.g. tile servers, hyper-parallel batch inference), an async reader avoids the thread-per-request overhead and exploits HTTP/2 multiplexing through `obstore`.
+
+**Deps.** `obstore` for transport. No GDAL.
+
+**Use cases.**
+
+- Tile-server backends fetching arbitrary COG tiles fast.
+- Batch processing where the bottleneck is "how many tiles per second can I pull from S3."
+- ML dataloaders that want async over thread-pooled rasterio.
+
+**Talks to.** `obstore` below. `georeader` above — `georeader.RasterioReader` is the sync reader, but a sibling `AsyncGeoTIFFReader` (or just direct `async-geotiff` calls) lands data into `GeoTensor` for the rest of the stack.
+
+### 4. `lazy-cogs` (file reading — lazy, external)
+
+**What it is.** Lazy COG access — open a COG without reading data; tiles are fetched only when sliced. Conceptually similar to what `rioxarray.open_rasterio(chunks=...)` does with dask, but lighter.
+
+**Why it matters.** For workflows that touch many COGs but only read a small spatial subset each (catalog-driven processing, sampler-driven ML), eager reads are wasteful. Lazy access defers I/O until a slice is requested, then makes one HTTP range request for exactly the tiles the slice covers.
+
+**Deps.** Typically `obstore` (or `fsspec`) for transport; pure-Python TIFF parsing for the header.
+
+**Use cases.**
+
+- "I have 50k COGs in S3, extract a 256×256 chip from each at coords X." Without laziness this is impossible; with it, it's seconds.
+- Stacking timeseries where you fetch only the bbox you care about across all timesteps.
+
+**Talks to.** Same shape as `async-geotiff`. The two overlap conceptually — you can think of `async-geotiff` as the async-first reader and `lazy-cogs` as the lazy-first abstraction; in practice they often fold into each other in user code.
+
+### 5. `georeader` (substrate)
+
+**What it is.** The Python library that owns the geospatial substrate types and I/O orchestration.
+
+| Component | Role |
+| --- | --- |
+| `GeoTensor` | `np.ndarray` subclass carrying `transform`, `crs`, `dims`, `fill_value_default`. The numpy-shaped, geo-aware, ufunc-protocol-friendly substrate. |
+| `GeoSlice` | A spatiotemporal descriptor — `bounds`, `interval`, `resolution`, `crs`. Unit of work passed between samplers and loaders. |
+| `GeoData` | Higher-level container / abstract reader interface. Likely the base type for things like `S2_SAFE` scenes, EMIT scenes, and other multi-product readers. |
+| `RasterioReader` | Sync, rasterio-backed reader. Lazy-but-windowed: open a file once, read sub-windows on demand. The default I/O path. |
+| `GeoCatalog` | Catalog of files / scenes. Wraps a GeoDataFrame with `IntervalIndex` + geometry; query / intersect / union live here. |
+
+**Why it matters.** This is the API surface RS users hold. Everything above (`geotoolz`, `titiler` indirectly, `lonboard` indirectly) consumes `GeoTensor`. Everything below (`async-geotiff`, `lazy-cogs`, `obstore`) is plumbing that produces them.
+
+**Deps.** Hard: `numpy`, `rasterio`, `shapely`, `geopandas`, `pyproj`. Optional: `obstore` / `async-geotiff` if/when remote-async paths are wired in.
+
+**Use cases.** All RS workflows. Loading a Sentinel-2 scene, reading a bbox from a Landsat archive, building a catalog over 1M files, sampling chips for ML, saving COGs.
+
+**Talks to.** Below: rasterio (sync), `obstore` / `async-geotiff` / `lazy-cogs` (async / lazy paths). Above: `geotoolz` for transformations, `titiler` and `lonboard` for serving / viz.
+
+### 6. `geotoolz` (computation)
+
+**What it is.** The composable Operator library on top of `GeoTensor`. `Operator`, `Sequential`, `Graph`, plus the curated RS modules (`indices`, `radiometry`, `cloud`, `compositing`, `pansharpen`, `sar`, `hyperspectral`, `sampling`, `inference`, `catalog_ops`, `presets`).
+
+**Why it matters.** Without it, every RS pipeline is bespoke glue code. With it, `Sequential([MaskClouds(...), TOAToBOA(...), NDVI(...)])` — declared in YAML or Python.
+
+**Deps.** Hard: `numpy`, `scipy`, `scikit-image`, `scikit-learn`, `georeader`. Optional: `torch` / `jax` (via `ModelOp`), `hydra-zen`, `xrpatcher`.
+
+**Use cases.** Single-tile pipelines, tiled inference (`ApplyToChips`), catalog-driven processing (`CatalogPipeline`), Hydra-config workflows, sensor-specific presets.
+
+**Talks to.** Below: consumes `GeoTensor` from `georeader`; reaches into `georeader.catalog` for the `CatalogPipeline` operator. Above: produces `GeoTensor` outputs that get saved as COGs (which `titiler` / `lonboard` then read).
+
+### 7. `titiler` (serving)
+
+**What it is.** A dynamic tile server built on FastAPI + `rio-tiler`. Serves XYZ / WMTS / OGC tiles from COGs, STAC items, or MosaicJSON. Comes with a viewer UI and OGC-compliant endpoints. By DevSeed.
+
+**Why it matters.** Once you've produced a COG (NDVI, classification map, segmentation result), you want to look at it on a web map. `titiler` does on-the-fly tiling: a request for tile `z/x/y` triggers a `rio-tiler` read of just that COG window, color-mapped, returned as PNG/JPEG. No pre-rendering, no tile cache management.
+
+**Deps.** `fastapi`, `uvicorn`, `rio-tiler`, `morecantile`. Doesn't depend on `georeader` or `geotoolz` directly — it consumes COGs (or STAC), which the lower stack produced.
+
+**Use cases.**
+
+- Production tile API serving raster outputs from `geotoolz` pipelines.
+- A research server that lets collaborators inspect intermediate results without downloading.
+- Backend for `lonboard` raster layers (lonboard can pull tiles from titiler URLs).
+
+**Talks to.** Below: reads COGs from object storage (potentially via `obstore` / `async-geotiff` if you wire `rio-tiler` that way; default is GDAL/VSI). Above: HTTP clients, `lonboard`, web maps, leafmap.
+
+### 8. `lonboard` (visualization)
+
+**What it is.** Geospatial visualization in Jupyter using deck.gl. Renders huge vector data (millions of features) and raster tiles efficiently by binary-streaming GeoArrow to the browser. Recently added raster (XYZ tile-layer) support. Also by DevSeed.
+
+**Why it matters.** Folium / ipyleaflet choke on 100k+ features. `lonboard` ships GeoArrow over the kernel-frontend boundary as a typed buffer and lets deck.gl's WebGL render it; the result is hundreds of millions of points / lines / polygons interactive in a notebook.
+
+**Deps.** `pyarrow`, `geopandas`, `anywidget`, `deck.gl-py-bindings`. Doesn't depend on `georeader` or `geotoolz` directly — accepts geopandas / GeoArrow / image arrays.
+
+**Use cases.**
+
+- Inspect a vector catalog you just queried (e.g. the GeoDataFrame backing `GeoCatalog`).
+- Overlay a `geotoolz`-generated raster on a basemap during analysis.
+- Drop a million-point ML dataset on a map without crashing the kernel.
+
+**Talks to.** Below: takes geopandas / arrays directly, or pulls raster tiles from a `titiler` URL.
+
+---
+
+## The three readers compared
+
+The choice of reader is usually the first decision in any pipeline.
+
+| Property | `RasterioReader` | `async-geotiff` | `lazy-cogs` |
+| --- | --- | --- | --- |
+| **Lives in** | `georeader` | external (DevSeed) | external |
+| **Sync / async** | sync | async | sync API, lazy semantics |
+| **Transport** | GDAL / VSI | `obstore` (Rust async) | `obstore` or `fsspec` |
+| **Driver support** | every GDAL driver (TIFF, JP2, NetCDF, HDF5, GRIB, ENVI, …) | TIFF / COG only | TIFF / COG only |
+| **Format-spec coverage** | full, including non-tiled rasters | COG-shaped (tiled) | COG-shaped (tiled) |
+| **CRS / warping** | GDAL warping, full PROJ stack | minimal — bytes → numpy | minimal |
+| **Open cost** | low (header + metadata) | low | very low (header only) |
+| **Read cost (small bbox)** | one VSI range request × N tiles, sequential | one async batch of tile reads, parallel | one range request per slice access |
+| **Read cost (whole file)** | streaming sequential read | parallel tiles | wasteful — was designed for slicing |
+| **Concurrency** | needs threadpool; GDAL not fully thread-safe | native asyncio | sync, easy to wrap in threadpool |
+| **Memory footprint** | bounded by window size | bounded by tile fan-out | bounded by what's been sliced |
+| **Best for** | single scenes, non-TIFF data, CRS-heavy work, batch jobs | tile servers, parallel batch reads of many COGs | random sampling across thousands of COGs |
+| **Worst for** | cloud-heavy 1000-files-at-a-time | non-TIFF rasters, GDAL-only quirks | reading the whole file |
+
+A practical rule:
+
+```text
+        Is the file a COG in cloud storage,
+        and do I need many concurrent reads?
+                       │
+                       ▼
+                ┌─────────────┐
+                │             │
+                ▼             ▼
+              YES            NO
+                │             │
+                ▼             ▼
+   Will I touch         RasterioReader.
+   many files,          (the safe default)
+   each with a
+   tiny bbox?
+        │
+        ▼
+     ┌────┐    ┌────┐
+     YES        NO
+      │          │
+      ▼          ▼
+  lazy-cogs  async-geotiff
+```
+
+In `geotoolz`, this maps to a `reader_class=` argument on `ApplyToChips` / `CatalogPipeline` — the pipeline definition stays the same regardless of which reader actually fetches bytes:
+
+```python
+# Default — sync rasterio, fine for local or small jobs
+geotoolz.catalog_ops.CatalogPipeline(catalog, op)
+
+# Many cloud COGs in parallel
+geotoolz.catalog_ops.CatalogPipeline(
+    catalog, op,
+    reader_class=georeader.AsyncGeoTIFFReader,
+    n_concurrent=64,
+)
+
+# Random chips across many cloud COGs
+geotoolz.sampling.RandomSampler(
+    catalog, chip_size=(256, 256), length=100_000,
+    reader_class=georeader.LazyCOGReader,
+)
+```
+
+The reader is a strategy; the rest of the pipeline doesn't care.
+
+---
+
+## `obstore` vs `fsspec` compared
+
+Once you're below the reader layer, you're choosing how the bytes themselves move. The two real options are `obstore` and `fsspec`. They overlap in scope but differ in shape, language backbone, and ecosystem fit.
+
+| Property | `obstore` | `fsspec` |
+| --- | --- | --- |
+| **Language backbone** | Rust (`object_store` crate via `pyo3`) | Pure Python with per-backend extensions |
+| **API style** | Object store (`get(key)`, `get_range(key, off, len)`, `put`, `list`) | Filesystem (`open(path)`, `seek`, `read`, `cat`, `glob`) |
+| **Sync / async** | Async-native; sync helpers ride on top | Sync-native; async bolt-on (`asynchronous=True`) |
+| **HTTP backend** | Rust `hyper` — HTTP/2, multiplexing, range coalescing | Per-backend lib (varies; often HTTP/1.1) |
+| **Backends** | S3, GCS, Azure, HTTP, local, in-memory | All of the above + FTP, SFTP, HDFS, ADLS, OCI, GitHub, Dropbox, Google Drive, … |
+| **Throughput on 1k parallel ranges** | ~10× over `s3fs`+`aiobotocore` | Baseline |
+| **Ecosystem integration** | New (zarr 3, `async-geotiff`, `lazy-cogs`, `obstore-rs` consumers) | Wide and mature: pandas, xarray, zarr ≤ 2, dask, geopandas, parquet readers, anything that wraps `fs.open()` |
+| **Auth** | Native credential chains (AWS / GCS / Azure SDKs) compiled in | Per-backend; quality varies |
+| **Install footprint** | One Rust binary | Tiny core; per-backend extras (`s3fs`, `gcsfs`, `adlfs`) |
+| **Maturity** | New (2024+); fast-moving | Mature (2017+); stable, ubiquitous |
+
+A practical rule:
+
+```text
+        Is the workload "read many byte ranges from
+        S3/GCS/Azure as fast as possible"?
+                       │
+                       ▼
+                ┌─────────────┐
+                │             │
+                ▼             ▼
+              YES            NO
+                │             │
+                │             ├─► Niche backend (FTP, SFTP, GitHub, …)?
+                │             │     └─► fsspec (only option)
+                │             │
+                │             └─► Need to plug into pandas/xarray/zarr/dask?
+                │                   └─► fsspec (the universal adapter)
+                │
+                ▼
+              obstore.
+              (5–10× faster on parallel COG reads)
+```
+
+The two coexist comfortably. New code paths in `async-geotiff` and `lazy-cogs` default to `obstore`; older code paths in `geopandas`, `pandas`, `xarray`, and `zarr ≤ 2` go through `fsspec`. `georeader.GeoCatalog` uses `obstore` for its parquet round-trip when reading remote catalogs because that's the hot path; but it can fall back to `fsspec` for niche storage.
+
+In `geotoolz` / `georeader`, this maps to a `store=` argument that any reader accepts:
+
+```python
+# Default — auto-pick obstore for s3://, gs://, az://, http(s)://; fsspec otherwise
+reader = georeader.LazyCOGReader("s3://bucket/scene.tif")
+
+# Explicit obstore
+from obstore.store import S3Store
+reader = georeader.LazyCOGReader(
+    "scene.tif",
+    store=ObstoreByteStore(S3Store("bucket")),
+)
+
+# Explicit fsspec — when you need a niche backend
+import fsspec
+fs = fsspec.filesystem("github", org="foo", repo="bar")
+reader = georeader.LazyCOGReader(
+    "path/to/scene.tif",
+    store=FsspecByteStore(fs),
+)
+```
+
+The reader doesn't care which transport actually fetches the bytes — both satisfy the same `ByteStore` Protocol (see the API reconciliation file).
+
+---
+
+## What's actually inside `RasterioReader`
+
+The main diagram shows `RasterioReader` going through `GDAL / VSI`. That's the *default*, but it isn't the only option. `rasterio.open(...)` accepts an `opener=` callable (added in rasterio 1.4) that GDAL uses for byte-level reads, which means `RasterioReader` can route bytes through `fsspec` or `obstore` instead of GDAL's built-in HTTP client. Three paths, all sync, all sitting under the same Python class:
+
+```text
+              ┌──────────────────────┐
+              │   RasterioReader     │
+              └──────────┬───────────┘
+                         │
+                         ▼
+              ┌──────────────────────┐
+              │  rasterio.open(...)  │
+              └──────────┬───────────┘
+                         │
+              ┌──────────┼──────────────────┐
+              ▼          ▼                  ▼
+       ┌──────────┐ ┌──────────────┐ ┌──────────────────┐
+       │ GDAL VSI │ │ opener=fs.open│ │ opener=<custom>  │
+       │ (libcurl)│ │  (fsspec)     │ │ (obstore-aware)  │
+       └────┬─────┘ └──────┬────────┘ └────────┬─────────┘
+            │              │                   │
+            └──────────────┴───────────────────┘
+                           │
+                           ▼
+                  S3 / GCS / Azure / …
+```
+
+| Path | Who fetches the bytes | When you'd use it |
+| --- | --- | --- |
+| **GDAL VSI** (default) | libcurl inside the GDAL binary — `/vsis3/`, `/vsigs/`, `/vsiaz/`, `/vsicurl/`. Pure C; no Python in the byte-fetching loop. | Anything S3/GCS/Azure/HTTPS. Just works; the fastest non-async option for general use. |
+| **`opener=fs.open`** (fsspec) | Python file-like via fsspec; GDAL calls back into Python for each byte range. Slower than VSI because of the Python ↔ C trip per range. | Niche backends GDAL doesn't natively support (FTP, SFTP, GitHub, custom auth flows), or when the rest of the pipeline already holds an fsspec filesystem and re-using it simplifies the auth story. |
+| **`opener=<custom obstore callback>`** | Python adapter wrapping `obstore.ObjectStore.get_range`, given to GDAL via `opener=`. | Possible in principle. In practice you'd bypass `RasterioReader` entirely and use `lazy-cogs` or `async-geotiff` directly — they're already that path, without GDAL in between. |
+
+### What this really means
+
+- **`RasterioReader` *can* fetch cloud bytes without fsspec or obstore.** Its default path is GDAL's native HTTP client (libcurl in C). That's been true since well before fsspec or obstore existed.
+- **GDAL VSI does real range requests.** When `RasterioReader.read_window(...)` is called on a cloud COG, GDAL issues `GET .../scene.tif Range: bytes=N-M` for exactly the tiles needed. This is why a single-file workflow on a 1 GB COG only downloads the few KB you actually read.
+- **The `opener=` escape hatch is for niche cases.** If GDAL's vsicurl works, use it — it's faster than fsspec-via-opener. If you need an unusual backend (FTP, GitHub, custom HTTP auth), `opener=fs.open` lets you reuse fsspec's coverage without leaving rasterio.
+- **For "thousands of parallel reads" or "millions of small chip fetches", you want a different reader, not a fancy opener.** That's where `async-geotiff` and `lazy-cogs` exist — they skip GDAL entirely.
+
+### How `georeader` exposes this
+
+`RasterioReader` accepts the opener as a kwarg, typically through `rio_open_kwargs` or a top-level convenience like `fs=`:
+
+```python
+# Default — GDAL VSI handles s3://
+reader = georeader.RasterioReader("s3://bucket/scene.tif")
+
+# Force fsspec routing (e.g. for an S3-compatible endpoint with custom auth)
+import fsspec
+fs = fsspec.filesystem(
+    "s3",
+    endpoint_url="https://my-minio:9000",
+    key=...,
+    secret=...,
+)
+reader = georeader.RasterioReader(
+    "s3://bucket/scene.tif",
+    rio_open_kwargs={"opener": fs.open},
+)
+
+# Or via a georeader-level shortcut, if surfaced:
+reader = georeader.RasterioReader("s3://bucket/scene.tif", fs=fs)
+```
+
+The reader's surface is identical regardless — same `.load()`, `.read_from_window(...)`, same `GeoTensor` output. Only the bytes path underneath changes.
+
+---
+
+## Three concrete combined flows
+
+### Flow A — single-scene inference, all sync, simplest
+
+```python
+# Read → process → save
+reader = georeader.RasterioReader("s3://bucket/scene.tif")
+gt = reader.load()                                     # GeoTensor
+ndvi = geotoolz.indices.NDVI(red_idx=2, nir_idx=3)(gt) # GeoTensor
+georeader.save_cog(ndvi, "s3://out/ndvi.tif")          # COG written
+
+# Then serve it:
+#   titiler --src s3://out/ndvi.tif
+#
+# Then look at it:
+import lonboard
+lonboard.Map(layers=[lonboard.BitmapTileLayer(
+    data="http://localhost:8000/cog/tiles/{z}/{x}/{y}.png?url=s3://out/ndvi.tif"
+)])
+```
+
+Stack used: `rasterio` → `georeader.RasterioReader` → `georeader.GeoTensor` → `geotoolz` → COG → `titiler` → `lonboard`. No async needed, no catalog. **`RasterioReader` is the right reader here** — single scene, GDAL-friendly, no concurrency need.
+
+### Flow B — catalog-driven async batch processing
+
+```python
+# Build / open a catalog of 50k COGs in S3
+catalog = georeader.catalog.open_catalog("s3://bucket/s2_eu.parquet")     # uses obstore
+
+# Define a per-tile pipeline — same as Flow A but as an Operator
+per_tile = geotoolz.Sequential([
+    geotoolz.cloud.MaskClouds(qa_band_idx=-1, bits=[10, 11]),
+    geotoolz.indices.NDVI(red_idx=2, nir_idx=3),
+    geotoolz.catalog_ops.WriteCOG(path_template="s3://out/{tile_id}.tif"),
+])
+
+# Run across the catalog
+geotoolz.catalog_ops.CatalogPipeline(
+    catalog,
+    per_tile,
+    reader_class=AsyncGeoTIFFReader,                   # async-geotiff under obstore
+    n_concurrent=64,
+).run()
+```
+
+Stack used: `obstore` → `async-geotiff` → `georeader.GeoTensor` → `geotoolz.Sequential` → `georeader.save_cog` → S3. The async path lights up because the workload is I/O-bound across thousands of small reads. **`RasterioReader` would also work here** — just sequentially over a threadpool — but `async-geotiff` will be 5–10× faster for cloud-COG-heavy workloads.
+
+### Flow C — ML dataloader with lazy COGs + chip sampler
+
+```python
+catalog = georeader.catalog.open_catalog("s3://bucket/s2_eu.parquet")
+sampler = geotoolz.sampling.RandomSampler(catalog, chip_size=(256, 256), length=100_000)
+
+# Each chip is one lazy COG window read — no full file fetched
+loader = torch.utils.data.DataLoader(
+    GeoChipDataset(sampler, reader_class=LazyCOGReader),
+    batch_size=32, num_workers=8,
+)
+
+for batch in loader:
+    preds = model(batch)
+    # ...
+```
+
+Stack used: `obstore` → `lazy-cogs` → `georeader.GeoSlice` → `geotoolz.sampling` → torch. The win is that 100k random chips across 50k COGs costs only the bytes in 100k tiny range requests, not 50k full files. **`RasterioReader` would technically work** but you'd pay GDAL's VSI overhead on every chip — `lazy-cogs` is a meaningful speedup at this fan-out.
+
+---
+
+## How they overlap, where the seams are
+
+A few places where two tools could do the same job and you have to pick:
+
+- **`RasterioReader` vs `async-geotiff` vs `lazy-cogs`.** See the comparison table above. Short version: `RasterioReader` is the safe default and the only choice for non-TIFF data; `async-geotiff` wins on parallel cloud-COG throughput; `lazy-cogs` wins on "many files, small slice each."
+- **`async-geotiff` vs `lazy-cogs`.** Both read COGs without GDAL. If you need *concurrent* reads, `async-geotiff`. If you need *deferred* reads with a numpy-like slicing surface, `lazy-cogs`. They co-exist; `geotoolz`'s `ApplyToChips` could call either through a `reader_class` argument.
+- **`titiler` vs direct `lonboard` raster.** `titiler` is the right choice when you want a real HTTP API for many viewers. `lonboard`'s direct array input is the right choice when you're in one notebook and just want to look. Same picture, different audiences.
+- **`obstore` vs `fsspec` / `s3fs`.** `obstore` is faster and async-native; `fsspec` has wider integration (zarr, parquet readers, etc. all speak fsspec). In practice `obstore` is the cloud transport for the new tools, and `fsspec` is what older libraries (including parts of geopandas/rasterio) still use. Coexist for now; new code prefers `obstore`.
+- **`georeader.RasterioReader` vs `async-geotiff`.** Sync vs async; full GDAL coverage vs TIFF-only. `RasterioReader` is fine for batch jobs, notebooks, and any non-TIFF source; `async-geotiff` shines when you're either serving tiles or running thousands of parallel reads.
+
+---
+
+## In one sentence
+
+`obstore` moves bytes; `RasterioReader` (sync, GDAL-backed, in georeader), `async-geotiff` (async, cloud-COG-heavy), and `lazy-cogs` (lazy, slice-on-access) turn those bytes into numpy slices via three different strategies; `georeader` wraps those slices as `GeoTensor` and indexes them as `GeoCatalog`; `geotoolz` composes operators over `GeoTensor`; `titiler` serves the resulting COGs as web tiles; `lonboard` shows them in Jupyter.

--- a/projects/geotoolz/plans/geostationary.md
+++ b/projects/geotoolz/plans/geostationary.md
@@ -1,0 +1,382 @@
+
+# Target API for Geostationary Satellites in `georeader`
+
+> **Design Report (v3)** — design for GOES-R ABI, MSG SEVIRI, MTG-FCI, and Himawari AHI readers in [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader).
+
+## Contents
+
+- [User Story](#user-story)
+- [Motivation](#motivation)
+- [Mathematics](#mathematics)
+- [Target API](#target-api)
+  - [Track A — Clean `+proj=geos` affine](#track-a--clean-projgeos-affine-goes-abi-mtg-fci)
+  - [Track B — Irregular file formats](#track-b--irregular-file-formats-seviri-ahi)
+  - [Public bucket helpers](#public-bucket-helpers)
+- [Example Use Cases](#example-use-cases)
+- [Subtasks](#subtasks)
+
+## User Story
+
+I’m migrating geostationary readers from `rs_tools` into `georeader`, starting with **GOES-R ABI** and **MSG SEVIRI**, with a path to **MTG-FCI** and **Himawari AHI**. The work is substantially smaller than first thought: `georeader` already owns CRS reprojection through `read.read_from_bounds` and irregular-geolocation reprojection through `griddata.read_to_crs`. What’s missing is the **reader** — the per-sensor class that opens these files, parses sensor-specific metadata, exposes calibrated radiance, and conforms to whichever existing convention (S2-style `GeoData` or PRISMA-style raw-arrays-plus-`lons`/`lats`) fits the file format on disk.
+
+## Motivation
+
+Each geostationary sensor lives in its own file format with its own quirks:
+
+|Sensor           |Format                          |Notes                                 |
+|-----------------|--------------------------------|--------------------------------------|
+|GOES-R ABI L1b/L2|NetCDF-CF                       |Clean `+proj=geos` affine, `sweep='x'`|
+|MTG-FCI L1c      |NetCDF (chunked)                |Clean `+proj=geos` affine, `sweep='y'`|
+|MSG SEVIRI       |`.nat` (Native) or xRIT segments|Custom binary; needs explicit parsing |
+|Himawari AHI     |HSD segments                    |Custom binary                         |
+
+A `satpy` install can read all of these but drags in xarray/dask/pyresample and is pipeline-shaped. The `georeader`-shaped equivalent is much smaller in scope: a reader per sensor that produces either a `GeoData` (when the file’s affine is clean) or a PRISMA-like object exposing `.lons`, `.lats`, and raw arrays (when it isn’t), and lets `georeader`’s existing machinery do the rest. The motivation is to keep `georeader` consistent: one mental model for the user (`georeader.readers.X`, then `read.read_from_bounds` or `griddata.read_to_crs`), regardless of sensor.
+
+## Mathematics
+
+The only math the reader itself owns is computing `.lons` and `.lats` from scan angles when the file format doesn’t already give them. This is the standard `+proj=geos` forward projection, lifted directly from the [GOES-R PUG](https://www.goes-r.gov/users/docs/PUG-main-vol1.pdf) and MSG ICD. As a private utility:
+
+```python
+# georeader/readers/geostationary/_projection.py
+import numpy as np
+from numpy.typing import NDArray
+
+
+def scan_to_geodetic(
+    x: NDArray, y: NDArray,        # scan angles (rad), broadcastable
+    lon_sub: float,                # sub-satellite longitude (rad)
+    height_m: float = 35_786_023.0,
+    r_eq: float = 6_378_137.0,
+    r_pol: float = 6_356_752.31414,
+) -> tuple[NDArray, NDArray, NDArray]:
+    """(x, y) → (lat, lon, on_disk). Used to populate reader.lons/lats."""
+    H = height_m + r_eq
+    cx, sx, cy, sy = np.cos(x), np.sin(x), np.cos(y), np.sin(y)
+    a   = cy**2 + (r_eq / r_pol)**2 * sy**2
+    s_d = (H * cx * cy)**2 - a * (H**2 - r_eq**2)
+    on_disk = s_d >= 0
+    s_n = (H * cx * cy - np.sqrt(np.where(on_disk, s_d, 0.0))) / a
+    s1, s2, s3 = H - s_n*cx*cy, -s_n*sx*cy, s_n*sy
+    lat = np.arctan((r_eq / r_pol)**2 * s3 / np.sqrt(s1**2 + s2**2))
+    lon = lon_sub + np.arctan2(s2, s1)
+    return lat, lon, on_disk
+```
+
+That’s the entire math footprint inside the reader package. Beyond it, anything users need (satellite/solar zenith, local resolution, disk mask) can live in a separate `geostationary_utils` module later — **out of scope** for this design.
+
+## Target API
+
+Two tracks fall out of the file formats. The reader user-facing surface is identical in spirit; the *implementation* differs.
+
+### Track A — Clean `+proj=geos` affine (GOES ABI, MTG-FCI)
+
+Conforms to `GeoData` like the S2 reader. The CRS is `+proj=geos` with the right sweep axis (`x` for GOES, `y` for FCI), the transform is linear in scan-angle-projected meters, and `read.read_from_bounds` works directly through rasterio:
+
+```python
+# georeader/readers/geostationary/abi.py
+from georeader.abstract_reader import GeoData
+from georeader.geotensor import GeoTensor
+
+
+class ABI_L1b(GeoData):
+    """GOES-R ABI Level-1b radiance reader. NetCDF; one file per channel per scan."""
+
+    # --- required by GeoData ---
+    bounds: tuple[float, float, float, float]   # +proj=geos meters
+    crs: CRS                                    # +proj=geos sweep=x lon_0=lon_sub
+    transform: Affine
+    shape: tuple[int, int, int]                 # (C, H, W)
+    fill_value_default: float
+    bands: list[str]                            # e.g. ['C02', 'C13']
+
+    # --- ABI-specific metadata (attributes, not methods) ---
+    time: datetime                              # scan midpoint, tz-aware
+    time_start: datetime
+    time_end: datetime
+    satellite: str                              # 'G16' | 'G17' | 'G18' | 'G19'
+    sub_satellite_lon: float                    # degrees
+    sector: str                                 # 'RadF' | 'RadC' | 'RadM1' | 'RadM2'
+    mode: int                                   # 3 | 4 | 6 (scan mode)
+    nadir_resolution_m: dict[str, float]        # {'C02': 500, 'C13': 2000, ...}
+    units: str                                  # 'W m-2 sr-1 um-1'
+
+    def __init__(
+        self,
+        path: str | list[str],                  # one URI per channel, or a glob
+        bands: list[str] | None = None,         # None → all available channels
+        out_res: float | None = None,           # native if None, else common-grid m
+    ): ...
+
+    @classmethod
+    def from_product_id(
+        cls, product_id: str, bands=None, out_res=None,
+        bucket: str = "noaa-goes16",
+    ) -> "ABI_L1b":
+        """Resolve a PRODUCT_ID to S3 URIs and instantiate."""
+
+    # --- GeoData contract methods ---
+    def load(self, *, boundless: bool = False) -> GeoTensor: ...
+    def read_from_window(self, window: Window) -> "ABI_L1b": ...
+    def isel(self, sel: dict) -> "ABI_L1b": ...
+
+    # --- ABI-specific helpers ---
+    def to_radiance(self) -> GeoTensor: ...     # apply scale+offset (default behavior)
+    def to_reflectance(self) -> GeoTensor: ...  # for reflective channels (C01–C06)
+    def to_brightness_temperature(self) -> GeoTensor: ...  # for thermal (C07–C16)
+```
+
+The `__repr__` matches the S2 / PRISMA conventions:
+
+```bash
+>>> obj = ABI_L1b.from_product_id(
+...     "OR_ABI-L1b-RadF-M6_G16_s20240011200205", bands=["C02", "C13"], out_res=2000)
+>>> obj
+ABI_L1b: G16  sector=RadF  mode=6  t=2024-01-01T12:04:53+00:00
+  bands: ['C02', 'C13']  shape: (2, 5424, 5424)  res: 2000 m
+  sub_satellite_lon: -75.0°  sweep_axis: 'x'
+  bounds (geos m): (-5434894, -5434894, 5434894, 5434894)
+  CRS: +proj=geos +lon_0=-75 +h=35786023 +a=6378137 +b=6356752.31414 +sweep=x
+```
+
+Multi-resolution handling follows the S2 reader: bands keep their native rasterio handles internally, and `out_res` selects a common output resolution at load time:
+
+```python
+# Internal — sketch
+class ABI_L1b(GeoData):
+    def __init__(self, path, bands=None, out_res=None):
+        self._datasets = {b: rasterio.open(p) for b, p in self._resolve_paths(path, bands)}
+        self._native_res = {b: self._datasets[b].res[0] for b in self._datasets}
+        self.out_res = out_res or max(self._native_res.values())
+        self._calib = self._read_calibration_coeffs()    # scale, offset, kappa0, etc.
+        self.crs, self.transform, self.shape, self.bounds = self._build_grid()
+
+    def load(self, *, boundless=False) -> GeoTensor:
+        arrays = []
+        for band in self.bands:
+            ds = self._datasets[band]
+            arr = ds.read(1, out_shape=self._target_shape(band),
+                          resampling=Resampling.bilinear)
+            arr = self._calibrate(arr, band)             # counts → radiance
+            arrays.append(arr)
+        return GeoTensor(np.stack(arrays), transform=self.transform, crs=self.crs,
+                         fill_value_default=self.fill_value_default)
+```
+
+### Track B — Irregular file formats (SEVIRI, AHI)
+
+Mirrors the PRISMA reader exactly. The reader does **not** conform to `GeoData`; instead it exposes raw arrays plus `.lons`/`.lats`, and users go through `griddata.read_to_crs`:
+
+```python
+# georeader/readers/geostationary/seviri.py
+class SEVIRI_Native:
+    """MSG SEVIRI Level-1.5 Native (.nat) reader. PRISMA-pattern."""
+
+    # --- per-pixel geolocation (PRISMA convention) ---
+    lons: NDArray                               # (H, W) degrees
+    lats: NDArray                               # (H, W) degrees
+
+    # --- SEVIRI metadata ---
+    bounds: tuple[float, float, float, float]   # in EPSG:4326 from lons/lats
+    time: datetime                              # nominal scan midpoint
+    time_start: datetime
+    time_end: datetime
+    satellite: str                              # 'MSG1' | 'MSG2' | 'MSG3' | 'MSG4'
+    sub_satellite_lon: float
+    bands: list[str]                            # e.g. ['IR_108', 'WV_062', 'HRV']
+    wavelengths: dict[str, float]               # central wavelengths in µm
+    units: str
+    calibration_coeffs: dict[str, tuple[float, float]]   # (slope, offset) per band
+
+    def __init__(
+        self,
+        path: str,
+        bands: list[str] | None = None,
+        include_hrv: bool = False,              # HRV is 1 km, others 3 km — different grid
+    ): ...
+
+    def load_raw(self, *, calibrated: bool = True) -> NDArray:
+        """Return (C, H, W) array; if calibrated, in self.units, else raw counts."""
+
+    def load_band(self, band: str, *, calibrated: bool = True) -> NDArray: ...
+
+    def to_reflectance(self) -> NDArray: ...    # solar channels
+    def to_brightness_temperature(self) -> NDArray: ...   # thermal channels
+```
+
+User code follows the PRISMA notebook idiom verbatim:
+
+```python
+from georeader.readers.geostationary import seviri
+from georeader import griddata
+import numpy as np
+
+obj = seviri.SEVIRI_Native("MSG3-SEVI-MSG15-...-NA.nat",
+                           bands=["IR_108", "WV_062"])
+print(obj)
+# SEVIRI_Native: MSG3  t=2024-06-14T12:00:00+00:00
+#   bands: ['IR_108', 'WV_062']  shape: (2, 3712, 3712)  res(nadir): 3000 m
+#   sub_satellite_lon: 0.0°  sweep_axis: 'y'
+
+raw = obj.load_raw()                                    # (2, H, W) in W m-2 sr-1 um-1
+geo = griddata.read_to_crs(np.moveaxis(raw, 0, 2),
+                           lons=obj.lons, lats=obj.lats,
+                           resolution_dst=3000, dst_crs="EPSG:3857")
+# geo: GeoTensor (2, H', W') in EPSG:3857
+```
+
+Internally, `_projection.scan_to_geodetic` populates `lons` and `lats` once during `__init__` from the file’s scan-angle metadata. **Users never see the projection module.**
+
+> **A note on the HRV channel.** SEVIRI’s HRV is 1 km native versus 3 km for the other 11 channels, on a smaller and offset grid. The reader handles this by treating HRV as a separate group with its own `lons`/`lats`, similar to S2’s 10/20/60 m groups. If `bands=['HRV']`, the reader’s grid is 1 km; if `bands=['IR_108', 'HRV']` is requested with `include_hrv=True`, the reader returns two parallel arrays and lets the user choose how to combine. Mixing resolutions silently is a known footgun and we don’t want it.
+
+### Public bucket helpers
+
+Mirroring `S2_SAFE_reader.s2_public_bucket_path`, one helper per sensor where applicable:
+
+```python
+# georeader/readers/geostationary/abi.py
+def public_bucket_path(product_id: str, bucket: str = "noaa-goes16") -> str: ...
+
+
+def find_files(
+    start: datetime, end: datetime,
+    satellite: Literal["G16", "G17", "G18", "G19"] = "G16",
+    sector: Literal["RadF", "RadC", "RadM1", "RadM2"] = "RadF",
+    channels: list[str] = ["C13"],
+    product_level: Literal["L1b", "L2"] = "L1b",
+) -> list[str]:
+    """Returns S3 URIs (s3://noaa-goes16/ABI-L1b-RadF/YYYY/DOY/HH/...)."""
+```
+
+MSG and MTG are gated behind EUMETSAT Data Store (auth required); a separate auth-aware helper goes in the SEVIRI/FCI modules.
+
+## Example Use Cases
+
+### 1. ABI in a UTM box around an EMIT detection
+
+Track A, vanilla `georeader` path:
+
+```python
+from georeader.readers.geostationary import abi
+from georeader import read
+from shapely.geometry import box
+
+obj = abi.ABI_L1b.from_product_id(
+    "OR_ABI-L1b-RadF-M6_G16_s20240011200205",
+    bands=["C07", "C13"], out_res=2000,
+)
+aoi = box(-104.5, 31.9, -104.3, 32.1)
+data = read.read_from_polygon(obj, aoi, crs_polygon="EPSG:4326",
+                              dst_crs="EPSG:32613", resolution_dst=2000).load()
+# data: GeoTensor (2, H, W) in UTM-13N
+```
+
+### 2. SEVIRI to Web Mercator over Europe
+
+Track B, PRISMA path:
+
+```python
+from georeader.readers.geostationary import seviri
+from georeader import griddata
+
+obj = seviri.SEVIRI_Native("MSG3-SEVI-MSG15-...-NA.nat", bands=["IR_108"])
+raw = obj.load_band("IR_108", calibrated=True)            # (H, W)
+geo = griddata.read_to_crs(raw[..., None],                # add channel axis
+                           lons=obj.lons, lats=obj.lats,
+                           resolution_dst=3000, dst_crs="EPSG:3857",
+                           bounds_dst=(-1.5e6, 4.5e6, 3.5e6, 8.5e6))
+```
+
+### 3. ABI–Sentinel-2 collocation
+
+Both readers conform to `GeoData`; existing helper does the lift:
+
+```python
+from georeader.readers import S2_SAFE_reader
+from georeader.readers.geostationary import abi
+from georeader import read
+
+s2 = S2_SAFE_reader.s2loader(s2_path, out_res=60, bands=["B12"])
+goes = abi.ABI_L1b.from_product_id(closest_abi_id, bands=["C13"])
+goes_on_s2_grid = read.read_reproject_like(goes, s2)      # already exists
+```
+
+### 4. Channel calibration
+
+The reader exposes physically-meaningful methods rather than forcing users to dig out scale/offset themselves:
+
+```python
+obj = abi.ABI_L1b.from_product_id("...", bands=["C13"])
+bt = obj.to_brightness_temperature().load()               # K, (1, H, W)
+```
+
+## Subtasks
+
+The work splits into the projection utility, the two reader templates, the per-sensor implementations, and the bucket helpers.
+
+### Projection utility (~1 day)
+
+`_projection.py` with `scan_to_geodetic` (above) and tests against published corner coordinates:
+
+```python
+# tests/test_projection.py
+def test_abi_corner_against_pug():
+    x, y = -0.151844, 0.151844
+    lat, lon, ok = scan_to_geodetic(x, y, lon_sub=np.deg2rad(-75.0))
+    assert ok and np.isclose(np.rad2deg(lat), 33.846, atol=1e-3)
+    assert np.isclose(np.rad2deg(lon), -84.690, atol=1e-3)
+
+
+def test_seviri_corner_against_icd():
+    ...
+```
+
+### ABI L1b reader (~1 week)
+
+The first concrete reader. NetCDF parsing through rasterio (`netcdf:path:Rad`); CRS construction from CF metadata or manually from sub-sat lon and sweep axis; calibration via `Rad`‘s `scale_factor`/`add_offset` plus `kappa0` for reflectance and Planck inversion for brightness temperature. Bands at three native resolutions handled S2-style. AWS S3 URIs work through fsspec/rasterio’s GDAL `/vsis3/` driver. Tests against a small fixture file in CI.
+
+### SEVIRI Native reader (~2 weeks)
+
+This is the bigger lift because the `.nat` format needs custom binary parsing. Two options:
+
+1. Leverage `eumdac` / `satpy`’s SEVIRI native reader as an internal dependency for the parsing step only and rebuild calibration ourselves.
+2. Write a from-scratch parser following the MSG Level 1.5 ICD (more work, fewer dependencies).
+
+Lean toward an optional `satpy` dependency for the parsing only — cleaner and we can always replace it. Calibration coefficients are in the file header; HRV handled as a separate grid.
+
+### MTG-FCI reader (~1 week)
+
+Follows ABI: NetCDF, CF metadata, similar calibration story. Quirks are FCI’s chunked layout and the L1c grid.
+
+### Himawari AHI HSD reader (~2 weeks)
+
+Custom binary, similar in scope to SEVIRI Native. **Defer** until ABI + SEVIRI are landed.
+
+### SEVIRI HRIT reader (~2 weeks)
+
+xRIT-compressed segments. The messiest of the lot. **Defer** until clear demand.
+
+### Public bucket helpers (~1 day per sensor)
+
+Small, self-contained.
+
+### Documentation (~1 week)
+
+Three notebooks in the same style as the S2 SAFE and PRISMA notebooks:
+
+- `abi_quickstart.ipynb` mirroring `read_S2_SAFE_from_bucket.ipynb`
+- `seviri_quickstart.ipynb` mirroring `prisma_with_cloudsen12.ipynb`
+- `goes_s2_collocation.ipynb` showing the cross-sensor workflow
+
+The notebooks are what users will actually read.
+
+### Staged release
+
+- [ ] **PR 1.** `_projection.py` + ABI L1b reader + bucket helper + ABI quickstart notebook (cohesive, end-to-end demonstrable)
+- [ ] **PR 2.** SEVIRI Native reader + SEVIRI quickstart notebook
+- [ ] **PR 3.** MTG-FCI reader
+- [ ] **PR 4.** Himawari AHI HSD reader
+- [ ] **PR 5.** SEVIRI HRIT reader
+
+-----
+
+If this lands, the next step is to pull the existing `S2_SAFE_reader.S2Image` and `prisma.PRISMA` source side by side and sketch `ABI_L1b` and `SEVIRI_Native` as concrete diffs against those templates — locking down the attribute names, calibration interfaces, and `__repr__` format before writing any sensor-specific parsing.

--- a/projects/geotoolz/plans/geostationary.md
+++ b/projects/geotoolz/plans/geostationary.md
@@ -1,5 +1,5 @@
 
-# Target API for Geostationary Satellites in `georeader`
+# Geostationary readers
 
 > **Design Report (v3)** — design for GOES-R ABI, MSG SEVIRI, MTG-FCI, and Himawari AHI readers in [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader).
 

--- a/projects/geotoolz/plans/geotoolz.md
+++ b/projects/geotoolz/plans/geotoolz.md
@@ -1,0 +1,826 @@
+
+# `geotoolz` — design report
+
+> **Scope:** a composable Operator library for remote sensing — preprocess, infer, and evaluate satellite imagery on top of `georeader.GeoTensor`. Sibling to `xr_toolz`, targeted at a different community and a different substrate. Functions, classes, and presets, all RS-shaped.
+>
+> **Status:** design proposal. Assumes `georeader` 2.0 (the `np.ndarray`-subclass `GeoTensor` with `__array_ufunc__`) exists as today. Borrows architectural patterns from `xr_toolz` but re-implements the composition core to avoid coordination tax.
+
+---
+
+## 0. What I read
+
+| Source | Takeaway |
+| --- | --- |
+| `xr_toolz/docs/design/vision.md`, `architecture.md`, `decisions.md`, `boundaries.md` | A working three-tier (Array / Tensor / Operator) stack, the Operator/Sequential/Graph machinery, the split-object stateful pattern (D2), dual-mode `__call__` (D3), Hydra-zen integration. **Patterns to borrow, code to re-implement.** |
+| `xr_toolz` decisions D7 / D9 / D10 / D11 | Two-layer module pattern (functions + Operator wrappers); domain-stub consolidation; viz operators returning Figure / Axes; per-module array-tier entry. |
+| `georeader/geotensor.py` (post `feature/geotensor_npapi`) | `GeoTensor(np.ndarray)` with `__array_ufunc__`, `__array_finalize__`, time as a first-class dim, math dunders. The substrate. |
+| `georeader.read`, `mosaic`, `reflectance`, `griddata`, `vectorize`, `rasterize`, `slices` | Existing georeader has the I/O + GeoTensor construction + reflectance physics. `geotoolz` sits on top, never re-implements. |
+| `jej_vc_snippets/remote_sensing/` (dataset, sampler, transforms_pipelines, predictions, spectral_unmixing, etc.) | The empirical RS workflow vocabulary — the operators users have been writing as snippets for years and want a library home for. |
+| Prior reports in this thread (catalog Phase 1/2, sampler design, `geo_toolz` v1/v2/v3 attempts) | The catalog work goes in `georeader`. The pure-numpy library idea is dropped: numpy primitives become per-Operator implementation details inside `geotoolz._src/`. |
+
+> **Decision recorded here:** the composition core (`Operator`, `Sequential`, `Graph`, `ModelOp`) is **re-implemented in `geotoolz`**, not shared with `xr_toolz`. ~300 LOC, gives each library freedom to specialize for its substrate and audience.
+
+---
+
+## 1. Inventory: what `geotoolz` is
+
+A composable Operator library targeted at remote sensing. Sibling to `xr_toolz` at the architectural level; orthogonal at the substrate level.
+
+### 1.1 The three-tier model (borrowed verbatim from `xr_toolz` D11)
+
+| Tier | Location | Input | Output | Coordinate semantics |
+| --- | --- | --- | --- | --- |
+| **A — Array** | `geotoolz.<module>._src.array` | `np.ndarray` | `np.ndarray` | `axis=` |
+| **B — Tensor** | `geotoolz.<module>._src.tensor` | `GeoTensor` | `GeoTensor` (or terminal type) | `axis=`, with `dims`-aware helpers |
+| **C — Operator** | `geotoolz.<module>` (public) | `GeoTensor` (or two for multi-input) | `GeoTensor` / scalar / `Figure` | constructor `axis=` / `band=` |
+
+Tier A is private, ufunc-pure where possible. Tier B does the `GeoTensor`-subclass dance for non-ufunc upstream calls (skimage / scipy.ndimage). Tier C carries config, composes via `Sequential` and `Graph`.
+
+### 1.2 Module surface
+
+Twelve modules, organised by RS workflow stage. Roughly 80 Operators in steady state; v0.1 ships ~25 (the asterisks below).
+
+| Group | Module | Operators |
+| --- | --- | --- |
+| **Composition core** | `core` | `Operator`*, `Sequential`*, `Graph`*, `Input`*, `Node`*, `Tap`, `ApplyToEach`, `Augment` |
+| **Radiometry & viz** | `radiometry` | `ToFloat32`*, `MinMax`*, `PercentileClip`*, `Gamma`*, `ZScore`, `LogStretch`, `LinearToDB`, `DBToLinear`, `SRFBin` |
+| **Atmospheric correction** | `correction` | `TOAToBOA`, `DarkObjectSubtraction`, `Py6SCorrection` (optional extra) |
+| **Spectral indices** | `indices` | `NDVI`*, `NDWI`*, `MNDWI`, `NDMI`, `EVI`, `SAVI`, `BSI`, `NormalizedDifference`*, `AppendIndex`* |
+| **Cloud & QA** | `cloud` | `MaskClouds`*, `MaskFromQABits`*, `ApplyMask`*, `CloudSEN12` (via `ModelOp`) |
+| **Compositing** | `compositing` | `MedianComposite`, `MaxNDVIComposite`, `CloudFreeComposite`, `MeanComposite` |
+| **Pansharpening** | `pansharpen` | `BroveyPansharpen`, `GramSchmidtPansharpen`, `HCSPansharpen` |
+| **SAR** | `sar` | `LeeSpeckle`, `FrostSpeckle`, `RatioPolarimetric` |
+| **Hyperspectral** | `hyperspectral` | `MatchedFilter`, `ACEDetector`, `RXDetector`, `LinearUnmixing` |
+| **Sampling & inference** | `sampling` | `RandomSampler`*, `GridSampler`*, `Stitch`* |
+| | `inference` | `ModelOp`*, `ApplyToChips`*, `BatchedModelOp` |
+| **Catalog-driven** | `catalog_ops` | `CatalogPipeline`, `WriteCOG`, `WriteParquet` |
+| **Sensor presets** | `presets.s2` | `S2_L2A_RGB`, `S2_L2A_NDVI`, `S2_L1C_TO_BOA_NDVI`, `S2_QA60_CLOUD_MASK` |
+| | `presets.landsat` | `L8_BOA_NDVI`, `L8_QA_PIXEL_CLOUD_MASK` |
+| | `presets.emit` | `EMIT_METHANE_MF`, `EMIT_REFLECTANCE` |
+| | `presets.enmap` | `ENMAP_TO_S2_BANDS` (SRF binning preset) |
+
+### 1.3 What it explicitly is *not*
+
+- **Not `xr_toolz`.** Different substrate (`GeoTensor` vs `xr.Dataset`). Different audience. Same architectural patterns, separately implemented.
+- **Not `georeader`.** No I/O, no CRS plumbing, no reader classes, no catalog construction. Those are `georeader`'s job. `geotoolz` consumes `GeoTensor`s and produces `GeoTensor`s.
+- **Not a numpy primitives library.** Tier A primitives live inside `_src/array.py` per module — internal. If someone wants pure-numpy NDVI without operators, `from geotoolz.indices._src.array import ndvi_array` works, but the public surface is the Operator.
+- **Not framework-coupled.** `ModelOp` doesn't import torch / JAX / sklearn — it duck-types via `getattr(model, "predict")` or `model(arr)`. Optional `[ml]` extra for torch/sklearn presets if needed.
+- **Not a kitchen sink.** Curated. RS-shaped. Sensor presets are pinned to product versions to bound the maintenance surface.
+
+---
+
+## 2. User story
+
+**Personas:**
+
+1. **The RS researcher** wants "load S2 → mask clouds → atmospheric correct → NDVI → save COG" as one composable pipeline. Today they write 40 lines of glue code per analysis.
+2. **The ML engineer** wants tiled inference: chip a scene, run a model on each chip, stitch back, save a georeferenced output. Today they write a custom dataloader + inference loop per project.
+3. **The hyperspectral retrieval scientist** wants a matched filter operator that takes a target spectrum and a hyperspectral `GeoTensor`. Today they copy code from a paper supplement.
+4. **The Hydra-driven pipeline author** wants to declare the whole workflow in YAML and have it reproducibly run. Today they hand-roll a class registry per project.
+5. **The "I just want to make a quick figure" user** wants `S2_L2A_RGB(brightness=2.0)(gt)` and gets a sensible RGB visualisation in three tokens.
+
+**Goal arc:**
+
+```python
+import geotoolz as gz
+
+# 1. RGB visualisation in three tokens.
+viz = gz.presets.s2.S2_L2A_RGB(brightness=2.0)(gt)
+
+# 2. NDVI in two operators composed.
+ndvi = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band="QA60", bits=[10, 11]),
+    gz.indices.NDVI(red_idx=2, nir_idx=3),
+])(gt)
+
+# 3. Cloud-free monthly composite over a year.
+composite = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band="QA60", bits=[10, 11]),
+    gz.compositing.CloudFreeComposite(time_axis=0, merge="last"),
+])(timeseries_gt)                                     # GeoTensor (T, B, H, W) → (B, H, W)
+
+# 4. Tiled inference: chip → predict → stitch.
+infer = gz.inference.ApplyToChips(
+    sampler=gz.sampling.GridSampler(chip_size=(256, 256), stride=(224, 224)),
+    chip_op=gz.inference.ModelOp(model, batch_size=8),
+    stitcher=gz.sampling.Stitch(method="average"),
+)
+prediction = infer(gt)                                # GeoTensor (1, H, W)
+
+# 5. Methane plume detection on EMIT.
+plumes = gz.presets.emit.EMIT_METHANE_MF(target=ch4_signature)(emit_gt)
+```
+
+The unifying line: **every RS workflow is a `Sequential` of operators, declared in code or YAML, executed eagerly on `GeoTensor`s.**
+
+---
+
+## 3. Motivation
+
+### 3.1 Why a separate library, not "extend `xr_toolz`"
+
+| Concern | Force |
+| --- | --- |
+| **Substrate is different.** RS users have `GeoTensor` (numpy-shaped, integer axes, transform + crs). Climate users have `xr.Dataset` (named dims, coord arrays, dask chunking). The Operator's `__call__` signature is genuinely different. | strong |
+| **Audience is different.** RS researchers think in bands, sensors, retrievals, indices, QA bits, atmospheric correction, mosaicking. Climate researchers think in dims, climatologies, anomalies, EOFs, regridding, ESM evaluation. Different vocabulary, different examples, different presets. | strong |
+| **Workflows are different.** RS is pipeline-shaped: ingest → preprocess → infer → save. Climate is analysis-shaped: clean → diagnose → compare → score. Different operators rise to the top. | strong |
+| **Forcing one library to serve both** means picking awkward compromises (rename `axis` to `dim`? carry both? ban `axis`?). Every previous attempt in this thread (`geo_toolz` numpy / curated wrapper / from-scratch) hit this wall. | strong |
+| **Coordination cost of one library + two adapters** is higher than the cost of two libraries with one shared substrate underneath. | medium |
+
+### 3.2 Why re-implement the composition core
+
+`Operator`, `Sequential`, `Graph`, `Input`, `Node`, `ModelOp` are ~300 LOC total. Sharing them through a third package costs a release process, a coordination tax, and a temptation to add features for one library that the other doesn't want. **Re-implementing is cheaper and freer.**
+
+What `geotoolz` will diverge on:
+
+- **`Operator.__call__` signature.** xr_toolz's is `(ds: xr.Dataset)`. geotoolz's is `(gt: GeoTensor)` with native chip-batching semantics for samplers and tilers.
+- **Default `dim` keyword.** xr_toolz: `dim="time"`. geotoolz: `axis=0` (with optional `dim_name="time"` for human-readable repr).
+- **Multi-input arity.** RS commonly pairs imagery with masks or labels; geotoolz's Operator accepts `(image, mask)` or `(image, ref)` directly without going through Graph for this case.
+- **ModelOp batching.** geotoolz's `ModelOp` defaults to chip-batched inference; xr_toolz's defaults to dataset-flattened inference.
+
+These small differences add up. Sharing across libraries would mean both diverge from a least-common-denominator.
+
+### 3.3 Compared with adjacent libraries
+
+- **TorchGeo.** Heavy torch dep, ML-first, `BoundingBox` query model. `geotoolz` is torch-optional and focused on Operator composition; the audiences overlap but the abstraction tier differs.
+- **xarray-spatial.** xarray-bound. NDVI etc. but no operator framework, no inference, no presets.
+- **`stackstac` / `odc-stac`.** Catalog + xarray composition. Different abstraction tier.
+- **`xr_toolz`** itself. Wrong substrate for RS workflows.
+- **plain rasterio + custom code.** What users do today. Verbose, no composition, snippet-shaped.
+
+`geotoolz` slots between torchgeo and xarray-spatial: more opinionated than xarray-spatial, less framework-coupled than torchgeo.
+
+---
+
+## 4. Mathematics
+
+### 4.1 The three-tier delegation chain (worked example: `NDVI`)
+
+```python
+# Tier A — array
+def ndvi_array(arr, *, axis, red_idx, nir_idx, eps=1e-6):
+    take = lambda i: np.take(arr, i, axis=axis)
+    return (take(nir_idx) - take(red_idx)) / (take(nir_idx) + take(red_idx) + eps)
+
+# Tier B — tensor
+def ndvi_tensor(gt, *, axis=0, red_idx, nir_idx, eps=1e-6):
+    """Returns a GeoTensor of shape gt.shape with the band axis collapsed."""
+    return ndvi_array(gt, axis=axis, red_idx=red_idx, nir_idx=nir_idx, eps=eps)
+    # Closed under ufuncs → GeoTensor metadata round-trips automatically.
+
+# Tier C — operator
+class NDVI(Operator):
+    def __init__(self, *, red_idx, nir_idx, axis=0, eps=1e-6):
+        self.red_idx, self.nir_idx, self.axis, self.eps = red_idx, nir_idx, axis, eps
+    def _apply(self, gt):
+        return ndvi_tensor(gt, axis=self.axis, red_idx=self.red_idx,
+                           nir_idx=self.nir_idx, eps=self.eps)
+    def get_config(self):
+        return {"red_idx": self.red_idx, "nir_idx": self.nir_idx,
+                "axis": self.axis, "eps": self.eps}
+```
+
+The Operator carries config (Hydra-friendly), delegates to the Tensor function, which delegates to the Array function. **No logic duplicated.** Tests target whichever tier is most informative — usually Tier A for analytic ground truth + Tier C for config round-trip.
+
+### 4.2 The dual-mode `Operator.__call__` (Graph mode)
+
+Borrowed from `xr_toolz` D3 verbatim:
+
+```python
+class Operator:
+    def __call__(self, *args, **kwargs):
+        if any(isinstance(a, Node) for a in args):
+            # Graph-building mode: record the call, return a Node.
+            return Node(operator=self, parents=args)
+        return self._apply(*args, **kwargs)
+    def _apply(self, *args, **kwargs):
+        raise NotImplementedError
+```
+
+Same operator works eagerly in `Sequential` and symbolically in `Graph`. No parallel hierarchy.
+
+### 4.3 The split-object pattern for stateful operators (D2)
+
+Stateful ops (`PercentileClip` learning thresholds from data, atmospheric correction learning AOD from a calibration scene) split into two operators:
+
+```python
+# Stage 1: compute state
+percentiles = CalculatePercentiles(p=(2, 98), axis=(-2, -1))(reference_gt)
+# percentiles is a small ndarray, saveable to disk.
+
+# Stage 2: apply state
+clip = ApplyPercentileClip(percentiles=percentiles)
+clipped = clip(gt)
+```
+
+Every operator in a `Sequential` is `GeoTensor → GeoTensor`, always. State is an artifact, not a hidden field.
+
+### 4.4 Sampler stride math (carried from earlier reports)
+
+For each tile of size `(H, W)`, chip `(h, w)`, stride `(s_y, s_x)`:
+
+$$
+n_y = \left\lceil \frac{H - h}{s_y} \right\rceil + 1, \qquad
+n_x = \left\lceil \frac{W - w}{s_x} \right\rceil + 1
+$$
+
+Final-row/column chips are shifted (not truncated) to keep chip size exact. `GridSampler` returns a sequence of slice tuples; `ApplyToChips` iterates over them, applies a chip op, hands the chip + slice to `Stitch`.
+
+### 4.5 Compositing reductions
+
+For a stacked time series `X ∈ ℝ^(T × B × H × W)`:
+
+| Operator | Rule |
+| --- | --- |
+| `MeanComposite` | $C_{b,h,w} = \frac{1}{T'} \sum_{t \in V} X_{t,b,h,w}$ where $V$ = valid timesteps |
+| `MedianComposite` | $C_{b,h,w} = \mathrm{median}_{t \in V} X_{t,b,h,w}$ |
+| `MaxNDVIComposite` | for each $(h,w)$: $t^* = \arg\max_t \mathrm{NDVI}(X_t)$; output $X_{t^*}$ |
+| `CloudFreeComposite` | for each $(h,w)$: most recent $t$ with `mask_t = 0` |
+
+The `valid` set is computed from a paired QA `GeoTensor` passed alongside the imagery. Multi-input Operator: `CloudFreeComposite()(imagery_gt, mask_gt)`.
+
+### 4.6 Matched filter (hyperspectral)
+
+Standard target detector:
+
+$$
+\mathrm{MF}(x) = \frac{(x - \mu)^\top \Sigma^{-1} t}{t^\top \Sigma^{-1} t}
+$$
+
+with `μ` = scene mean spectrum, `Σ` = scene covariance, `t` = target spectrum. Pure numpy at the array tier; one-line einsum reshape. Sibling detectors (`ACE`, `RX`) reuse the same covariance compute via the split-object pattern (compute Σ once, share across detectors).
+
+### 4.7 Pansharpening (Brovey, condensed)
+
+$$
+\mathrm{R}'_{h,w} = \mathrm{R}_{h,w} \cdot \frac{\mathrm{P}_{h,w}}{\mathrm{R}_{h,w} + \mathrm{G}_{h,w} + \mathrm{B}_{h,w} + \epsilon}
+$$
+
+Resamples the multispectral bands to the pan grid first (via `skimage.transform.resize` through the Tier B `preserve_subclass` wrapper), then applies the per-channel ratio. Same pattern for Gram-Schmidt and HCS, different math.
+
+### 4.8 Lee speckle filter (SAR)
+
+Adaptive local-statistics filter:
+
+$$
+\hat{x} = \bar{x} + W \cdot (y - \bar{x}), \quad W = \frac{\sigma_x^2}{\sigma_x^2 + \sigma_n^2}
+$$
+
+with `ȳ`, `σ_y²` from a sliding window, `σ_n²` an estimate of speckle noise. `scipy.ndimage.uniform_filter` for the local statistics; pure numpy for the rest.
+
+---
+
+## 5. Coupling with the ecosystem
+
+### 5.1 `georeader` — primary substrate
+
+`geotoolz` operators take and return `GeoTensor`. `__array_ufunc__` handles metadata round-trips for ufunc-y operations; the Tier B layer handles non-ufunc upstream calls via `preserve_subclass`. **Zero changes required to `georeader`.**
+
+### 5.2 `numpy / scipy / scikit-image / scikit-learn` — compute
+
+All Tier A primitives. `geotoolz` consumes; never re-implements. Hard deps.
+
+### 5.3 `xrpatcher` — chip extraction (optional)
+
+`geotoolz.sampling.GridSampler` can use `xrpatcher` internally for the windowing logic, or a hand-rolled stride math (the §4.4 formula). `xrpatcher` is an optional `[patcher]` extra; the hand-rolled path is the default.
+
+### 5.4 `georeader.catalog` — large-scale processing
+
+`geotoolz.catalog_ops.CatalogPipeline(catalog, op)` iterates a catalog, applies an Operator per row, writes outputs. The catalog itself (build, query, intersect, persist) is **`georeader`'s job**, not `geotoolz`'s. `geotoolz` is a consumer.
+
+### 5.5 ML frameworks (`torch` / `jax` / `sklearn`) — optional, via `ModelOp`
+
+`ModelOp(model)` calls `getattr(model, "predict")`, `getattr(model, "__call__")`, or a user-provided method name. Never imports a framework. Optional `[ml]` extra ships convenience subclasses (`SklearnModelOp`, `TorchModelOp`) that set sensible defaults but stay duck-typed.
+
+### 5.6 `Hydra` / `hydra-zen` — config-driven pipelines
+
+Every Operator's `get_config()` returns JSON. `hydra-zen.builds(NDVI, red_idx=2, nir_idx=3)` round-trips. YAML pipelines compose without ceremony. Optional `[hydra]` extra ships pre-built configs for the standard operators.
+
+### 5.7 `xr_toolz` — sibling library, no dep
+
+`geotoolz` and `xr_toolz` share architectural patterns (D2, D3, D11) but no code. Users with both substrates install both. See [§10](#10-xr_toolz-coexistence).
+
+---
+
+## 6. Proposed API surface
+
+### 6.1 Module layout
+
+```text
+geotoolz/
+├── pyproject.toml                # numpy, scipy, scikit-image, scikit-learn, georeader
+├── src/geotoolz/
+│   ├── __init__.py               # __version__; re-export Operator, Sequential, Graph, Tap
+│   ├── core/                     # Operator, Sequential, Graph, Input, Node, Tap, ApplyToEach
+│   │   ├── __init__.py
+│   │   └── _src/
+│   │       ├── operator.py       # Operator base, __call__ dual-mode, get_config
+│   │       ├── sequential.py     # Sequential, __or__ pipe sugar
+│   │       ├── graph.py          # Graph, Input, Node, topological sort
+│   │       └── utils.py          # preserve_subclass decorator, axis helpers
+│   ├── radiometry/{__init__.py, _src/{array.py, tensor.py, operators.py}}
+│   ├── correction/...            # TOAToBOA, DarkObjectSubtraction, Py6S
+│   ├── indices/...               # NDVI, NDWI, MNDWI, NDMI, EVI, SAVI, BSI, NormalizedDifference, AppendIndex
+│   ├── cloud/...                 # MaskClouds, MaskFromQABits, ApplyMask, CloudSEN12
+│   ├── compositing/...           # MedianComposite, MaxNDVIComposite, CloudFreeComposite, MeanComposite
+│   ├── pansharpen/...            # Brovey, GramSchmidt, HCS
+│   ├── sar/...                   # LeeSpeckle, FrostSpeckle, RatioPolarimetric
+│   ├── hyperspectral/...         # MatchedFilter, ACEDetector, RXDetector, LinearUnmixing
+│   ├── sampling/...              # RandomSampler, GridSampler, Stitch
+│   ├── inference/...             # ModelOp, ApplyToChips, BatchedModelOp
+│   ├── catalog_ops/...           # CatalogPipeline, WriteCOG, WriteParquet
+│   └── presets/
+│       ├── s2.py, landsat.py, emit.py, enmap.py, modis.py
+└── tests/                        # mirroring src/, one test_<tier>.py per module
+```
+
+### 6.2 The Operator base class (the ~80 LOC core)
+
+```python
+class Operator:
+    """Base class for geotoolz operators.
+
+    Single-input ops map GeoTensor → GeoTensor. Multi-input ops accept multiple
+    positional arguments. Reductions may return scalars / lower-dim GeoTensors /
+    plain ndarrays. Terminal viz/IO ops may return Figure / None.
+
+    Subclasses implement `_apply(*args, **kwargs)`; the base class handles the
+    eager-vs-graph dispatch.
+    """
+
+    def __call__(self, *args, **kwargs):
+        if any(isinstance(a, Node) for a in args):
+            return Node(operator=self, parents=args)
+        return self._apply(*args, **kwargs)
+
+    def _apply(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_config(self) -> dict:
+        """JSON-serialisable dict of constructor args."""
+        return {}
+
+    def __repr__(self) -> str:
+        params = ", ".join(f"{k}={v!r}" for k, v in self.get_config().items())
+        return f"{self.__class__.__name__}({params})"
+
+    def __or__(self, other: "Operator") -> "Sequential":
+        if isinstance(other, Sequential):
+            return Sequential([self, *other.operators])
+        return Sequential([self, other])
+```
+
+### 6.3 `Sequential` and `Graph`
+
+```python
+class Sequential(Operator):
+    def __init__(self, operators: list[Operator]):
+        self.operators = operators
+    def _apply(self, gt):
+        for op in self.operators:
+            gt = op(gt)
+        return gt
+    def get_config(self):
+        return {"operators": [
+            {"class": op.__class__.__name__, "config": op.get_config()}
+            for op in self.operators
+        ]}
+
+class Input:
+    def __init__(self, name: str): self.name = name; self.parents = (); self.operator = None
+
+class Node:
+    def __init__(self, operator: Operator, parents: tuple): self.operator = operator; self.parents = parents
+
+class Graph(Operator):
+    def __init__(self, inputs: dict[str, Input], outputs: dict[str, Node]):
+        self.inputs, self.outputs = inputs, outputs
+        self._order = self._topological_sort()
+    def _apply(self, **kwargs):
+        cache = {id(node): kwargs[name] for name, node in self.inputs.items()}
+        for node in self._order:
+            args = tuple(cache[id(p)] for p in node.parents)
+            cache[id(node)] = node.operator._apply(*args)
+        return {name: cache[id(node)] for name, node in self.outputs.items()}
+```
+
+Same shape as xr_toolz's, separately implemented.
+
+### 6.4 `ModelOp` — framework-agnostic inference
+
+```python
+class ModelOp(Operator):
+    """Wrap any callable as an Operator.
+
+    Calls `getattr(model, method)(arr)` or `model(arr)`. Never imports
+    torch / jax / sklearn. Optional batched inference for chips.
+    """
+    def __init__(self, model, *, method: str = "__call__", batch_size: int | None = None):
+        self.model, self.method, self.batch_size = model, method, batch_size
+    def _apply(self, gt):
+        arr = gt.values  # plain ndarray
+        fn = getattr(self.model, self.method) if self.method != "__call__" else self.model
+        if self.batch_size is None:
+            out = fn(arr)
+        else:
+            out = self._batched(fn, arr)
+        return GeoTensor(values=out, transform=gt.transform, crs=gt.crs)
+    def _batched(self, fn, arr):
+        # split arr along axis 0 into batches, concatenate results
+        ...
+```
+
+### 6.5 Function signature conventions
+
+- Every Operator constructor takes keyword-only args (after `self`).
+- `axis=` for the integer axis convention; `dim_name=` (optional) for human-readable repr.
+- Single-input `_apply(self, gt)`; multi-input `_apply(self, gt_a, gt_b)` (unambiguous from arity).
+- `get_config()` returns JSON. Rich state (e.g. fitted percentiles, a model) is a constructor argument; users save / load it themselves.
+- No `**kwargs` in public constructors. Every option named.
+
+### 6.6 Hydra-zen YAML compatibility
+
+```yaml
+# conf/preprocess.yaml
+preprocess:
+  _target_: geotoolz.core.Sequential
+  operators:
+    - _target_: geotoolz.cloud.MaskClouds
+      qa_band: "QA60"
+      bits: [10, 11]
+    - _target_: geotoolz.radiometry.PercentileClip
+      p_min: 2
+      p_max: 98
+      axis: [-2, -1]
+    - _target_: geotoolz.indices.NDVI
+      red_idx: 2
+      nir_idx: 3
+```
+
+```python
+from hydra import compose, initialize
+from hydra.utils import instantiate
+
+with initialize(config_path="conf"):
+    cfg = compose(config_name="preprocess")
+pipeline = instantiate(cfg.preprocess)
+result = pipeline(gt)
+```
+
+### 6.7 Dependencies
+
+```toml
+[project]
+dependencies = [
+    "numpy >= 1.26",
+    "scipy >= 1.12",
+    "scikit-image >= 0.22",
+    "scikit-learn >= 1.4",
+    "georeader >= 2.0",
+]
+
+[project.optional-dependencies]
+ml = ["torch", "scikit-learn"]
+hydra = ["hydra-zen"]
+patcher = ["xrpatcher"]
+catalog = ["geopandas", "duckdb"]
+viz = ["matplotlib"]
+atmos = ["py6s"]
+```
+
+Five hard deps. Everything else opt-in.
+
+### 6.8 Versioning and stability
+
+Pre-1.0 (`0.x`). Operator constructor signatures are the public surface. Internal Tier A/B can change freely. Sensor presets are pinned with version suffixes (`S2_L2A_RGB_v1`) so users can stay on an old preset across breaking sensor changes.
+
+---
+
+## 7. Sharp edges
+
+1. **Don't share `Operator` with `xr_toolz`.** They diverge on call signature and chip semantics. The 300-LOC duplication is cheaper than the coordination tax.
+2. **`GeoTensor` subclass round-trip discipline.** For non-ufunc upstream calls (skimage, scipy.ndimage, sklearn), use the `preserve_subclass` decorator at the Tier B layer. For shape-changing operations (resize, zoom), the wrapper returns a plain ndarray and the Operator wraps a fresh `GeoTensor` with the new transform — `georeader` provides the construction.
+3. **Time-axis convention.** GeoTensor's `dims` may be `("time", "band", "y", "x")` or `("band", "time", "y", "x")` depending on how it was loaded. **Operators take `axis=` (int), never assume time is at axis 0.** The user passes `axis=` to match their tensor.
+4. **Multi-input arity is positional.** `CloudFreeComposite()(imagery, mask)` — the first GeoTensor is the imagery, the second is the mask. Document per Operator. Don't do `(image=..., mask=...)` keyword form; mixing positional and keyword args in `__call__` makes the dual-mode dispatch (eager vs graph) fragile.
+5. **`Sequential` strict on intermediate types.** Every step except the last must return a `GeoTensor`. Terminal ops (`WriteCOG`, viz operators) are allowed only at the end. Sequential validates and raises a clear `TypeError`.
+6. **Sensor presets are version-pinned.** When ESA changes Sentinel-2 product spec (it has, multiple times), the old `S2_L2A_RGB_v1` keeps working; `S2_L2A_RGB_v2` is a new operator. Users opt in.
+7. **`ModelOp` doesn't import frameworks.** Imports happen in user code, not in `geotoolz`. `from torch import nn` is the user's job. The optional `[ml]` extra is for *examples* and sensor-preset model wrappers, not for `ModelOp` itself.
+8. **Stateful operators use the split-object pattern.** No `fit` / `transform` duality on Operator. `CalculatePercentiles → ApplyPercentileClip(percentiles)`. State is an artifact.
+9. **Catalog ops live on georeader.** `geotoolz.catalog_ops.CatalogPipeline(catalog, op)` consumes a `georeader.catalog.GeoCatalog`. Don't reimplement catalog construction here.
+10. **Don't absorb every snippet.** Curated operator surface. If a user has a one-off RS computation, they write it as a one-off function or a custom `Operator` subclass — not as a PR adding it to `geotoolz`.
+11. **No `print` in operators.** Use `warnings.warn` for soft issues; raise for hard. Operators are building blocks; they shouldn't decorate stdout.
+12. **Float precision.** Default `float32` for image-bandwidth math, `float64` for stats and FFT. Per Operator, documented.
+
+---
+
+## 8. End-to-end examples
+
+`GeoTensor`-centric, using the proposed Operator surface. All examples assume `import geotoolz as gz` and `import numpy as np`.
+
+| § | Example | Pattern |
+| --- | --- | --- |
+| 8.1 | A. RGB visualisation in three lines | viz |
+| 8.1 | B. NDVI with cloud-masked Sentinel-2 | indices + cloud |
+| 8.2 | C. Cloud-free monthly composite over a year | compositing |
+| 8.2 | D. Max-NDVI annual composite | compositing |
+| 8.3 | E. TOA → BOA with dark-object subtraction | atmospheric correction |
+| 8.4 | F. Tiled inference with model + stitch | sampling + inference |
+| 8.4 | G. Patch-based cloud detection writing aligned QA | inference + catalog |
+| 8.5 | H. Methane plume detection on EMIT | hyperspectral |
+| 8.5 | I. Hyperspectral linear unmixing | hyperspectral |
+| 8.6 | J. Catalog-driven processing across hundreds of tiles | catalog_ops |
+| 8.7 | K. Hydra YAML pipeline | composition |
+| 8.7 | L. Branching analysis via Graph | composition |
+| 8.8 | M. Sentinel-2 RGB preset in one import | presets |
+
+### 8.1 Simple pipelines
+
+#### A. RGB visualisation
+
+```python
+gt = georeader.read_from_bounds(reader, bounds=AOI)            # (B, H, W) uint16
+
+viz = gz.Sequential([
+    gz.radiometry.ToFloat32(),
+    gz.radiometry.PercentileClip(p_min=2, p_max=98, axis=(-2, -1)),
+    gz.radiometry.MinMax(),
+    gz.radiometry.Gamma(g=1.2),
+])(gt)                                                         # GeoTensor (B, H, W) ∈ [0, 1]
+plt.imshow(viz[:3].transpose(1, 2, 0).values)
+```
+
+#### B. NDVI with cloud-masked Sentinel-2
+
+```python
+ndvi_pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band_idx=-1, bits=[10, 11]),
+    gz.indices.NDVI(red_idx=2, nir_idx=3),
+])
+veg = ndvi_pipeline(s2_gt)                                     # GeoTensor (H, W)
+georeader.save_cog(veg, "/out/ndvi.tif")
+```
+
+### 8.2 Compositing
+
+#### C. Cloud-free monthly composite
+
+```python
+ts = georeader.read_timeseries(reader, bounds=AOI, t=YEAR)     # GeoTensor (T, B, H, W)
+
+# Build a paired QA timeseries (one band per timestep)
+qa = georeader.read_timeseries(qa_reader, bounds=AOI, t=YEAR)  # GeoTensor (T, 1, H, W)
+
+# Cloud-free composite: most recent valid pixel per location
+composite = gz.compositing.CloudFreeComposite(
+    time_axis=0, qa_bits=[10, 11], merge="last",
+)(ts, qa)                                                       # GeoTensor (B, H, W)
+georeader.save_cog(composite, "/out/cloud_free_2023.tif")
+```
+
+#### D. Max-NDVI annual composite
+
+```python
+mosaic = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band_idx=-1, bits=[10, 11]),
+    gz.compositing.MaxNDVIComposite(time_axis=0, red_idx=2, nir_idx=3),
+])(ts)                                                          # GeoTensor (B, H, W)
+```
+
+### 8.3 Atmospheric correction
+
+#### E. TOA → BOA with dark-object subtraction
+
+```python
+boa_pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band_idx=-1, bits=[10, 11]),
+    gz.correction.DarkObjectSubtraction(percentile=1, axis=(-2, -1)),
+    gz.correction.TOAToBOA(sun_zenith=sza, atmosphere="midlatitude_summer"),
+])
+boa = boa_pipeline(toa_gt)                                      # GeoTensor (B, H, W) reflectance
+```
+
+`TOAToBOA` is an Operator wrapping georeader's reflectance physics — it doesn't re-implement, it composes.
+
+### 8.4 Tiled inference
+
+#### F. Model inference + stitch
+
+```python
+model = load_my_unet()                                          # any callable / torch model
+
+tiled_inference = gz.inference.ApplyToChips(
+    sampler=gz.sampling.GridSampler(chip_size=(256, 256), stride=(224, 224)),
+    chip_op=gz.inference.ModelOp(model, batch_size=8),
+    stitcher=gz.sampling.Stitch(method="average"),
+)
+prediction = tiled_inference(s2_gt)                             # GeoTensor (1, H, W)
+georeader.save_cog(prediction, "/out/segmentation.tif")
+```
+
+#### G. Cloud detection writing aligned QA across a catalog
+
+```python
+catalog = georeader.catalog.open_catalog("s3://bucket/s2_eu.parquet")
+
+per_tile = gz.Sequential([
+    gz.inference.ApplyToChips(
+        sampler=gz.sampling.GridSampler(chip_size=(512, 512)),
+        chip_op=gz.inference.ModelOp(cloudsen12_model),
+        stitcher=gz.sampling.Stitch(method="average"),
+    ),
+    gz.catalog_ops.WriteCOG(path_template="{filepath_stem}.cloud.tif"),
+])
+
+gz.catalog_ops.CatalogPipeline(catalog, per_tile).run()         # writes one COG per row
+```
+
+### 8.5 Hyperspectral
+
+#### H. Methane plume detection on EMIT
+
+```python
+emit_gt = georeader.readers.emit.load(scene_path)               # (B=285, H, W) reflectance
+
+mf_pipeline = gz.Sequential([
+    gz.cloud.ApplyMask(mask_op=gz.cloud.MaskFromQABits(...)),
+    gz.hyperspectral.MatchedFilter(target=ch4_signature, axis=0),
+])
+score = mf_pipeline(emit_gt)                                    # GeoTensor (H, W) detection score
+georeader.save_cog(score, "/out/methane_mf.tif")
+```
+
+#### I. Linear spectral unmixing
+
+```python
+endmembers = np.load("/data/endmembers_4_classes.npy")          # (4, B) reference spectra
+
+unmix = gz.hyperspectral.LinearUnmixing(endmembers=endmembers, method="fcls", axis=0)
+fractions = unmix(emit_gt)                                      # GeoTensor (4, H, W) class fractions
+```
+
+### 8.6 Catalog-driven
+
+#### J. Apply a pipeline across hundreds of tiles
+
+```python
+catalog = georeader.catalog.open_catalog("/cat/s2_T29SND.parquet")
+
+pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band_idx=-1, bits=[10, 11]),
+    gz.indices.NDVI(red_idx=2, nir_idx=3),
+    gz.catalog_ops.WriteCOG(path_template="/out/ndvi/{tile_id}_{date}.tif"),
+])
+
+gz.catalog_ops.CatalogPipeline(
+    catalog,
+    pipeline,
+    n_workers=4,                                                # process multiple tiles in parallel
+).run()
+```
+
+`CatalogPipeline` is a Tier C Operator that wraps the catalog iteration. The actual catalog (build / query / persistence) lives in `georeader.catalog`.
+
+### 8.7 Composition patterns
+
+#### K. Hydra YAML pipeline
+
+```yaml
+# conf/methane_retrieval.yaml
+pipeline:
+  _target_: geotoolz.core.Sequential
+  operators:
+    - _target_: geotoolz.cloud.ApplyMask
+      mask_op:
+        _target_: geotoolz.cloud.MaskFromQABits
+        qa_band_idx: -1
+        bits: [10, 11]
+    - _target_: geotoolz.hyperspectral.MatchedFilter
+      target: ${load_target_spectrum}
+      axis: 0
+```
+
+```python
+from hydra import compose, initialize
+from hydra.utils import instantiate
+
+with initialize(config_path="conf"):
+    cfg = compose(config_name="methane_retrieval")
+pipeline = instantiate(cfg.pipeline)
+score = pipeline(emit_gt)
+```
+
+#### L. Branching analysis via `Graph`
+
+```python
+img = gz.core.Input("image")
+ref = gz.core.Input("reference")
+
+cleaned = gz.cloud.MaskClouds(qa_band_idx=-1, bits=[10, 11])(img)
+ndvi    = gz.indices.NDVI(red_idx=2, nir_idx=3)(cleaned)
+ndwi    = gz.indices.NDWI(green_idx=1, nir_idx=3)(cleaned)
+rmse    = gz.metrics.RMSE(axis=(-2, -1))(ndvi, ref)             # multi-input
+
+g = gz.core.Graph(
+    inputs={"image": img, "reference": ref},
+    outputs={"ndvi": ndvi, "ndwi": ndwi, "rmse": rmse},
+)
+result = g(image=s2_gt, reference=ref_gt)                       # dict of GeoTensors / scalars
+```
+
+### 8.8 Sensor presets
+
+#### M. One-line Sentinel-2 RGB
+
+```python
+from geotoolz.presets.s2 import S2_L2A_RGB_v1
+
+viz = S2_L2A_RGB_v1(brightness=2.0)(s2_gt)                      # GeoTensor (3, H, W) viz-ready
+plt.imshow(viz.transpose(1, 2, 0).values)
+```
+
+The preset is just a `Sequential` with sensible defaults baked in. Users override via constructor args.
+
+---
+
+## 9. Verdict
+
+`geotoolz` is **the RS-shaped sibling to `xr_toolz`**. Same architectural patterns, different substrate, different audience, different opinionated surface. Two libraries, two use cases, that's it.
+
+What needs to happen to ship v0.1:
+
+- [ ] Cut the new repo. `src/` layout, five hard deps.
+- [ ] Re-implement the composition core: `Operator`, `Sequential`, `Graph`, `Input`, `Node`, `Tap`. Borrow patterns from `xr_toolz`; ~300 LOC; no shared dep.
+- [ ] Author the v0.1 modules: `radiometry`, `indices`, `cloud`, `sampling`, `inference`, plus the core. ~25 Operators. **2 weeks.**
+- [ ] One `_src/{array, tensor, operators}.py` per module — preserves the three-tier discipline from day one.
+- [ ] `preserve_subclass` decorator + `GeoTensor` round-trip tests.
+- [ ] Hydra-zen smoke tests (every Operator's `get_config()` round-trips through `builds()`).
+- [ ] One end-to-end example notebook per category in §8 (six notebooks).
+
+v0.2 — `compositing`, `correction`, `catalog_ops`. **2 weeks.**
+v0.3 — `pansharpen`, `sar`, `hyperspectral` (matched filter, ACE, RX, unmixing). **2 weeks.**
+v0.4 — `presets.s2`, `presets.landsat`, `presets.emit`, `presets.enmap`. **1 week per sensor.**
+
+What to defer past v0.4:
+
+- A full atmospheric correction story (Py6S/MODTRAN integration). Optional `[atmos]` extra; ship a stub `Py6SCorrection` operator.
+- Distributed processing (Dask integration on the `CatalogPipeline` parallelism). v0.5+.
+- xrpatcher integration as the default sampler. v0.5+.
+- A "geotoolz / xr_toolz interop" doc page. v0.4, when both have shipped enough to point at concrete patterns.
+
+The total cost: roughly **two months** for v0.1–v0.4. The payoff: every RS workflow that today is 30–100 lines of glue code becomes a `Sequential` of 3–6 Operators, declared in code or YAML, composable, testable, and pinnable to a sensor product version.
+
+---
+
+## 10. `xr_toolz` coexistence
+
+`geotoolz` and `xr_toolz` are siblings. This section codifies the boundary so users know which to reach for.
+
+### 10.1 The substrate-split rule
+
+| If your data is | Reach for |
+| --- | --- |
+| `xr.Dataset` / `xr.DataArray` (named dims, coord arrays, dask chunks) | `xr_toolz` |
+| `georeader.GeoTensor` (numpy subclass with transform + crs) | `geotoolz` |
+| Raw `np.ndarray` (no metadata) | `numpy` / `scipy` / `scikit-image` directly |
+
+For users with both substrates: install both. Conversion between substrates is `georeader.dataarray.to_dataarray(gt)` / `from_dataarray(da)` — already in georeader.
+
+### 10.2 Shared architectural patterns
+
+Both libraries follow:
+
+- **Three-tier model** (Array → Tensor → Operator).
+- **Split-object pattern for stateful operations** (calculate state → apply state).
+- **Dual-mode `__call__`** (eager vs Graph-symbolic).
+- **Sequential and Graph composition.**
+- **`get_config()` for Hydra round-trip.**
+- **No framework deps in core; ML via duck-typed `ModelOp`.**
+
+The pattern docs live once (in `xr_toolz` or in a third "design conventions" doc); each library's own docs reference them. Code is independent.
+
+### 10.3 What does NOT cross-pollinate
+
+- **Operator implementations.** `xr_toolz.indices.NDVI` doesn't exist — climate users don't need NDVI as an Operator. If they do, they call `geotoolz.indices.NDVI` after converting to `GeoTensor`.
+- **`xr_toolz.kinematics.Coriolis(lat=...)`** stays in xr_toolz for climate users (operates on a `Dataset` with named lat/lon).
+- **`geotoolz.kinematics.geostrophic_velocity(...)`** is a leaf operator if RS workflows need it (operates on a `GeoTensor` with integer axes). Re-implementation is fine — different signatures, different defaults.
+
+### 10.4 Conversion patterns
+
+Cross-substrate workflows (load with georeader, run climate analysis, write back) look like:
+
+```python
+gt = georeader.read_from_bounds(...)                          # GeoTensor
+da = georeader.dataarray.to_dataarray(gt)                     # xr.DataArray
+result_da = xr_toolz.detrend.RemoveClimatology(clim)(da)
+result_gt = georeader.dataarray.from_dataarray(result_da)     # GeoTensor
+georeader.save_cog(result_gt, "/out/result.tif")
+```
+
+`georeader` is the bridge. Both libraries treat it as substrate, not as dep tier.
+
+### 10.5 Documentation cross-references
+
+A short doc page in each library: "I have *X* data, should I use this library or the other?" with a decision tree. Linked from both READMEs. Half-day of doc work, prevents the most common new-user confusion.
+
+### 10.6 The endpoint
+
+Two libraries, two communities, one shared substrate library underneath, one shared design vocabulary on top. Each library focused, each community served, no awkward unifying compromise. **That's the right shape, and that's the recommendation.**

--- a/projects/geotoolz/plans/modis.md
+++ b/projects/geotoolz/plans/modis.md
@@ -1,4 +1,4 @@
-# Target API for MODIS and Curvilinear Whisk-Broom Sensors in `georeader`
+# MODIS / curvilinear readers
 
 > **Design Report** — design for MODIS, VIIRS, and related curvilinear-geolocation readers in [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader). Companion to the geostationary readers design.
 

--- a/projects/geotoolz/plans/modis.md
+++ b/projects/geotoolz/plans/modis.md
@@ -1,0 +1,381 @@
+# Target API for MODIS and Curvilinear Whisk-Broom Sensors in `georeader`
+
+> **Design Report** — design for MODIS, VIIRS, and related curvilinear-geolocation readers in [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader). Companion to the geostationary readers design.
+
+## Contents
+
+- [User Story](#user-story)
+- [Motivation](#motivation)
+- [Mathematics: The Curvilinear Transformation](#mathematics-the-curvilinear-transformation)
+- [Target API](#target-api)
+  - [MODIS L1B reader](#modis-l1b-reader)
+  - [VIIRS L1B reader](#viirs-l1b-reader)
+  - [Variations within the family](#variations-within-the-family)
+- [Example Use Cases](#example-use-cases)
+- [Subtasks](#subtasks)
+- [Open Design Question](#open-design-question)
+
+## User Story
+
+I'm continuing the migration from `rs_tools` into `georeader` with the next family of sensors: **MODIS** on Aqua/Terra, plus its close relatives **VIIRS** (S-NPP, NOAA-20/21), and eventually **AVHRR**, **Sentinel-3 OLCI/SLSTR**, and airborne **AVIRIS-NG**. Unlike GOES/SEVIRI, none of these have a clean affine in any standard CRS — they're polar-orbiting (or airborne) curvilinear scanners whose native geometry is "this is the lat/lon of every single pixel." The PRISMA reader is the right precedent and `griddata.read_to_crs` is the right resampler, but the reader has to set things up carefully so the curvilinear → regular-grid step works correctly, especially around bowtie pixels, multi-resolution bands, and dateline crossings.
+
+## Motivation
+
+MODIS is the foundational dataset of the modern remote-sensing era — 25 years of daily global coverage, 36 spectral bands, three native resolutions (250 m / 500 m / 1 km), and an enormous downstream Level-2 product family (MOD09 surface reflectance, MOD11 LST, MOD13 vegetation indices, MOD14 fires, ...). VIIRS is the operational successor (similar bands, similar geometry, NetCDF instead of HDF4). Both ship as files where the *only* honest description of geometry is per-pixel `lons`/`lats`; any attempt to fit an affine to them is a lie at the swath edges.
+
+| Sensor | Format | Geolocation | Native res. | Notes |
+|---|---|---|---|---|
+| MODIS L1B (Aqua/Terra) | HDF4 (HDF-EOS) | Separate `MOD03`/`MYD03` at 1 km; in-file at 500 m/250 m | 250 m / 500 m / 1 km | Bowtie at scan edges; 36 bands |
+| VIIRS SDR (S-NPP, NOAA-20/21) | HDF5 / NetCDF | Companion `GIMGO` / `GMTCO` files | 375 m (I) / 750 m (M) | Bowtie aware; 22 bands |
+| AVHRR (NOAA, MetOp) | L1B binary / NetCDF | In-file | ~1.1 km | Older format; defer |
+| Sentinel-3 OLCI/SLSTR | NetCDF | In-file `geo_coordinates` | 300 m / 500 m / 1 km | Push-broom but still curvilinear; defer |
+| AVIRIS-NG (airborne) | ENVI binary | Separate `IGM`/`GLT` files | sub-meter to ~10 m | Very long swaths; defer |
+
+`rs_tools` solved download and patching for MODIS but not the read-arbitrary-AOI problem; `satpy` solves both at the cost of a heavy dependency tree. The georeader-shaped equivalent is one reader per sensor following the PRISMA pattern, plus a small set of curvilinear utilities to handle quirks that PRISMA doesn't have.
+
+The reader's job is, again, narrow: open the HDF/NetCDF files, parse calibration, link the geolocation file (when separate), expose `.lons`/`.lats` plus calibrated arrays and metadata, and let `griddata.read_to_crs` do the rest. The new things this design has to address that the GEO design didn't:
+
+1. **Multi-file products** (data file + separate geolocation file)
+2. **The bowtie effect** (overlapping pixels at scan edges)
+3. **Multi-resolution geolocation** (1 km comes from `MOD03`; 500 m / 250 m must be derived or upsampled)
+4. **Antimeridian crossings** (lons jump from +180 to -180 mid-swath)
+5. **The actual curvilinear → regular-grid resampling** in the middle
+
+## Mathematics: The Curvilinear Transformation
+
+The forward problem — pixel index $(i, j)$ → $(\varphi_{ij}, \lambda_{ij})$ — is given by the file's geolocation arrays. The backward problem is the reprojection that `griddata.read_to_crs` does, and it's worth being explicit about what's happening, because the choice of resampling method interacts with bowtie pixels in ways that matter.
+
+Let `V[i, j, k]` be the source array of shape `(H, W, C)`, with `lons[i, j]` and `lats[i, j]` giving the geographic location of pixel `(i, j)`. For a target CRS and a target resolution `Δ`, we want a regular grid `V_dst[m, n, k]` at locations `(x_m, y_n)` in target-CRS meters. The transformation has three steps:
+
+```python
+# Pseudocode for what griddata.read_to_crs is doing under the hood
+
+# 1. Project source points: (φ, λ) → (x_src, y_src) in dst_crs meters
+transformer = pyproj.Transformer.from_crs("EPSG:4326", dst_crs, always_xy=True)
+x_src, y_src = transformer.transform(lons, lats)            # (H, W) each
+
+# 2. Build target grid (regular in dst_crs)
+x_min, y_min, x_max, y_max = bounds_dst or auto_bounds(x_src, y_src)
+x_grid = np.arange(x_min, x_max, resolution_dst)
+y_grid = np.arange(y_max, y_min, -resolution_dst)
+X_dst, Y_dst = np.meshgrid(x_grid, y_grid)                  # (H', W') each
+
+# 3. Scattered → regular interpolation. Two common kernels:
+
+#    (a) nearest neighbor via KD-tree
+tree = scipy.spatial.cKDTree(np.column_stack([x_src.ravel(), y_src.ravel()]))
+_, idx = tree.query(np.column_stack([X_dst.ravel(), Y_dst.ravel()]), k=1)
+V_dst = V.reshape(-1, C)[idx].reshape(X_dst.shape + (C,))
+
+#    (b) linear via Delaunay triangulation
+V_dst = scipy.interpolate.griddata(
+    points=np.column_stack([x_src.ravel(), y_src.ravel()]),
+    values=V.reshape(-1, C),
+    xi=(X_dst, Y_dst),
+    method="linear",
+)
+```
+
+Three numerical hazards show up here that the reader has to either fix or document:
+
+> **Bowtie duplicates.** The source point cloud has multiple samples for the same ground location at scan edges. Nearest-neighbor handles this gracefully (one of the duplicates wins arbitrarily) but Delaunay-based linear interpolation can produce visible seams where degenerate triangles meet.
+
+> **Antimeridian crossings.** A swath might have lons of +179.8° and -179.7° in adjacent pixels; if you project naively to a CRS that doesn't wrap (Web Mercator, UTM), the swath gets stretched halfway around the world. The reader handles this by detecting the discontinuity in `.lons` and either splitting the swath or unwrapping (e.g., `lons[lons < 0] += 360` when in the eastern-hemisphere tile).
+
+> **Off-disk / fill values.** Sentinels like `-999` in `.lats`/`.lons` must be masked before the KD-tree is built, otherwise they pull nearest-neighbor queries into nonsense.
+
+The reader does **not** implement the resampling — `griddata.read_to_crs` does — but it owns making sure the inputs to that function are clean: valid masks applied, antimeridian unwrapped or flagged, and bowtie status known. As a small utility module:
+
+```python
+# georeader/readers/curvilinear/_swath.py — internal, sensor-agnostic
+
+def crosses_antimeridian(lons: NDArray) -> bool:
+    """True if the lon array contains a ±180° discontinuity."""
+    return np.any(np.abs(np.diff(lons, axis=1)) > 180)
+
+
+def unwrap_antimeridian(lons: NDArray) -> NDArray:
+    """Add 360 to negative lons if the swath straddles the dateline.
+    Returns lons with no discontinuity; downstream CRS must handle it."""
+    if crosses_antimeridian(lons):
+        return np.where(lons < 0, lons + 360, lons)
+    return lons
+
+
+def bowtie_mask(scan_size: int, n_scans: int, edge_rows: int = 2) -> NDArray:
+    """True for pixels that are bowtie duplicates (scan edge rows).
+    scan_size = lines per scan (10 for MODIS 1 km, 16 for VIIRS M-band)."""
+    ...
+
+
+def dedupe_bowtie(
+    values: NDArray, lons: NDArray, lats: NDArray, scan_size: int,
+) -> tuple[NDArray, NDArray, NDArray]:
+    """Drop the bowtie duplicate rows. Returns reduced (values, lons, lats)."""
+    ...
+```
+
+Users never call these directly. Readers call them from `__init__` or expose them as opt-in methods.
+
+## Target API
+
+The MODIS L1B reader follows the PRISMA template precisely. A separate geolocation file (`MOD03`/`MYD03`) is the norm at 1 km; for 500 m and 250 m the geolocation either lives inside the data file or must be derived by interpolation, and the reader handles both cases.
+
+### MODIS L1B reader
+
+```python
+# georeader/readers/modis.py
+from datetime import datetime
+from numpy.typing import NDArray
+from typing import Literal
+
+
+class MODIS_L1B:
+    """MODIS Level 1B calibrated radiances/reflectances.
+
+    Handles MOD021KM/MYD021KM (1 km), MOD02HKM/MYD02HKM (500 m),
+    and MOD02QKM/MYD02QKM (250 m). Geolocation from MOD03/MYD03.
+    """
+
+    # --- per-pixel geolocation (PRISMA convention) ---
+    lons: NDArray                               # (H, W) degrees
+    lats: NDArray                               # (H, W) degrees
+
+    # --- viewing/solar geometry (free in MODIS, useful downstream) ---
+    solar_zenith: NDArray                       # (H, W) degrees
+    solar_azimuth: NDArray
+    sensor_zenith: NDArray
+    sensor_azimuth: NDArray
+
+    # --- MODIS metadata ---
+    bounds: tuple[float, float, float, float]   # in EPSG:4326 from lons/lats
+    time: datetime                              # granule midpoint, tz-aware
+    time_start: datetime
+    time_end: datetime
+    satellite: Literal["Terra", "Aqua"]
+    sensor: str = "MODIS"
+    resolution: Literal["1km", "500m", "250m"]
+    bands: list[str]                            # e.g. ['B01', 'B02', 'B26', 'B31']
+    wavelengths: dict[str, float]               # central wavelengths in µm
+    units: str                                  # 'W m-2 sr-1 um-1' for radiance
+    crosses_antimeridian: bool
+    scan_size: int                              # 10 (1 km), 20 (500 m), 40 (250 m)
+
+    def __init__(
+        self,
+        path: str,                              # MOD021KM (or HKM/QKM)
+        geo_path: str | None = None,            # MOD03; if None, look inside path
+        bands: list[str] | None = None,
+        unwrap_antimeridian: bool = True,
+    ): ...
+
+    # --- load methods (PRISMA-style) ---
+    def load_raw(self, *, calibrated: bool = True) -> NDArray:
+        """(C, H, W) array; if calibrated, in self.units; else raw DN."""
+
+    def load_band(self, band: str, *, calibrated: bool = True) -> NDArray: ...
+
+    def to_reflectance(self) -> NDArray:
+        """Solar bands → TOA reflectance, dividing by cos(solar_zenith)."""
+
+    def to_brightness_temperature(self) -> NDArray:
+        """Thermal bands (20–25, 27–36) → BT via Planck inversion."""
+
+    # --- bowtie handling (MODIS-specific) ---
+    def dedupe_bowtie(self) -> "MODIS_L1B":
+        """Return a new reader with bowtie duplicate rows removed."""
+
+    @property
+    def bowtie_mask(self) -> NDArray: ...
+```
+
+Construction and use mirror PRISMA exactly:
+
+```python
+from georeader.readers import modis
+from georeader import griddata
+import numpy as np
+
+obj = modis.MODIS_L1B(
+    path="MYD021KM.A2024165.1855.061.2024166094021.hdf",
+    geo_path="MYD03.A2024165.1855.061.2024166081542.hdf",
+    bands=["B01", "B02", "B26", "B31"],     # red, NIR, cirrus, 11 µm
+)
+print(obj)
+# MODIS_L1B: Aqua  res=1km  t=2024-06-13T18:55:00+00:00
+#   bands: ['B01', 'B02', 'B26', 'B31']  shape: (4, 2030, 1354)
+#   bounds: (-12.4, 35.6, 18.9, 58.3)  crosses_antimeridian: False
+#   scan_size: 10 (bowtie aware)
+
+raw = obj.load_raw(calibrated=True)         # (4, H, W) in W m-2 sr-1 um-1
+geo = griddata.read_to_crs(
+    np.moveaxis(raw, 0, 2),
+    lons=obj.lons, lats=obj.lats,
+    resolution_dst=1000, dst_crs="EPSG:3035",   # ETRS89 / LAEA Europe
+    method="nearest",                            # bowtie-safe
+)
+# geo: GeoTensor (4, H', W') in EPSG:3035
+```
+
+### VIIRS L1B reader
+
+VIIRS follows the same pattern with sensor-specific tweaks (the I-band/M-band split mirrors MODIS resolution groups; geolocation lives in `GMTCO`/`GIMGO` companion files):
+
+```python
+# georeader/readers/viirs.py
+from typing import Literal
+
+
+class VIIRS_L1B:
+    """VIIRS SDR (Sensor Data Record) reader for I-bands (375 m) and M-bands (750 m)."""
+
+    lons: NDArray                               # from GIMGO (I) or GMTCO (M)
+    lats: NDArray
+    solar_zenith: NDArray
+    solar_azimuth: NDArray
+    sensor_zenith: NDArray
+    sensor_azimuth: NDArray
+
+    satellite: Literal["S-NPP", "NOAA-20", "NOAA-21"]
+    sensor: str = "VIIRS"
+    resolution: Literal["I", "M"]               # 375 m or 750 m
+    scan_size: int                              # 32 (I), 16 (M)
+    bands: list[str]                            # e.g. ['I04', 'I05', 'M11']
+    # ... rest same shape as MODIS_L1B
+```
+
+### Variations within the family
+
+For Level-2 MODIS products (`MOD09`, `MOD11`, `MOD13`), the same reader pattern applies but the bands change and the calibration helpers (`to_reflectance` / `to_brightness_temperature`) become identity passes — the products are already in physical units. Implement these as separate small classes (`MODIS_L2_SurfaceReflectance`, `MODIS_LST`) that share a base mixin if duplication appears.
+
+For **Sentinel-3 OLCI/SLSTR** (NetCDF, push-broom but still curvilinear due to Earth rotation during the scan), the reader is structurally identical: open file, expose `.lons`/`.lats`, calibrate, route through `griddata.read_to_crs`. Defer until MODIS and VIIRS land.
+
+For **AVIRIS-NG** (airborne, ENVI format with separate IGM/GLT geolocation files), again structurally identical — the only difference is the file-parsing layer.
+
+## Example Use Cases
+
+### 1. MODIS true color over a methane site, reprojected to UTM
+
+```python
+from georeader.readers import modis
+from georeader import griddata
+import numpy as np
+
+obj = modis.MODIS_L1B(
+    "MYD021KM.A2024165.1855.061.....hdf",
+    geo_path="MYD03.A2024165.1855.061.....hdf",
+    bands=["B01", "B04", "B03"],            # red, green, blue
+)
+rgb = obj.to_reflectance()                  # (3, H, W)
+out = griddata.read_to_crs(
+    np.moveaxis(rgb, 0, 2),
+    lons=obj.lons, lats=obj.lats,
+    resolution_dst=1000, dst_crs="EPSG:32613",
+    method="nearest",
+)
+```
+
+### 2. Bowtie-aware processing for cloud detection
+
+```python
+obj = modis.MODIS_L1B(path, geo_path, bands=["B01", "B02", "B06", "B26", "B31"])
+obj_clean = obj.dedupe_bowtie()              # rows reduced, no duplicates
+
+# now linear interpolation in griddata.read_to_crs is safe
+geo = griddata.read_to_crs(
+    np.moveaxis(obj_clean.load_raw(), 0, 2),
+    lons=obj_clean.lons, lats=obj_clean.lats,
+    resolution_dst=1000, dst_crs="EPSG:3857",
+    method="linear",
+)
+```
+
+### 3. MODIS–Sentinel-2 collocation for fusion
+
+```python
+from georeader.readers import S2_SAFE_reader, modis
+from georeader import griddata
+import numpy as np
+
+s2 = S2_SAFE_reader.s2loader(s2_path, out_res=60, bands=["B04", "B08", "B11"])
+m  = modis.MODIS_L1B(modis_path, modis_geo_path, bands=["B01", "B02", "B06"])
+m_on_s2 = griddata.read_to_crs(
+    np.moveaxis(m.to_reflectance(), 0, 2),
+    lons=m.lons, lats=m.lats,
+    resolution_dst=s2.transform.a,           # match S2 grid
+    dst_crs=s2.crs,
+    bounds_dst=s2.bounds,
+)
+```
+
+### 4. VIIRS at high latitudes with antimeridian crossing
+
+The reader auto-unwraps `.lons` so downstream resampling doesn't fail:
+
+```python
+from georeader.readers import viirs
+from georeader import griddata
+
+v = viirs.VIIRS_L1B(path, geo_path, bands=["M15"], unwrap_antimeridian=True)
+print(v.crosses_antimeridian)                # True
+print(v.lons.max(), v.lons.min())            # 195.3, 174.2 (unwrapped)
+
+geo = griddata.read_to_crs(
+    v.load_raw(),
+    lons=v.lons, lats=v.lats,
+    resolution_dst=750, dst_crs="EPSG:3413",  # NSIDC north polar
+)
+```
+
+## Subtasks
+
+The work splits into a small curvilinear utility module, the per-sensor readers, and notebooks.
+
+### Curvilinear utilities (~2 days)
+
+`georeader/readers/curvilinear/_swath.py` with `crosses_antimeridian`, `unwrap_antimeridian`, `bowtie_mask`, `dedupe_bowtie`, plus tests. These are sensor-agnostic and the only piece of new shared infrastructure. Whether to expose any of these publicly is a design decision; start internal-only and promote if external users need them.
+
+### MODIS L1B reader (~2 weeks)
+
+The first concrete reader. HDF4 parsing through `pyhdf` (the only mature HDF4 binding); calibration coefficients live in attributes per-band; geolocation comes from the linked `MOD03` file at 1 km, and from in-file SDS at 500 m / 250 m. Three resolution variants share the class and dispatch on file name. Tests against a small fixture granule in CI. The bowtie deduplication is the one MODIS-specific footgun and gets its own test.
+
+### MODIS L2 readers (~1 week each)
+
+`MODIS_L2_SurfaceReflectance` (`MOD09`), `MODIS_LST` (`MOD11`), `MODIS_VegetationIndex` (`MOD13`). These are thinner because calibration is a no-op, but each has its own band list and quality-flag conventions. Build only the ones I need first, generalize later.
+
+### VIIRS L1B reader (~2 weeks)
+
+HDF5 / NetCDF instead of HDF4 (cleaner). I-band and M-band variants in one class with a `resolution` switch like MODIS. Geolocation from `GIMGO` / `GMTCO` companion files. Tests against a small fixture.
+
+### Sentinel-3 OLCI/SLSTR, AVHRR, AVIRIS-NG (~1–2 weeks each)
+
+**Defer** until MODIS + VIIRS are landed.
+
+### Notebooks (~1 week)
+
+Three in the established style:
+
+- `modis_quickstart.ipynb` mirroring `prisma_with_cloudsen12.ipynb` (open file, calibrate, run cloud detection, compare to S2)
+- `viirs_quickstart.ipynb`
+- `modis_s2_collocation.ipynb` showing the cross-sensor fusion workflow
+
+### Staged release
+
+- [ ] **PR 1.** Curvilinear utilities + MODIS L1B + MODIS quickstart notebook (cohesive, end-to-end)
+- [ ] **PR 2.** VIIRS L1B + VIIRS quickstart notebook
+- [ ] **PR 3.** MODIS L2 family (`MOD09`, `MOD11`, `MOD13`)
+- [ ] **PR 4.** Sentinel-3 OLCI/SLSTR
+- [ ] **PR 5.** AVHRR
+- [ ] **PR 6.** AVIRIS-NG
+
+## Open Design Question
+
+The single biggest open design question, worth resolving before locking anything down:
+
+> **Where does `dedupe_bowtie` live?** Three options:
+>
+> 1. As a method on the reader (`obj.dedupe_bowtie()` returns a new reader)
+> 2. As a free function in `_swath.py` (users call it on raw arrays)
+> 3. As a kwarg at construction time (`MODIS_L1B(..., bowtie_dedupe=True)`)
+
+The PRISMA reader doesn't have analogous concerns so there's no precedent. **Instinct: the method form** — leaves the default behavior untouched (all pixels exposed), but gives users a clean opt-in for resampling pipelines that need it.


### PR DESCRIPTION
## Summary

- New project tree under `projects/geotoolz/` with two parts: design plans and a georeader tutorial.
- **7 design plans** covering the geotoolz umbrella (RS-shaped operator-composition library), reader reconciliation, two-phase catalog (in-memory + DuckDB), ecosystem stack, and sensor-reader designs (geostationary, MODIS).
- **18-chapter georeader tutorial** walking the [spaceml-org/georeader](https://github.com/spaceml-org/georeader) package on the \`feature/geotensor_npapi\` branch module by module, preserving all ~62 ASCII diagrams from docstrings.
- Wires the new project into \`myst.yml\` under Projects.

## Tutorial structure

- **Part I (Ch. 1–3):** core data model — \`GeoTensor\`, abstract reader protocols, \`RasterioReader\`
- **Part II (Ch. 4–6):** reading & windowing — \`window_utils\`, \`read\`, \`slices\`
- **Part III (Ch. 7–10):** geometry & gridding — \`griddata\`, \`mosaic\`, \`rasterize\`, \`vectorize\`
- **Part IV (Ch. 11–13):** radiometry & I/O — \`reflectance\`, \`save\`, miscellaneous utilities
- **Part V (Ch. 14–18):** sensor readers — Sentinel-2, hyperspectral trio (EMIT/PRISMA/EnMAP), Earth Engine, legacy sensors, query/download

## Test plan

- [ ] \`myst start\` renders the new project tree without TOC errors
- [ ] All 19 tutorial files (00_index + 18 chapters) appear under Projects → geotoolz → georeader tutorial
- [ ] All 7 plan files appear under Projects → geotoolz → Plans
- [ ] Inter-chapter links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)