### PR TITLE
docs(geotoolz): motivation rewrite, operational-attribution success story, two-tier model

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -112,6 +112,8 @@ project:
                 - file: projects/plume_simulation/notebooks/radtran/05_matched_filter_retrieval.ipynb
         - title: geotoolz
           children:
+            - file: projects/geotoolz/geostack_notes.md
+            - file: projects/geotoolz/operational_attribution.md
             - title: Plans
               children:
                 - title: geotoolz

--- a/projects/geotoolz/geostack_notes.md
+++ b/projects/geotoolz/geostack_notes.md
@@ -1,0 +1,778 @@
+---
+title: The Modern GeoStack
+subject: The Modern GeoStack
+subtitle: "Motivation and ecosystem map for `geotoolz`, `xrtoolz`, and `GeoCatalog`"
+short_title: GeoStack notes
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: geospatial, ecosystem, motivation, geotoolz, xrtoolz, geocatalog
+---
+
+> **Status:** living motivation document — companion to the per-design specs in [`plans/`](plans/).
+> **Scope:** the modern cloud-native geospatial ecosystem and the gaps that motivate `geotoolz`, `xrtoolz`, and `GeoCatalog`.
+> **Audience:** anyone trying to understand *why* these libraries exist and *where* they sit in the broader stack.
+
+---
+
+## Primer for newcomers
+
+> **ELI5.** Imagine a planetary **shipping network**. **Warehouses** all over the world hold the cargo. **Trucks and ships** move it between ports. **Dock workers** crack open containers and stack the contents on **standard pallets**, which feed **factories** that build finished products. Customers find what they want through a **shipping registry**, and they see the result in **storefronts**.
+>
+> Modern geospatial software is exactly this network — but the cargo is *data* (satellite pixels, climate cubes, building footprints) instead of widgets, and the warehouses span continents and petabytes. The libraries I'm building are the missing pieces in this network: better **factories** for raster and cube data, and a better **registry** to tie everything together.
+
+### The five-layer view
+
+A flattened picture of the whole stack, before the detailed walk-through:
+
+```text
+                       [ STOREFRONT  —  the USER ]
+              ┌─────────────────────────────────────────────┐
+              │     notebook  ·  web map  ·  tile server    │
+              └──────────────────────▲──────────────────────┘
+                                     │
+                       [ FACTORIES  —  the LOGIC ]
+              ┌──────────────────────┴──────────────────────┐
+              │     pixel math  ·  joins  ·  regridding     │
+              │     compose, transform, reduce, render       │
+              └──────────────────────▲──────────────────────┘
+                                     │
+                  [ SHIPPING REGISTRY  —  DISCOVERY ]
+              ┌──────────────────────┴──────────────────────┐
+              │     "what exists, where it lives, what's     │
+              │      inside" — a queryable metadata index    │
+              └──────────────────────▲──────────────────────┘
+                                     │
+                    [ FORKLIFTS  —  the TRANSPORT ]
+              ┌──────────────────────┴──────────────────────┐
+              │   HTTP range requests  ·  concurrent IO     │
+              │   (only fetch the bytes you actually need)  │
+              └──────────────────────▲──────────────────────┘
+                                     │
+                    [ WAREHOUSES  —  the STORAGE ]
+              ┌──────────────────────┴──────────────────────┐
+              │  cloud object stores  ·  S3 / GCS / Azure   │
+              │  raster files · cube stores · tabular files │
+              └─────────────────────────────────────────────┘
+```
+
+Read it from the bottom: bytes sit in **warehouses**, **forklifts** haul them out only when asked, the **registry** tells the forklift *which* warehouse to go to, **factories** turn raw cargo into finished products, and the **storefront** shows it to the human. Every layer above is useless without the one below — but the *registry* is the layer most people skip and then regret.
+
+### Walking down the stack
+
+The stack is eight conceptual layers — same anatomy whether the cargo is a satellite scene, a climate cube, or a building footprint. For each: what it does, how we used to do it, what changed, and what's still awkward.
+
+**1. The warehouses (Storage).** Where the data physically lives. Today these are **object stores** in the cloud — buckets full of files, stacked in racks the size of city blocks, billed by the byte. *Old world:* tape archives, FTP servers, lab NAS appliances. Data lived where the people who collected it happened to work, and you got a copy by emailing someone or `scp`-ing it overnight. *What changed:* one address — `s3://…`, `gs://…` — for everyone, with effectively infinite capacity, and fault-tolerance baked in. *Still awkward:* the bytes alone are dumb; nothing useful happens until something fetches them, and "where exactly is my pallet inside this warehouse?" is a real problem (see layer 7).
+
+**2. The forklifts (Transport).** Getting bytes out of the warehouse and onto your laptop. Modern transport speaks **HTTP** with **range requests** — "give me bytes 4096–8191 of this 10 GB file" — and dispatches many in parallel. *Old world:* full-file FTP downloads, mounted network shares, vendor-specific transfer protocols. If you wanted one tile out of a satellite scene, you downloaded the whole scene. *What changed:* concurrency hides latency; you only pay for what you read; a single laptop can saturate a 10 Gbps link. *Still awkward:* range reads only help if the **file format** lets you compute *which* bytes you want without reading the whole thing first — most pre-2015 formats don't.
+
+**3. The retrofit team (Virtualisation).** A clever hack for legacy cargo. The world has petabytes of data sitting in monolithic file formats (HDF4, HDF5, NetCDF-3) that *aren't* range-readable. Rather than rewrite all of it, the retrofit team scans each old crate once, writes a tiny "where everything is inside" index, and exposes the index so modern forklifts can pretend the old crate is a new one. *Old world:* migrate everything — years of effort, double storage costs while in flight, and political fights over who owns the canonical copy. *What changed:* zero-migration access to legacy archives — the old data didn't move, but it now behaves cloud-native. *Still awkward:* one more layer of indirection to maintain, and the indices go stale when the underlying files change.
+
+**4. The dock workers (Readers).** The code that actually opens a file and turns its bytes into something you can compute on. Modern readers are **asynchronous and concurrent** — many small range reads dispatched in parallel — and *lazy*, deferring work until you ask for the result. *Old world:* synchronous, one-file-at-a-time, blocking; or worse, click-through GUI dialogs in a vendor application (ArcToolbox, ENVI menus). *What changed:* a single Python process can drive thousands of concurrent reads. *Still awkward:* async code is harder to reason about, and each data geometry (raster vs cube vs vector) needs its own specialised reader — there's no one universal "open this geo-thing" function.
+
+**5. The standard pallet (Substrate).** Once cargo is unloaded, what *shape* does it take in memory? The modern answer is a **typed carrier** — an array (or table) that remembers its coordinates: which axis is latitude, which row is "Paris", which column is "geometry", what the units are, what projection the world is in. *Old world:* bare arrays plus sidecar files (`.prj`, `.tfw`, `.hdr`, `.aux.xml`) you had to read by hand and keep in sync. Lose the sidecar, lose the meaning. *What changed:* coordinate-aware operations don't need manual bookkeeping; downstream code stays geographically honest. *Still awkward:* the three data geometries (raster / cube / vector) each have a different idea of "the right pallet" — there isn't yet one universal carrier.
+
+**6. The factories (Compute / engines).** Where the science actually happens — pixel math, regridding, climatologies, spatial joins, ensemble statistics. Modern factories are **composable**: small typed operators chained into pipelines, like Lego blocks for analysis. *Old world:* monolithic GIS suites (ArcGIS, ENVI, GRASS, IDL) where every workflow was a vendor-specific click-trail, plus a long tail of one-off scripts copy-pasted between projects. *What changed:* reusable, testable units that work the same in a notebook, a script, and a server. *Still awkward:* the factory ecosystem is **fragmented** — each data geometry has its own factory, and operators don't always compose cleanly across them. (This is one of the gaps the libraries below try to close.)
+
+**7. The shipping registry (Discovery / Catalog).** The single most underrated layer. A registry knows *what* exists, *where* each pallet is stored, and *what's inside* each container — without having to physically open them. You query the registry first, get back a short list of warehouse addresses, then send the forklifts. *Old world:* directory-of-files plus a README, hand-maintained CSV indices, FGDC metadata XML no one updated, or full-blown enterprise spatial databases for the lucky few. At petabyte scale there are heavyweight standardised registries (you'll meet them later); at lab scale most teams still wing it. *What changed:* the same columnar file format used for tabular data can *hold* the metadata index, queryable with the same SQL engine you already use for analytics — the registry becomes "just another file". *Still awkward:* no universal agreement on *what* metadata to record, and registries decay if no one keeps the crawls running.
+
+**8. The storefront (Viz / UX).** Where humans actually see the result. Modern storefronts are **GPU-accelerated** and **in-browser**, reading straight from cloud storage — interactive maps that fetch tiles on demand and render millions of features at 60 fps. *Old world:* render to PNG, save to disk, open in a desktop GIS (QGIS, ArcMap), or maintain a heavyweight tile-server farm pre-rendering images for the web. *What changed:* the same notebook that ran the analysis can also render the map; the same cloud bytes feed both. *Still awkward:* GPU memory is finite, browsers have limits, and "ship a million polygons to a tablet" is still a real engineering problem.
+
+### Two organising ideas
+
+Borrowing the networking metaphor: the modern stack splits cleanly into a **control plane** and a **data plane**.
+
+- **Control plane (the brain).** Knows *what* exists, *where* it lives, and *how* to find it. This is the **registry** (layer 7).
+- **Data plane (the muscle).** Moves bytes, decodes pixels, runs math. This is layers 1–6 plus 8.
+
+You need both. A registry with no readers is a phone book with no phones; readers with no registry means every workflow re-implements path-globbing and metadata parsing.
+
+### The three stacks
+
+Geospatial data has three fundamentally different geometries, and each gets its own optimised stack — **same eight layers, different specialisations** in each row:
+
+| Stack | Geometry | Cargo (Storage) | Pallet (Substrate) |
+|---|---|---|---|
+| **Imagery** | 2D / 3D pixel grids | tiled-and-overviewed raster files | typed georeferenced array |
+| **Dense** | N-D coordinate cubes | chunked array stores | labelled-coordinate dataset |
+| **Vector** | Discrete features | columnar tabular files | typed spatial table |
+
+The registry sits *above* all three and uses the **vector stack** to govern the other two — i.e., it stores raster and cube metadata as rows in a columnar tabular file and queries them with SQL.
+
+> The rest of this document names the actual tools, walks each of the three stacks layer by layer, shows the byte-by-byte lifecycle of a query in each, and maps the gaps onto the libraries I'm building.
+
+---
+
+## Why this exists
+
+The cloud-native geospatial ecosystem is **mature at the edges** (storage formats, byte transport, viz) and **fragmented in the middle** (slicing, indexing, composition). Three concrete gaps motivate this work:
+
+**1. No unified compute layer for imagery.** `rio-tiler` does web tiles, `rasterio` does GDAL-backed reads, `eo-learn` does workflow DAGs — but nothing composes pixel-level operators (band math, masking, regridding, sensor calibration) over a typed `GeoTensor` carrier with the same ergonomics as PyTorch's `nn.Sequential`. → **`geotoolz`**.
+
+**2. No first-class operator algebra for dense cubes.** `xarray` is a brilliant *substrate* (labelled arrays, coordinates, chunking) but operator composition still happens as ad-hoc function chains. Climatologies, regridding, EOF decompositions, and ensemble statistics all want a shared shape. → **`xrtoolz`**.
+
+**3. No lightweight catalog for personal/lab-scale work.** STAC is the gold standard at petabyte scale, but spinning up a STAC API for a few hundred TB of project data is overkill. A GeoParquet-backed catalog queryable with DuckDB closes the gap between "directory of files" and "full STAC deployment". → **`GeoCatalog`** (see [`plans/geodatabase/`](plans/geodatabase/)).
+
+---
+
+## The unified picture
+
+### The Grand Unified GeoStack
+
+The full stack, with `GeoCatalog` as the discovery layer that ties the three data-plane stacks together:
+
+```{mermaid}
+flowchart TB
+    subgraph UX["Viz / UX"]
+        lonboard
+        titiler
+        Felt
+    end
+
+    subgraph LOGIC["Logic — Engines"]
+        geotoolz["geotoolz<br/>(imagery)"]
+        xrtoolz["xrtoolz<br/>(dense)"]
+        duckdb["DuckDB<br/>(vector)"]
+    end
+
+    subgraph DISC["Discovery — The Glue"]
+        cat["★ GeoCatalog ★<br/>GeoParquet / GeoJSON / STAC"]
+    end
+
+    subgraph SUB["Substrate — Readers"]
+        georeader
+        xarray
+        geopandas[GeoPandas]
+        agt[async-geotiff]
+    end
+
+    subgraph TRANSPORT["Transport — IO"]
+        obstore
+        kerchunk
+        vsi[GDAL / VSI]
+    end
+
+    subgraph STORAGE["Storage — Cloud"]
+        cog[COG]
+        zarr[Zarr]
+        gpq[GeoParquet]
+    end
+
+    UX --> LOGIC
+    LOGIC --> DISC
+    DISC --> SUB
+    SUB --> TRANSPORT
+    TRANSPORT --> STORAGE
+
+    style cat fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
+    style geotoolz fill:#e1f5ff,stroke:#0288d1
+    style xrtoolz fill:#e1f5ff,stroke:#0288d1
+```
+
+ASCII version (kept as the source of truth for terminal/PR review):
+
+```text
+                     [ THE USER / UI LAYER ]
+             ┌──────────────┬──────────────┬──────────────┐
+             │   lonboard   │   titiler    │     Felt     │
+             └──────▲───────┴──────▲───────┴──────▲───────┘
+                    │              │              │
+    ┌─────────────────────────────────────────────────────────────┐
+    │                 [ THE LOGIC LAYER (Engines) ]               │
+    │  geotoolz (Imagery)  ·  xrtoolz (Dense)  ·  DuckDB (Vector) │
+    └──────────────▲───────────────▲───────────────▲──────────────┘
+                   │               │               │
+    ┌──────────────┴───────────────┴───────────────┴──────────────┐
+    │               [ THE DISCOVERY LAYER (The Glue) ]            │
+    │                      ★ GeoCatalog ★                         │
+    │        (Metadata DB: GeoParquet / GeoJSON / STAC)           │
+    └──────────────┬───────────────┬───────────────┬──────────────┘
+                   │               │               │
+    ┌──────────────▼───────────────▼───────────────▼──────────────┐
+    │               [ THE SUBSTRATE / READERS ]                   │
+    │  georeader  ·  xarray  ·  GeoPandas  ·  async-geotiff       │
+    └──────────────┬───────────────┬───────────────┬──────────────┘
+                   │               │               │
+    ┌──────────────▼───────────────▼───────────────▼──────────────┐
+    │               [ THE TRANSPORT LAYER (IO) ]                  │
+    │               obstore  ·  kerchunk  ·  VSI                  │
+    └──────────────┬───────────────┬───────────────┬──────────────┘
+                   │               │               │
+    ┌──────────────▼───────────────▼───────────────▼──────────────┐
+    │               [ THE STORAGE LAYER (Cloud) ]                 │
+    │      COG      ·      Zarr     ·     GeoParquet              │
+    └─────────────────────────────────────────────────────────────┘
+```
+
+### The catalog is the glue
+
+The key move across all three stacks: the **vector stack** (GeoParquet metadata, DuckDB query) is what makes the **imagery** and **dense** stacks navigable. Without a catalog, every workflow re-implements `glob()` + STAC parsing and the boilerplate compounds across projects. Each stack below ends with a **lifecycle of a query** sequence diagram showing exactly how the catalog hand-off works for that data geometry.
+
+---
+
+## The three stacks
+
+Each stack is a **specialised silo** optimised for its data geometry, but they share a common transport foundation (`obstore`) and a common discovery layer (`GeoCatalog`).
+
+### Shared anatomy
+
+The same six layers repeat across all three stacks; only the row contents change.
+
+| Layer | Imagery | Dense | Vector |
+|---|---|---|---|
+| **Storage** | COG | Zarr · HDF5 · NetCDF | GeoParquet · PostgreSQL · FlatGeobuf |
+| **Transport** | `obstore` · GDAL/VSI | `obstore` · `kerchunk` | `obstore` · GDAL/VSI |
+| **Readers** | `RasterioReader` · `async-geotiff` · `lazy-cogs` · `rio-tiler` | `zarr-python` · `icechunk` · `kerchunk` | `pyogrio` · `PostGIS` · `SedonaDB` |
+| **Substrate** | `GeoTensor` · `GeoSlice` (`georeader`) | `DataArray` · `Dataset` · chunks (`xarray`) | `GeoArrow` · `GeoDataFrame` |
+| **Compute** | **`geotoolz`** | **`xrtoolz`** | `DuckDB` · `PostGIS` · `SedonaDB` |
+| **Viz** | `lonboard` · `titiler` · `terracotta` | `lonboard` · Holoviz · Datashader | `lonboard` · Felt |
+
+### Stack A — Imagery (Rasterio territory)
+
+**Focus.** 2D/3D satellite and aerial imagery.
+**Philosophy.** Window-based processing — crop spatial slices from massive COGs via HTTP range requests.
+
+```text
+                ┌──────────────────┐    ┌─────────────────┐
+                │    lonboard      │    │    titiler      │
+   VIZ / UX  →  │  (Jupyter/GPU)   │    │ (Flexible API)  │
+                └────────┬─────────┘    └────────┬────────┘
+                         │                       │
+                ┌────────▼───────────────────────▼───────┐
+   COMPUTE   →  │              geotoolz                  │
+                │   Operator · Sequential · Graph        │
+                └────────────────┬───────────────────────┘
+                                 │ GeoTensor in / out
+                ┌────────────────▼───────────────────────┐
+   SUBSTRATE →  │       georeader (The Object Model)     │
+                │  GeoTensor · GeoSlice · GeoCatalog     │
+                └─────┬─────────────┬───────────────┬────┘
+                      │             │               │
+              ┌───────▼─────┐ ┌─────▼───────┐ ┌─────▼──────┐
+   READERS   →│ Rasterio-   │ │ async-      │ │  rio-      │
+              │ Reader      │ │ geotiff     │ │  tiler     │
+              └──────┬──────┘ └─────┬───────┘ └─────┬──────┘
+                     │              │               │
+              ┌──────▼──────┐       └───────┬───────┘
+   TRANSPORT →│  GDAL / VSI │               ▼
+              │ (Legacy IO) │      ┌─────────────────┐
+              └──────┬──────┘      │     obstore     │
+                     │             │(Rust Byte Mover)│
+                     ▼             └───────┬─────────┘
+              ┌──────────────────────────────────────┐
+   STORAGE   →│   COG (Cloud Optimized GeoTIFF)      │
+              └──────────────────────────────────────┘
+```
+
+#### Layers
+
+**Storage — [COG (Cloud Optimized GeoTIFF)](https://www.cogeo.org/).** A standard GeoTIFF with two structural choices: pixels are organised into internal tiles (typically 256×256 or 512×512), and decimated overviews (½, ¼, ⅛ resolution) are appended to the same file. The IFD (Image File Directory) at the start of the file lists the byte offset and length of every tile and every overview. Because clients can read the IFD with a single small HEAD/GET, then fetch only the tiles overlapping their AOI via HTTP range requests, a 10 GB Sentinel-2 scene becomes a few-MB read for a small region. *Advantage: arbitrary spatial subsetting over HTTP without downloading the whole file.*
+
+**Transport — [`obstore`](https://github.com/developmentseed/obstore) and [GDAL/VSI](https://gdal.org/user/virtual_file_systems.html).** Two parallel paths into cloud storage. **`obstore`** is a Python wrapper around the Rust [`object_store`](https://docs.rs/object_store/) crate — it speaks S3, GCS, Azure Blob, and HTTP natively, dispatches concurrent range requests, and benchmarks 2–5× faster than `fsspec`-based alternatives for byte-range workloads. **GDAL/VSI** is the C++ "Virtual File System" baked into GDAL (`vsis3://`, `vsigs://`, `vsicurl://` etc.), which is what `rasterio` uses by default — mature, ubiquitous, but synchronous, and configured through environment variables (`AWS_*`, `GDAL_HTTP_*`). *Advantage: `obstore` for new async pipelines, GDAL/VSI for the long tail of formats GDAL already understands.*
+
+**Readers — `RasterioReader`, [`async-tiff`](https://github.com/developmentseed/async-tiff), [`rio-tiler`](https://github.com/cogeotiff/rio-tiler), `lazy-cogs`.** This is where bytes become arrays.
+- **`RasterioReader`** — `rasterio`/GDAL-backed, synchronous, the workhorse. Supports every format GDAL does, not just COG. When you just want to open a file and read pixels, this is it.
+- **`async-tiff`** — pure-Rust async COG reader. Parses IFDs and dispatches concurrent tile fetches through `object_store`. No GDAL dependency. Optimised for many-small-tiles workloads (web tile servers, parallel scene processing).
+- **`rio-tiler`** — handles web-tile coordinate math: given an XYZ tile coordinate, compute the COG pixel window, read it, resample to 256×256, encode as PNG/JPEG.
+- **`lazy-cogs`** — slice-on-access logic. Maps out a COG's tile structure without reading any pixels; reads are deferred until the slice is materialised.
+
+*Advantage: pick the reader that matches your concurrency model — sync for scripts, async for servers, lazy for chained pipelines.*
+
+**Substrate — [`georeader`](https://github.com/spaceml-org/georeader).** A small object model that lets every reader hand back the same shape of object, so downstream code doesn't care which reader produced it.
+- **`GeoTensor`** — an N-D array (numpy `ndarray` subclass) carrying its CRS and affine transform, so coordinate-aware ops never lose georeferencing.
+- **`GeoSlice`** — a declarative crop specification (bounds + CRS + optional time window). Decouples *what region* from *which file*.
+- **`GeoData`** — protocol-style container any reader can satisfy.
+- **`GeoCatalog`** — index over `GeoData` instances, queryable by bounds/time/attrs.
+
+*Advantage: a typed carrier means coordinate metadata propagates automatically through pipelines, no `crs=` arguments threaded through every call.*
+
+**Compute — `geotoolz`.** Operator algebra over `GeoTensor`. A single `Operator` is a typed function `GeoTensor → GeoTensor`; `Sequential` composes a linear chain (e.g. `mask → calibrate → NDVI`); `Graph` handles multi-input DAGs (e.g. fusing radar + optical inputs). Mirrors the ergonomics of PyTorch's `nn.Sequential`/`nn.Module` but for georeferenced rasters. *Advantage: composable, testable units with carrier-aware semantics.* See [`plans/geotoolz/`](plans/geotoolz/).
+
+**Viz / UX — [`titiler`](https://github.com/developmentseed/titiler), [`terracotta`](https://github.com/DHI-GRAS/terracotta), [`lonboard`](https://github.com/developmentseed/lonboard).**
+- **`titiler`** — FastAPI-based dynamic tile server. Reads COGs directly from cloud storage and returns XYZ tiles on demand. The standard for "give me a URL, get a slippy map".
+- **`terracotta`** — lighter-weight, SQLite-indexed, pre-processed-tile server. Trades flexibility for raw serving speed.
+- **`lonboard`** — GPU-accelerated Jupyter renderer using deck.gl. Pushes raw arrays straight to the GPU; ideal for inline notebook exploration of millions of pixels.
+
+*Advantage: dynamic vs pre-baked tile serving for production; in-notebook GPU rendering for exploration.*
+
+#### Lifecycle of a query
+
+A user asks for a low-cloud Sentinel-2 mosaic of Paris in 2024:
+
+```{mermaid}
+sequenceDiagram
+    participant U as User
+    participant C as GeoCatalog
+    participant R as Reader<br/>(georeader)
+    participant O as obstore
+    participant S as S3
+    U->>C: SQL: bbox ∩ Paris ∧ date ∈ 2024 ∧ cloud < 10
+    C-->>U: list of COG URLs + metadata
+    U->>R: open(urls, slice=GeoSlice(bbox))
+    R->>O: HEAD + small range read
+    O->>S: HTTP Range (header)
+    S-->>O: COG IFD bytes
+    O-->>R: tile offsets + nodata + CRS
+    R->>R: compute overlapping tile indices
+    par parallel tile fetch
+        R->>O: range read (tile k)
+        O->>S: HTTP Range (tile k)
+        S-->>O: compressed tile bytes
+        O-->>R: tile bytes
+    end
+    R->>R: decompress + assemble window
+    R-->>U: GeoTensor (CRS + affine + array)
+```
+
+**The trick.** The reader makes *two* round trips — first a cheap header read to learn tile layout, then a fan-out of concurrent range reads for just the tiles that overlap the AOI. That's how you turn a 10 GB scene into a 3 MB transfer.
+
+**What's specific.** GDAL/VSI is the *legacy* transport for synchronous readers; `obstore` is the *modern* transport for async readers. `geotoolz` carries `GeoTensor` (CRS + affine + array) end-to-end so operators stay coordinate-aware.
+
+### Stack B — Dense (Xarray territory)
+
+**Focus.** Multi-dimensional scientific grids — climate, weather, oceanography.
+**Philosophy.** Coordinate-based DataCubes. Time, altitude, and variable are physical dimensions of a single labelled array.
+
+```text
+                ┌──────────────────┐    ┌─────────────────┐
+   VIZ / UX  →  │    lonboard      │    │    Holoviz      │
+                │  (GPU Render)    │    │ (Aggregation)   │
+                └────────┬─────────┘    └────────┬────────┘
+                         │                       │
+                ┌────────▼───────────────────────▼───────┐
+   COMPUTE   →  │              xrtoolz                   │
+                │   (N-D Algebra / Regridding / Means)   │
+                └────────────────┬───────────────────────┘
+                                 │ Dataset / DataArray
+                ┌────────────────▼───────────────────────┐
+   SUBSTRATE →  │       xarray (The DataCube Model)      │
+                │     Coordinates · Dimensions · Chunks  │
+                └─────┬──────────────┬──────────────┬────┘
+                      │              │              │
+              ┌───────▼─────┐ ┌──────▼──────┐ ┌─────▼──────┐
+   READERS   →│    Zarr     │ │  Icechunk   │ │  lazy-     │
+              │ (Standard)  │ │ (Versioned) │ │  cogs      │
+              └──────┬──────┘ └──────┬──────┘ └─────┬──────┘
+                     │               │              │
+              ┌──────▼───────────────▼──────┐       │
+   VIRTUAL   →│          kerchunk           │◀──────┘
+              │ (HDF5/NetCDF Virtualization)│
+              └──────────────┬──────────────┘
+                             │
+   TRANSPORT →      ┌────────▼─────────┐
+                    │     obstore      │
+                    └────────┬─────────┘
+                             ▼
+              ┌──────────────────────────────────────┐
+   STORAGE   →│     Zarr  ·  HDF5  ·  NetCDF         │
+              └──────────────────────────────────────┘
+```
+
+#### Layers
+
+**Storage — [Zarr](https://zarr.dev/), [HDF5](https://www.hdfgroup.org/solutions/hdf5/), [NetCDF](https://www.unidata.ucar.edu/software/netcdf/).** All three store N-D arrays plus metadata, but with very different physical layouts.
+- **Zarr** is *cloud-native by design*: the array is split into chunks, each chunk is a separate file (e.g. `var/0.0.5`), and metadata lives in small JSON files (`.zarray`, `.zattrs`). Readers fetch only the chunks they need.
+- **HDF5 / NetCDF-4** are *legacy* monolithic binary formats — single big files with internal B-tree indices. Brilliant on local disk; painful in object storage because reading any chunk often requires walking the tree, which means many small range reads.
+
+*Advantage of Zarr: parallel reads/writes scale linearly with object-store concurrency. Advantage of HDF5/NetCDF: ubiquitous in climate science and decades of tooling.*
+
+**Transport — [`obstore`](https://github.com/developmentseed/obstore).** Same Rust-backed mover as Stack A. Zarr's "many small files" workload is exactly what `object_store` is tuned for — concurrent GETs without the per-request overhead of `s3fs`/`gcsfs`. *Advantage: makes a Zarr that lives in S3 feel like a Zarr that lives on a fast local disk.*
+
+**Virtualisation — [`kerchunk`](https://github.com/fsspec/kerchunk) / [VirtualiZarr](https://github.com/zarr-developers/VirtualiZarr).** A clever trick for the legacy formats: scan an HDF5/NetCDF file once, record the byte offsets of every chunk into a small JSON or Parquet "reference file", then expose that reference as a virtual Zarr store. Readers see a Zarr; under the hood `obstore` is doing range reads into the original HDF5. *Advantage: no rewriting of petabytes of legacy data — you get cloud-native access patterns for free.*
+
+**Readers — [`zarr-python`](https://github.com/zarr-developers/zarr-python), [`Icechunk`](https://icechunk.io/), `lazy-cogs`.**
+- **`zarr-python`** — the canonical Zarr reader. Recently (Zarr v3) gained a Rust-backed obstore-aware backend.
+- **`Icechunk`** — Earthmover's transactional, version-controlled storage engine on top of Zarr. Adds Git-like snapshots, atomic commits, and time-travel to climate datasets — critical when you're updating a global temperature cube nightly and need rollback semantics.
+- **`lazy-cogs`** — used here in reverse, to expose stacks of COGs as virtual coordinates so an Xarray user can treat them as a single cube.
+
+*Advantage: `zarr-python` for vanilla cubes, `Icechunk` when you need ACID-like guarantees on a writable cube.*
+
+**Substrate — [`xarray`](https://docs.xarray.dev/).** The de-facto Python model for labelled N-D arrays.
+- **`DataArray`** — a single N-D array with named dimensions and labelled coordinates (e.g. *temperature* at specific *lat*, *lon*, *time*).
+- **`Dataset`** — a dict-like container of `DataArray`s sharing coordinates (e.g. *temperature* + *humidity* on the same grid).
+- **Chunks** — internal subdivisions allowing Dask (or other engines) to process the cube in parallel.
+
+*Advantage: coordinate-aware indexing (`ds.sel(time="2024-06", lat=slice(45, 50))`) means you write the science in the units of the science, not array indices.*
+
+**Compute — `xrtoolz`.** Operator algebra over `xarray.Dataset`/`DataArray`, mirroring `geotoolz` but for cubes. Targets the recurring patterns: climatologies (rolling means, seasonal anomalies), regridding (between map projections), EOF / spectral decompositions, and ensemble statistics. *Advantage: composable units that respect xarray's labelled-coordinate semantics, instead of ad-hoc `groupby().mean()` chains scattered across notebooks.*
+
+**Viz / UX — [`lonboard`](https://github.com/developmentseed/lonboard), [HoloViz](https://holoviz.org/) ([Datashader](https://datashader.org/), [hvPlot](https://hvplot.holoviz.org/)).**
+- **`lonboard`** — pushes raw grid values to the GPU for real-time interaction with scientific data.
+- **HoloViz / Datashader** — server-side aggregation of massive grids into browser-readable rasters. Essential when the data exceeds millions of points and naive rendering would melt the browser.
+
+*Advantage: GPU rendering for interactive exploration; server-side aggregation for browser-friendly delivery of huge cubes.*
+
+#### Lifecycle of a query
+
+A climate scientist asks for monthly mean SST over the North Atlantic for 1990–2024:
+
+```{mermaid}
+sequenceDiagram
+    participant U as User
+    participant C as GeoCatalog
+    participant X as xarray
+    participant O as obstore
+    participant S as S3
+    U->>C: query: collection=ERA5, var=sst
+    C-->>U: Zarr URL
+    U->>X: xr.open_zarr(url)
+    X->>O: GET .zmetadata (consolidated)
+    O->>S: HTTP GET
+    S-->>O: schema + chunk grid + coords
+    O-->>X: lazy Dataset (no chunks read yet)
+    U->>X: ds.sst.sel(lat=slice(20,60), lon=slice(-80,0), time=slice("1990","2024"))
+    X->>X: map coord ranges → chunk indices
+    par parallel chunk fetch
+        X->>O: GET chunk (t_i, lat_j, lon_k)
+        O->>S: HTTP GET
+        S-->>O: compressed chunk bytes
+        O-->>X: chunk array
+    end
+    X->>X: decompress + assemble + (optional) Dask graph
+    U->>X: .groupby("time.month").mean()
+    X-->>U: DataArray (12, n_lat, n_lon)
+```
+
+**The trick.** Coordinate selection (`.sel`) is translated into chunk indices *before* any bytes are read; only the chunks intersecting the requested coordinate hyperrectangle are fetched. Lazy evaluation through Dask means downstream reductions (`.mean()`) collapse the chunk-fetch + compute graph into a single optimised pass.
+
+**What's specific.** A *virtualisation* layer (`kerchunk`) sits between readers and transport — it makes legacy HDF5/NetCDF behave like Zarr without rewriting the underlying files. `xrtoolz` provides operator composition over `Dataset`/`DataArray` (climatologies, regridding, EOFs, ensemble statistics).
+
+### Stack C — Vector (GeoPandas territory)
+
+**Focus.** Discrete features — points, lines, polygons, and their attributes.
+**Philosophy.** Tabular and relational. Geography is just another column in a high-performance database.
+
+```text
+                ┌──────────────────┐    ┌─────────────────┐
+   VIZ / UX  →  │    lonboard      │    │      Felt       │
+                │ (GeoArrow/GPU)   │    │ (Collaborative) │
+                └────────┬─────────┘    └────────┬────────┘
+                         │                       │
+                ┌────────▼───────────────────────▼───────┐
+   ENGINES   →  │      DuckDB SQL  /  GeoPandas          │
+                │    (Spatial Joins / Buffers / Filters) │
+                └────────────────┬───────────────────────┘
+                                 │ GeoArrow / DataFrames
+                ┌────────────────▼───────────────────────┐
+   SUBSTRATE →  │    GeoArrow (The Memory Layout)        │
+                │   Zero-copy Tabular Spatial Streams    │
+                └─────┬──────────────┬──────────────┬────┘
+                      │              │              │
+              ┌───────▼─────┐ ┌──────▼──────┐ ┌─────▼──────┐
+   READERS   →│   pyogrio   │ │   PostGIS   │ │  SedonaDB  │
+              │ (Fast OGR)  │ │ (Database)  │ │ (Big Data) │
+              └──────┬──────┘ └──────┬──────┘ └─────┬──────┘
+                     │               │              │
+   TRANSPORT →       └───────┬───────┴──────────────┘
+                             ▼
+                    ┌─────────────────┐
+                    │     obstore     │
+                    └────────┬────────┘
+                             ▼
+              ┌──────────────────────────────────────┐
+   STORAGE   →│  GeoParquet · PostgreSQL · FlatGeobuf│
+              └──────────────────────────────────────┘
+```
+
+#### Layers
+
+**Storage — [GeoParquet](https://geoparquet.org/), [PostgreSQL/PostGIS](https://postgis.net/), [FlatGeobuf](https://flatgeobuf.org/).**
+- **GeoParquet** — the modern standard. Apache Parquet (columnar, compressed, partitioned into row groups) with a spec extension for storing geometries (WKB or GeoArrow encoding) and per-row-group bbox statistics. Cloud-native, range-readable, predicate-pushdown friendly.
+- **PostgreSQL + PostGIS** — the relational gold standard for stateful, multi-user vector data. Stores geometries as binary blobs with R-tree (GiST) indexes; handles concurrent writes and complex spatial joins.
+- **FlatGeobuf** — a streamable flatbuffer format with a packed Hilbert R-tree at the start of the file. Allows fast spatial filtering over plain HTTP without any SQL engine.
+
+*Advantage: GeoParquet for analytical workloads on cloud storage; PostGIS for transactional / multi-user; FlatGeobuf for lightweight HTTP-only access patterns.*
+
+**Transport — [`obstore`](https://github.com/developmentseed/obstore), [GDAL/VSI](https://gdal.org/user/virtual_file_systems.html).** `obstore` pulls Parquet row groups from cloud storage; GDAL/VSI is what `pyogrio` uses to interface with the long tail of vector formats (GPKG, SHP, GeoJSON, KML, …). *Advantage: same dual-path story as Stack A — modern async path for Parquet, mature GDAL path for legacy formats.*
+
+**Readers — [`pyogrio`](https://github.com/geopandas/pyogrio), [PostGIS](https://postgis.net/), [Sedona](https://sedona.apache.org/).**
+- **`pyogrio`** — vectorised interface to GDAL/OGR vector drivers. Reads/writes via Arrow buffers, an order of magnitude faster than the legacy `fiona`-based path.
+- **PostGIS** — the actual reader for rows out of a PostgreSQL spatial table; uses GiST indexes for spatial filtering.
+- **Apache Sedona** — distributed engine for petabyte-scale vector data on Spark/Flink clusters. The right tool when "global road network" or "every building footprint on Earth" doesn't fit on one machine.
+
+*Advantage: `pyogrio` for single-node analytics, PostGIS for transactional, Sedona for distributed.*
+
+**Substrate — [GeoArrow](https://geoarrow.org/), [GeoPandas](https://geopandas.org/).**
+- **GeoArrow** — a standardised Arrow memory layout for spatial data. Geometries are stored as native Arrow extension types (interleaved or struct coordinates), so DuckDB can hand a query result to `lonboard` *without re-serialising* — both speak Arrow buffers.
+- **GeoPandas** — the Python `DataFrame`-with-a-geometry-column standard. Familiar pandas-like API; in-memory, single-node.
+
+*Advantage: GeoArrow's zero-copy hand-off eliminates the "serialise to GeoJSON, parse, re-serialise" tax that used to dominate vector pipelines.*
+
+**Compute / Engines — [DuckDB](https://duckdb.org/) (with [`spatial`](https://duckdb.org/docs/extensions/spatial/overview)), [PostGIS](https://postgis.net/), [Sedona](https://sedona.apache.org/).**
+- **DuckDB + `spatial`** — in-process SQL engine that reads GeoParquet directly from S3, with predicate pushdown on the bbox column. The closest thing the geospatial world has to "SQLite for analytics".
+- **PostgreSQL + PostGIS** — production multi-user spatial database. Concurrent writes, complex joins, mature query planner.
+- **Sedona** — distributed spatial SQL on Spark.
+
+*Advantage: DuckDB collapses a whole category of "load shapefile → filter in pandas" workflows into a single SQL statement against cloud storage. **This is the engine that powers `GeoCatalog`.***
+
+**Viz / UX — [`lonboard`](https://github.com/developmentseed/lonboard), [Felt](https://felt.com/).**
+- **`lonboard`** — pushes GeoArrow buffers directly to the GPU via deck.gl. Renders millions of polygons smoothly inside Jupyter.
+- **Felt** — collaborative web mapping for sharing finished vector products with non-technical stakeholders.
+
+*Advantage: GPU-rendered interactive exploration in notebooks; collaborative web sharing for handoff.*
+
+#### Lifecycle of a query
+
+An analyst asks for all building footprints in a flood zone:
+
+```{mermaid}
+sequenceDiagram
+    participant U as User
+    participant D as DuckDB<br/>(spatial)
+    participant O as obstore
+    participant S as S3
+    U->>D: SELECT * FROM 's3://buildings.parquet'<br/>WHERE ST_Intersects(geom, :flood_bbox)
+    D->>O: GET Parquet footer (small range)
+    O->>S: HTTP Range
+    S-->>O: row-group stats (bbox per group)
+    O-->>D: footer parsed
+    D->>D: predicate pushdown — drop non-intersecting groups
+    par parallel row-group fetch
+        D->>O: GET row-group k (geom + attr columns only)
+        O->>S: HTTP Range
+        S-->>O: column chunks
+        O-->>D: Arrow record batch
+    end
+    D->>D: ST_Intersects on candidates (refine)
+    D-->>U: GeoArrow result table
+    U->>U: hand to lonboard / GeoPandas (zero-copy)
+```
+
+**The trick.** Two stages of filtering: (1) **row-group pruning** using the bbox statistics in the Parquet footer skips entire row groups that can't possibly intersect, and only the surviving groups are fetched. (2) **column pruning** means non-needed attribute columns are never read off the wire. The result lands as Arrow buffers, so the hand-off to `lonboard` or GeoPandas is zero-copy.
+
+**What's specific.** `GeoArrow` enables *zero-copy* hand-off — DuckDB can stream query results straight into `lonboard` without re-serialisation. This is also the stack that powers `GeoCatalog`: the catalog *is* a GeoParquet file queried with DuckDB.
+
+---
+
+## Where my libraries fit
+
+Most of the modern stack is **already there**. Two of the three libraries below (`georeader` modernisation, `GeoCatalog`) are *reconciliation* work — taking pieces that already work and giving them a coherent surface. The third (`geotoolz` + `xrtoolz`) is the genuinely missing piece: the **factory layer** that doesn't yet have a good general-purpose shape.
+
+```{mermaid}
+flowchart TB
+    USER["<b>USER</b><br/>notebook · API · map"]
+    LOGIC["<b>LOGIC</b><br/>★ geotoolz   ·   ★ xrtoolz<br/><i>future: geoarrax (JAX bridge)</i>"]
+    DISC["<b>DISCOVERY</b><br/>★ GeoCatalog<br/>(GeoParquet + DuckDB)"]
+    SUBS["<b>SUBSTRATE</b><br/>★ georeader (unified Reader Protocol)"]
+    TRANS["<b>TRANSPORT</b><br/>obstore · GDAL/VSI"]
+    STOR["<b>STORAGE</b><br/>COG · Zarr · GeoParquet"]
+
+    USER --> LOGIC --> DISC --> SUBS --> TRANS --> STOR
+
+    style LOGIC fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
+    style DISC fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
+    style SUBS fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
+```
+
+Stars mark where my libraries plug in. Read it from the top: a user wants something → engines compose carriers → the registry tells them which files to open → readers translate cloud bytes into typed carriers → transport hauls only the bytes needed → cloud storage is the source of truth.
+
+---
+
+### 1. Modernising `georeader` *(reconciliation, not invention)*
+
+`georeader` already gives us a clean object model: **`GeoTensor`** (georeferenced array), **`GeoSlice`** (declarative crop), and a small reader surface anchored on **`RasterioReader`**. What it doesn't yet have is a *protocol* — a shared shape every reader can satisfy — which means newer readers (async, lazy) reinvent the substrate every time.
+
+**What plugs in.**
+- **[`async-tiff`](https://github.com/developmentseed/async-tiff)** — pure-Rust async COG reader. Drops in as `AsyncGeoTIFFReader` behind a shared `AsyncReader` Protocol.
+- **`lazy-cogs`** — lazy slice-on-access logic. Drops in as `LazyCOGReader`, GDAL-free.
+- **[`obstore`](https://github.com/developmentseed/obstore)** — the byte mover for both, abstracted behind a `ByteStore` Protocol so `fsspec` users aren't locked out.
+
+**What falls out for free.** A unified **`Reader` Protocol** (`SyncReader` + `AsyncReader` surfaces, anchored on a small `_ReaderMeta` metaclass); cross-cutting types (`GeoSlice`, `Credential`, `ByteStore`) extracted to a shared home in [`plans/types/`](plans/types/) instead of being buried in whichever subsystem first needed them; existing `RasterioReader` keeps doing what it does well; new async/lazy readers stop re-inventing the carrier.
+
+**Sensor-specific readers built on the same Protocol.** Once the Reader Protocol stabilises, per-sensor readers slot in without re-inventing the substrate — each handles its own quirks (`+proj=geos` affines, bowtie distortion, irregular file formats) but emits the same `GeoTensor` carrier:
+
+- **Geostationary** — `ABI_L1b` (GOES), `SEVIRI_Native` (Meteosat), with `MTG_FCI`, `Himawari_AHI` HSD, and `SEVIRI_HRIT` queued.
+- **Polar-orbiting** — `MODIS_L1B` (Terra/Aqua), `VIIRS_L1B` (S-NPP/JPSS).
+- **Public bucket helpers** — one-line URL constructors for the AWS/GCS open-data buckets each sensor lives in.
+
+→ [`plans/readers/`](plans/readers/) for the per-sensor designs.
+
+**Honest framing.** This isn't a new library. It's a refactor that turns several already-working tools into a coherent stack with a single Reader Protocol surface. *It's the prerequisite for everything else below* — `geotoolz` operators don't compose if every reader hands back a different shape of object.
+
+→ Designs: [`plans/georeader/`](plans/georeader/), [`plans/types/`](plans/types/), [`plans/readers/`](plans/readers/).
+
+---
+
+### 2. `GeoCatalog` — *the registry as a file*
+
+The pitch in one line: **store metadata as GeoParquet, query it with the tool that fits the scale — GeoPandas for most cases, DuckDB when the catalog gets big.**
+
+**Why now.** [STAC](https://stacspec.org/) is the gold-standard registry at petabyte scale where you have a team running an API. It's overkill for the *lab-scale* problem most teams actually have: a few TB of project data on object storage that you want to slice by bbox + date + attribute without spinning up infrastructure. Meanwhile [GeoParquet](https://geoparquet.org/), [GeoPandas](https://geopandas.org/), and [DuckDB Spatial](https://duckdb.org/docs/extensions/spatial/overview) have matured to the point where the metadata index can be *just another file*.
+
+**Two backends, one API.**
+
+- **Phase 1 — GeoPandas in memory.** The catalog is *literally* a `geopandas.GeoDataFrame` with a `pd.IntervalIndex` for time. R-tree spatial indexing and interval-tree temporal lookup come for free from the existing libraries — no new spatial data-structure code. This handles the **90% case**: ≤10⁵ rows, fits in RAM, runs without a query engine. Round-trip via `to_geoparquet(...)` / `from_geoparquet(...)` for portability.
+- **Phase 2 — DuckDB on GeoParquet.** When the catalog grows past ~10⁶ rows or has to live in cloud storage, the same API switches to a `DuckDBGeoCatalog`. SQL queries with predicate pushdown via the GeoParquet 1.1 bbox column; no daemon, no server. Most projects never need this — but the upgrade path is one constructor swap.
+
+**The point: GeoParquet is the artifact, GeoPandas is the default tool, DuckDB is the scale-up.** You can do 90% of analysis with just the first two — `gpd.read_parquet(...)` plus the geopandas API you already know — and the third joins in transparently when row counts demand it.
+
+**What's in the API.**
+- **Builders** — one per substrate (`build_raster_*`, `build_xarray_*`, `build_vector_*`). Crawl storage once, extract bounds + CRS + timestamps, emit a `GeoCatalog`. Sensor-aware presets handle Sentinel-1/2, MODIS, VIIRS, ABI, SEVIRI, etc.
+- **Loaders** — return `GeoTensor` (raster) or `xr.Dataset` (xarray-backed) for each catalog row, ready to compose with operators downstream.
+- **Samplers** — `random_geo_sampler`, `grid_geo_sampler` produce `GeoSlice` objects from the catalog; `stitch_predictions` reassembles inference outputs back into geographic coordinates.
+- **Set algebra** — `intersect`, `union`, `query` for cross-catalog operations (raster × label fusion, multi-sensor pairing, change-detection across epochs).
+- **Adapters** — `GeoDataset` (torch `IterableDataset`); STAC read/write so a STAC catalogue can be lifted into the lighter format and back.
+
+**Honest framing.** Nothing here is new technology. The contribution is the **convention** — the canonical schema, the IntervalIndex+R-tree pairing, the GeoParquet 1.1 bbox column convention — plus a thin Python API that hides the schema and connection plumbing. STAC-compatible read/write keeps the door open when you scale past lab size.
+
+→ Designs: [`plans/geodatabase/geocatalog.md`](plans/geodatabase/geocatalog.md) (Phase 1, GeoPandas), [`plans/geodatabase/geoduckdb.md`](plans/geodatabase/geoduckdb.md) (Phase 2, DuckDB).
+
+---
+
+### 3. `geotoolz` + `xrtoolz` — *the factory layer that's missing*
+
+This is the part of the stack where I keep hitting the same gap, regardless of which institution or project I'm working at. The storage / transport / discovery layers have gotten brilliant. The **research-notebook → operational-pipeline** leap is still mostly hand-rolled glue.
+
+#### What shape is actually missing?
+
+There *are* operator-flavoured libraries in the geospatial ecosystem. Each is excellent at what it does. None of them hits all three of *typed carrier* + *composable algebra* + *backend-agnostic execution*:
+
+- **[`eo-learn`](https://github.com/sentinel-hub/eo-learn)** (Sentinel Hub) — workflow DAG over Earth-observation tasks. Wraps each step as an `EOTask` operating on a heavyweight `EOPatch` container, chained via `EOWorkflow`. **Different shape:** tightly coupled to `EOPatch` (not a general-purpose carrier); `EOWorkflow` is a *workflow runner*, not an operator algebra in the `nn.Module` sense; designed for batch processing, less so for interactive composition; doesn't address the dense-cube domain.
+- **[`torchgeo`](https://github.com/microsoft/torchgeo)** — PyTorch-native datasets, samplers, and model architectures for ML on remote-sensing imagery. **Different shape:** ML-pipeline focused (`Dataset`/`DataLoader`/`LightningModule`), not a general analysis library; no `Sequential`-style composition for non-ML transforms; doesn't cover cubes.
+- **[`xclim`](https://github.com/Ouranosinc/xclim)** (Ouranos) — climate indicators on `xarray` with rigorous CF-convention handling. **Different shape:** a domain-specific function library tied to climate-index semantics; no composition primitives; each indicator is a standalone callable.
+- **[`xesmf`](https://github.com/pangeo-data/xESMF)** — regridding between map projections via ESMF. **Different shape:** a single-capability tool, brilliant at it; doesn't claim to be more.
+- **[`xarray-spatial`](https://github.com/makepath/xarray-spatial)** — spatial-analytics primitives (slope, aspect, hillshade, viewshed, focal stats). **Different shape:** a pure-function library; no typed-operator surface, no composition machinery, no backend abstraction.
+- **[`coordax`](https://github.com/neuralgcm/coordax)** (Google / NeuralGCM) — a JAX-native labelled-array library from the NeuralGCM team. Coordinate-aware arrays in the spirit of xarray but built for the differentiable / JAX ecosystem. **Closest thing to the missing carrier shape.** Different shape relative to the *operator-algebra* gap: `coordax` solves the carrier (and the JAX backend) but does not itself ship `Operator`/`Sequential`/`Graph` composition. **The honest take: `xrtoolz` should probably build *on top of* `coordax` rather than reinvent the carrier — and if `coordax` matures further, much of the cube-side work collapses to "just add the operator-algebra layer".**
+- **[`geocube`](https://github.com/corteva/geocube)** — vector-to-raster rasterisation. Narrow scope.
+- **[`rio-cogeo`](https://github.com/cogeotiff/rio-cogeo)**, **[`pyresample`](https://github.com/pytroll/pyresample)**, **[`rasterio.features`](https://rasterio.readthedocs.io/en/stable/topics/features.html)** — single-purpose utility libraries, not algebras.
+
+What's missing is a **general-purpose operator algebra over typed georeferenced carriers** — the `nn.Module`/`Sequential`/`Graph` shape, but for `GeoTensor` (raster) and `Dataset`/`DataArray`/`coordax.Array` (cube). The libraries above each fill *one or two* of those properties; none combines all three. `coordax` gets us closest, and is treated below as a likely *foundation* for the cube side rather than competition.
+
+#### The two-layer ladder *(Keras-style progression of complexity)*
+
+One of the best lessons from Keras is that **complexity should be opt-in**. Beginners reach for `model = Sequential([Dense(10), Dense(1)])`; experts reach for the functional API or `Module` subclasses. The same library scales with the user's expertise. `geotoolz` and `xrtoolz` apply the same lesson:
+
+- **Layer 0 — Primitives.** Pure `np.ndarray → np.ndarray` functions, jaxtyped at the signature (`Float[ndarray, "*batch bands H W"]`) so callers see expected dimensions in their IDE. `ndvi(arr)`, `mask(arr, cloud_mask)`, `lee_speckle(arr, window=7)`. Drop-in replacements for the one-liner you'd write today; nothing to learn beyond Python functions + jaxtyping shape annotations.
+- **Layer 1 — Operators.** Composable typed objects on the carrier: `NDVI()`, `Mask()`, `LeeSpeckle()`. Take and return `GeoTensor`. Plug into `Sequential` chains and `Graph` DAGs. Pickle-able, version-pinnable, swappable, testable in isolation.
+
+The same operation lives at both layers — `NDVI()(tensor)` and `ndvi(np.asarray(tensor))` produce the same result. The choice is ergonomic, not semantic. *This is the on-ramp that lets a researcher write a one-liner today, lift it into a pipeline tomorrow, and ship it as a serving endpoint next month — without rewriting.*
+
+*(`geotoolz` deliberately ships **only** these two tiers, where its sibling `xrtoolz` ships three. The asymmetry is architectural: `GeoTensor` is an `np.ndarray` subclass with `__array_ufunc__`, so metadata round-trips through ufunc-pure primitives for free, and non-ufunc primitives get wrapped at the Operator boundary in a single line. `xarray.DataArray` is composition over `ndarray`, not a subclass — its middle "tensor function" tier earns its keep. Substrate dictates tier count.)*
+
+#### The pattern
+
+- **`Operator`** — a typed function `Carrier → Carrier`. Stateful when needed (config, learnable weights), stateless otherwise.
+- **`Sequential`** — a linear chain of operators with type-checked composition.
+- **`Graph`** — a multi-input DAG built from `Input` and `Node` primitives, for fusion workflows (e.g. radar + optical + DEM into a single classifier).
+- **`ModelOp`** — a framework-agnostic operator that wraps any callable from `torch`, `jax`, or `sklearn`. Inference becomes just another node in the graph.
+- **Sensor presets** — one-line constructors (`Sentinel2RGB()`, `S2NDVI()`, `EmitMethanePlume()`, …) that pre-configure entire pipelines for common sensors. Newcomers get a working pipeline in a single line; experts pop the hood and inspect the operator chain.
+- **Hydra / hydra-zen friendly.** Every Operator is config-serialisable, so YAML-driven pipelines are first-class — the same graph runs from a notebook, a script, or a config file.
+- **Carrier-aware.** CRS, transform, coordinates, units, fill values propagate automatically. The pipeline stays geographically honest without manual bookkeeping.
+- **Backend-agnostic.** ***Carriers determine the surface, backends determine the scale.***
+
+#### Why this matters — the use-case spectrum
+
+The same operator graph supports:
+
+- **Research notebooks** — composition of typed building blocks beats a 200-line one-shot script. Easier to read, easier to share.
+- **Production pipelines** — the same graph runs in CI, batch jobs, scheduled tasks. No translation step.
+- **Backend APIs / model serving** — lift the research graph straight into a FastAPI handler or a streaming worker. The operator graph *is* the request handler. No glue layer to maintain.
+- **Reproducibility & governance** — operator graphs are serialisable, version-pinnable, and auditable. Run the same analysis on the same inputs years later; ship it as a regulatory deliverable; diff two analyses.
+- **Composability across teams** — operators are installable units. A colleague's calibration operator drops into your pipeline like a Python package, because it *is* one. (`eo-learn`'s vision tied to `EOPatch`; this version is carrier-typed and lighter.)
+- **Testability** — every operator is a typed function. Golden-file regression tests, property-based tests, and isolation testing become trivial.
+- **Education / pedagogy** — composition of typed blocks is easier to teach than monolithic notebooks. Students learn the *shape* of an analysis instead of memorising a script.
+
+The throughline: **the gap I keep running into, across affiliations and projects, is the research-to-production translation step.** The modern stack has gotten brilliant at storage and transport; the *factory layer* that lets a research idea graduate into operational infrastructure without a rewrite is still mostly hand-rolled. That's what these libraries aim at.
+
+#### The scale spectrum
+
+The same composition pattern carries across data sizes — *the carrier determines the surface, the backend determines the scale*:
+
+| Regime | Data size | Backend | Typical workflow |
+|---|---|---|---|
+| **Small** | fits in RAM | numpy | interactive notebook, single-scene analysis — operators run as-is |
+| **Medium** | fits on one box, doesn't fit in RAM | Dask, async batch, Ray | per-tile parallel processing, daily-scale pipelines — same operators dispatched per chunk/tile |
+| **Big** | needs a cluster | distributed JAX (via `coordax`) | continental-scale ensemble analyses — same composition pattern, JAX-backed carriers |
+
+The architectural commitment: operators don't bake in a backend. They run on whatever the carrier wraps.
+
+**Honest scope.** "Same operator everywhere" holds for **single-machine numpy, Dask-orchestrated batch, and distributed JAX** — same composition pattern, sometimes with backend-specific implementations under one signature. Sedona / Spark and other distributed-SQL engines are *not* covered by the same code path; if you need them, the operator graph would have to emit Sedona SQL, which is a separate library and not currently planned. We'd rather deliver the 80% case cleanly than over-promise the 100%.
+
+#### Honest research-to-prod scope
+
+"Production" is a slippery word. The marquee pitch — *the same operator graph runs in a notebook and a serving endpoint* — holds for these targets:
+
+- ✅ **Notebooks** (Jupyter, Marimo) — the native habitat.
+- ✅ **Scripts** (`python pipeline.py`) — pickle-able Operator graphs.
+- ✅ **Backend APIs** (FastAPI, Litestar, Flask) — Operator graph as the request handler.
+- ✅ **Workflow orchestrators** (Airflow, Prefect, Dagster) — pickle-able graphs as task units.
+- ✅ **Per-tile batch** (Dask, Ray, Modal, async-driven) — one graph per tile, parallelism at the orchestration layer.
+
+What is *not* directly covered:
+
+- ⚠️ **Distributed SQL engines** (Sedona, Spark, Snowflake) — different paradigm. Would require emitting SQL from operator graphs (out of scope, possible future work).
+- ⚠️ **Streaming pipelines** (Flink, Beam, Kafka Streams) — operator graphs aren't streaming-aware. Wrapping each Operator as a Flink UDF works but loses composition guarantees.
+- ⚠️ **Edge / mobile inference** (TFLite, ONNX runtime on mobile) — `ModelOp` wraps a callable; if the callable is exportable (ONNX), you ship the *model*, not the surrounding pre/post-processing operators.
+
+The 80% case (notebook → API / pipeline / orchestrator / batch) is the deliverable target. The 20% (streaming, distributed SQL, edge) is acknowledged out-of-scope rather than promised and missed.
+
+#### Specialisations
+
+- **`geotoolz`** — carrier = **`GeoTensor`**. Domain = imagery (band math, cloud masking, atmospheric calibration, sensor presets, tile assembly, reprojection). Mirrors the "PyTorch for georeferenced rasters" shape. → [`plans/geotoolz/`](plans/geotoolz/).
+- **`xrtoolz`** — carrier = **`xarray.Dataset` / `DataArray`**, with a JAX-native option via **[`coordax`](https://github.com/neuralgcm/coordax)** (NeuralGCM's labelled-array library). Domain = dense cubes (climatologies, regridding, EOFs, anomalies, ensemble statistics, spectral analysis). The carrier story is largely already solved — `xarray` for numpy/Dask, `coordax` for JAX — so `xrtoolz`'s contribution is the *operator-algebra layer* on top, mirroring `geotoolz`'s `Operator`/`Sequential`/`Graph` shape. Don't reinvent the array; build the algebra. → [github.com/jejjohnson/xr_toolz](https://github.com/jejjohnson/xr_toolz).
+
+---
+
+### 4. Supporting infrastructure
+
+The cross-cutting types that flow *between* layers each get their own design — small, but load-bearing.
+
+- **`GeoSlice`** — declarative crop specification (bbox + CRS + optional time window). Decouples *what region* from *which file*; produced by samplers, consumed by readers and operators. → [`plans/types/geoslice.md`](plans/types/geoslice.md).
+- **`Credential`** — Protocol + per-cloud subclasses (Azure SAS / managed identity, AWS static / profile, GCS service account) + `from_config(...)` factory. Replaces the env-var-soup pattern every project currently re-implements. → [`plans/types/credentials.md`](plans/types/credentials.md).
+- **`ByteStore`** — Protocol over the cloud byte interface. `ObstoreByteStore` and `FsspecByteStore` adapters mean readers don't lock you into one transport library. → [`plans/types/bytestore.md`](plans/types/bytestore.md).
+
+---
+
+### Future work — JAX bridge *(via `coordax`)*
+
+`GeoTensor` is a `numpy.ndarray` subclass — fine for 99% of cases, but it walls off **differentiability**. The future-work direction is a thin bridge that translates `GeoTensor ↔ jax.Array` (most likely via `coordax`'s coordinate-aware array) while preserving CRS / transform metadata, opening the door to:
+
+- **Differentiable operators** — calibration, atmospheric correction, geometric warps as learnable layers.
+- **Surrogate models** — physics-informed networks where the simulator and the data sit in the same operator graph.
+- **End-to-end training** — gradients propagating through the geospatial pipeline.
+
+The bridge does **not** need to be invented from scratch — [`coordax`](https://github.com/neuralgcm/coordax) is JAX-native, coordinate-aware, and probably the right backbone. The real work is the `GeoTensor ↔ coordax.Array` adapter and the CRS-preserving operator implementations, not a new array library. (An earlier working name for this glue was `geoarrax`; if `coordax` keeps maturing, even the glue may shrink to a handful of converter functions.)
+
+Out of scope for the initial library push; flagged here so the architecture leaves room for it — operators avoid `numpy`-only assumptions, carriers stay duck-typed where possible.
+
+---
+
+### Reference: library × layer × design
+
+| Library / module | Layer | Status | Design doc |
+|---|---|---|---|
+| `georeader` (modernised) | Substrate / Readers | Reconciliation refactor | [`plans/georeader/`](plans/georeader/) |
+| Sensor-specific readers (ABI, SEVIRI, MODIS, VIIRS, …) | Substrate / Readers | New, on shared Reader Protocol | [`plans/readers/`](plans/readers/) |
+| `GeoCatalog` (Phase 1, GeoPandas) | Discovery | New (on existing GeoParquet + GeoPandas) | [`plans/geodatabase/geocatalog.md`](plans/geodatabase/geocatalog.md) |
+| `DuckDBGeoCatalog` (Phase 2) | Discovery | New (on existing GeoParquet + DuckDB) | [`plans/geodatabase/geoduckdb.md`](plans/geodatabase/geoduckdb.md) |
+| `geotoolz` (`Operator`, `Sequential`, `Graph`, `ModelOp`, sensor presets) | Logic (imagery) | New library | [`plans/geotoolz/`](plans/geotoolz/) |
+| `xrtoolz` (operator algebra over xarray / `coordax`) | Logic (cubes) | External library | [github.com/jejjohnson/xr_toolz](https://github.com/jejjohnson/xr_toolz) |
+| `GeoSlice` + samplers + `stitch_predictions` | Cross-cutting types | Extracted from existing designs | [`plans/types/geoslice.md`](plans/types/geoslice.md) |
+| `Credential` + per-cloud subclasses | Cross-cutting types | New | [`plans/types/credentials.md`](plans/types/credentials.md) |
+| `ByteStore` + `ObstoreByteStore` / `FsspecByteStore` | Cross-cutting types | New | [`plans/types/bytestore.md`](plans/types/bytestore.md) |
+| JAX bridge (via `coordax`) | Logic ↔ JAX | Future work | *TBD* |
+
+---
+
+## See also
+
+- [`plans/geostack.md`](plans/geostack.md) — the engineering-focused ecosystem reference (strategy tables, bytes-paths triage, end-to-end flows). Eventually this motivation doc will merge in.
+- [`plans/geotoolz/`](plans/geotoolz/) — `geotoolz` operator library design.
+- [`plans/geodatabase/`](plans/geodatabase/) — `GeoCatalog` + DuckDB backend design.
+- [`plans/georeader/`](plans/georeader/) — reader Protocols and concrete reader designs.
+- [`plans/types/`](plans/types/) — cross-cutting type designs (`GeoSlice`, `Credential`, `ByteStore`).
+- [`plans/readers/`](plans/readers/) — per-sensor reader designs (geostationary, MODIS, …).
+
+### The success-story anchor
+
+The motivation in this doc is anchored on a concrete, projected end-to-end pipeline: **MARS-style methane attribution** rebuilt on the unified stack across three instruments (TROPOMI + GHGSat + EMIT) and three orchestration phases (research notebook → batch pipeline → FastAPI alert service). The full plan lives in:
+
+- [`operational_attribution.md`](operational_attribution.md) — projected end-to-end pipeline + validation plan + migration story from current MARS-style work.
+
+It's the single best demonstration of the *"same operator graph runs in research and production"* claim — and the place where the geotoolz / xrtoolz / GeoCatalog substrate, the per-sensor readers, and the `plumax` science modules all compose into one operational artifact.

--- a/projects/geotoolz/operational_attribution.md
+++ b/projects/geotoolz/operational_attribution.md
@@ -1,0 +1,615 @@
+---
+title: Operational attribution on a unified stack
+subject: Operational attribution on a unified stack
+subtitle: A forward plan for MARS-style methane attribution rebuilt on `georeader` + `GeoCatalog` + `geotoolz` + `plumax`
+short_title: Operational attribution
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: methane, attribution, plume, MARS, geotoolz, plumax, operational, satellite
+---
+
+> **Status.** Forward-looking plan. Projected pipeline assuming the unified stack lands. Treats everything except the current `georeader` package as future work.
+>
+> **Scope.** MARS-style methane source attribution from satellite observations. Three instruments (TROPOMI + GHGSat + EMIT). Covers **exploration, preprocessing, inference, and serving** — explicitly **not** model training.
+>
+> **Audience.** Three layers in one doc: an executive summary for funders/talks, an architectural plan for engineers, a validation + migration story for paper/blog framing.
+
+---
+
+## TL;DR
+
+Methane attribution from satellite imagery — *"this scene shows a plume; what is the source rate, where is the source, with what uncertainty?"* — is what UNEP-IMEO's **Methane Alert and Response System (MARS)** does operationally today. It works. It's also rebuilt as bespoke glue code in nearly every research project that touches the same problem. *Across the institutions I've worked at — FIT, RIT, Universidad de Valencia, CNRS, CSIC, UNEP-IMEO, MARS — the same research-to-production gap appears every time, with the storage and transport layers getting steadily better while the **factory layer** (the science composition) stays hand-rolled.*
+
+This doc projects what an operational attribution pipeline looks like once the unified stack lands: **`georeader` 2.0 (modernised reader Protocol), `GeoCatalog` (multi-satellite metadata index), `geotoolz`/`xrtoolz` (operator algebra), `plumax` (forward models)**. The same operator graph runs in:
+
+1. **A research notebook** — exploration, single-event analysis, MAP via NumPyro.
+2. **A batch pipeline** — last-week's-overpasses fanned out across detections, posteriors written to GeoParquet.
+3. **An alert service** — a FastAPI handler that takes a detection event and returns a posterior in seconds.
+
+One graph, three orchestration modes, zero rewrites between research and production. *That's* the substrate gap this stack is meant to close.
+
+---
+
+## 1. Why this doc exists
+
+MARS-style attribution is a real, deployed operational system at UNEP-IMEO. **This is not a proposal to rebuild MARS.** The question this doc answers is different: *what would the right substrate look like for this entire class of operational attribution work — not just MARS, but every research-to-production translation of a satellite-driven Bayesian inversion?*
+
+Two motivations sit underneath:
+
+1. **The same pipeline shape recurs everywhere.** Methane plume attribution, NO₂ inversion, CO₂ flux estimation, oil-spill backtracking, wildfire-emission attribution — all are: *(satellite L1/L2 data) → (forward model with met forcing) → (Bayesian inversion) → (posterior on source parameters)*. The science differs; the **plumbing is identical**. Today every project rebuilds the plumbing.
+2. **MARS is a proof point that the operational form exists.** The constraint isn't "can this be done"; it's "can this be done with a *unified, composable, reproducible* substrate that other groups can pick up and extend without re-implementing the IO layer". Plumax + geotoolz is that substrate.
+
+This doc projects how the v1 plumax target — **Tier I + AK + multi-satellite L2 fusion across {TROPOMI, GHGSat, EMIT}** — would be implemented end-to-end on the unified stack, with three orchestration phases demonstrating the research-to-prod arc.
+
+---
+
+## 2. What MARS-style attribution does today (and where the seams are)
+
+Operational attribution today is the composition of half a dozen well-understood pieces, each typically implemented as project-specific glue:
+
+```text
+                ┌──────────────────────────────────────────────────────┐
+                │  Detection trigger                                   │
+                │  (operator alert · matched-filter scan · TROPOMI Q4) │
+                └──────────────────────┬───────────────────────────────┘
+                                       │ event (lat, lon, time, instrument)
+                                       ▼
+        ┌─────────────────────────────────────────────────────────────┐
+        │  Multi-instrument data assembly                             │
+        │  • Pull EMIT scene for the event time + AOI                 │
+        │  • Pull TROPOMI overpass(es) within the event window        │
+        │  • Pull GHGSat target acquisition if available              │
+        │  • Pull met forcing (WRF / ERA5) for the AOI + window       │
+        └─────────────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+        ┌─────────────────────────────────────────────────────────────┐
+        │  Per-instrument preprocessing                               │
+        │  • EMIT: matched-filter detection on radiance cube          │
+        │  • TROPOMI: L2 XCH₄ + averaging-kernel + retrieval-prior    │
+        │  • GHGSat: L2 XCH₄ + footprint                              │
+        │  • Cloud + QA masks, native-resolution preserved            │
+        └─────────────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+        ┌─────────────────────────────────────────────────────────────┐
+        │  Forward model + likelihood + inference                     │
+        │  • Tier I Gaussian plume forward (Q, x₀, ū, θ_wind, …)      │
+        │  • Per-instrument AK operator + bias correction             │
+        │  • Joint multi-instrument likelihood at native resolution   │
+        │  • MAP / MCMC / variational posterior                       │
+        └─────────────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+        ┌─────────────────────────────────────────────────────────────┐
+        │  Reporting                                                  │
+        │  • Posterior mean + uncertainty                             │
+        │  • Provenance (which instruments contributed, met source)   │
+        │  • Alert payload to operational responders                  │
+        └─────────────────────────────────────────────────────────────┘
+```
+
+**Where the seams show up today:**
+
+| Seam | Today's reality | Cost |
+|---|---|---|
+| Satellite ingest | Per-instrument scripts, often re-implemented per project; auth via env-var soup; no shared cache / metadata index | Multi-week ramp-up per new project + non-reproducible IO |
+| Multi-instrument catalog | Per-project CSV / pandas notebooks; bespoke schema; no spatiotemporal index | Cross-project discovery is impossible; same data is re-curated 10× |
+| Forward model | Per-paper code; matched filter often a research script; no operator surface | No reuse across projects; small bug fixes don't propagate |
+| Inference loop | NumPyro / TensorFlow Probability / Stan, hand-wired to the forward; switching requires rewriting | Slow methods iteration |
+| Operational delivery | Inference moved into a FastAPI / Cloud Function via cut-and-paste from the research notebook; metadata round-trips lost | Production code drifts from research code; can't validate prod against research |
+
+The unified stack closes each of these seams with a typed, composable surface. The next sections show how.
+
+---
+
+## 3. The three-instrument scope
+
+The v1 target is **TROPOMI + GHGSat + EMIT** — the same set the [Tier IV plumax design](../plume_simulation/notes/roadmap/05_tier4_coupled.md) targets for v1 multi-instrument fusion. Each instrument contributes a different role; the demo's value is precisely in the *fusion*, not in any single instrument.
+
+| Instrument | Role | Resolution | Cadence | Native product | What it constrains |
+|---|---|---|---|---|---|
+| **[TROPOMI](https://sentinel.esa.int/web/sentinel/missions/sentinel-5p)** (S5P) | Wide-swath screening | ~5.5 × 7 km nadir | Daily global | L2 XCH₄ NetCDF | Regional context; rough source localisation; persistent emitters |
+| **[GHGSat](https://www.ghgsat.com/)** (commercial constellation) | Targeted high-resolution | ~25 m | Tasked | L2 XCH₄ HDF5 | Single-source rate; tight localisation; intermittent leaks |
+| **[EMIT](https://earth.jpl.nasa.gov/emit/)** (NASA / ISS) | Hyperspectral imaging spectrometer | ~60 m | ISS overpass cadence | L1B radiance NetCDF | Scene-context plume detection via matched filter; fingerprint validation |
+
+**Why these three, why this fusion:**
+
+- **Independent verification.** Three independent instruments observing the same plume with different physics (TROPOMI's full-disk averaging-kernel, GHGSat's pointed retrieval, EMIT's hyperspectral matched-filter) is the strongest possible evidence basis for an attribution claim. Single-instrument attributions are routinely contested.
+- **Different latencies.** TROPOMI is ~near-real-time global; GHGSat is tasked (latency ~hours); EMIT is ISS-cadence (latency ~days). The fusion is *temporally heterogeneous* — `Q(t)` as a stochastic process (per [Tier IV §3](../plume_simulation/notes/roadmap/05_tier4_coupled.md)) handles this naturally.
+- **Different state-vector constraints.** TROPOMI constrains regional background; GHGSat constrains source rate; EMIT validates the plume signature spectrally. Together they solve a system that no single instrument solves alone.
+- **MARS pattern.** This three-instrument fusion is the operational reality at UNEP-IMEO. The unified stack should match that reality without forcing a re-architecture.
+
+**What's explicitly out of scope for v1:** Sentinel-2 / Landsat (cloud-shadow vegetation-index methane proxies — useful but different physics); PRISMA / Tanager (similar to EMIT, additive once the EMIT pipeline works); CarbonMapper (commercial, schema TBD).
+
+---
+
+## 4. Mapping the unified stack to the attribution pipeline
+
+Each layer of the [geostack](geostack_notes.md) maps onto a concrete piece of the attribution pipeline. The point of the table below is that **none of this is novel science** — the science modules already have well-understood mathematical structure; the substrate work is making them compose cleanly.
+
+```text
+        ┌─────────────────────────────────────────────────────────────┐
+   USER │  notebook · alert API · operational dashboard               │
+        └─────────────────────────▲───────────────────────────────────┘
+                                  │
+        ┌─────────────────────────┴───────────────────────────────────┐
+  LOGIC │  ★ geotoolz operators (preprocessing, AK, masking, fusion)  │
+        │  ★ plumax operators (transport, RTM, likelihood, inversion) │
+        │  ★ xrtoolz operators (met-field reductions, climatology)    │
+        └─────────────────────────▲───────────────────────────────────┘
+                                  │
+        ┌─────────────────────────┴───────────────────────────────────┐
+   DISC │  ★ GeoCatalog: multi-satellite overpass + footprint index   │
+        │  Phase 1: GeoPandas + IntervalIndex (≤10⁵ overpasses/basin) │
+        │  Phase 2: DuckDB + GeoParquet (global, multi-year)          │
+        └─────────────────────────▲───────────────────────────────────┘
+                                  │
+        ┌─────────────────────────┴───────────────────────────────────┐
+   SUBS │  ★ georeader 2.0: GeoTensor carrier + per-sensor readers    │
+        │  EMIT_L1B · TROPOMI_L2 · GHGSat_L2 · WRF · ERA5             │
+        └─────────────────────────▲───────────────────────────────────┘
+                                  │
+        ┌─────────────────────────┴───────────────────────────────────┐
+  TRANS │  obstore · GDAL/VSI                                         │
+        └─────────────────────────▲───────────────────────────────────┘
+                                  │
+        ┌─────────────────────────┴───────────────────────────────────┐
+   STOR │  cloud buckets · COG · NetCDF · GeoParquet · Zarr (met)     │
+        └─────────────────────────────────────────────────────────────┘
+```
+
+Layer by layer, what each contributes to the attribution pipeline:
+
+### 4.1 Storage
+
+Already exists. EMIT lives on AWS / DAAC; TROPOMI on Copernicus / GES DISC; GHGSat on the vendor's portal; ERA5 on Copernicus CDS; WRF outputs on local compute. **No new storage** — the unified stack is about access patterns, not new repositories.
+
+### 4.2 Transport — `obstore`
+
+Single byte mover for all cloud buckets. Three concrete payoffs over the current per-project mix of `s3fs` / `boto3` / `gcsfs`:
+
+- Concurrent range reads make per-event AOI extraction (e.g. EMIT 1 km × 1 km AOI from a 100 km × 50 km scene) feasible without downloading the whole scene.
+- One credential model across S3 / GCS / Azure (where MARS partner data lives) — the [`Credential`](plans/types/credentials.md) Protocol abstracts the auth dance.
+- Reproducibility — `obstore` calls are pure functions of `(url, range, credential)`. No global env-var state.
+
+### 4.3 Substrate — modernised `georeader` + per-sensor readers
+
+The most concrete user-visible payoff. Today's per-project ingest replaced with five typed readers conforming to one Protocol:
+
+| Reader | Status today | What lands in the unified stack |
+|---|---|---|
+| `EMIT_L1B` (NetCDF radiance) | Per-project hand-rolled; matched-filter often a fork of the JPL reference code | Sensor-specific reader emitting `GeoTensor[*batch, bands, H, W]` with a `wavelength` attribute; matched-filter operator consumes it |
+| `TROPOMI_L2` (NetCDF L2 XCH₄) | Per-project, often via `harp` or hand-coded `xarray` | Sensor reader emitting `GeoTensor[*time, H, W]` with averaging-kernel sidecar |
+| `GHGSat_L2` (HDF5 L2 XCH₄) | Per-project, schema differs by product version | Sensor reader emitting `GeoTensor` with footprint + retrieval-prior metadata |
+| `WRF` / `ERA5` (NetCDF / GRIB met) | `xarray.open_dataset(...)` per project | `xrtoolz` reader emitting `MetField` as a `coordax.Dataset` (per [`plumax/00_prerequisites.md`](../plume_simulation/notes/roadmap/00_prerequisites.md#metfield-schema)) |
+| `inventory` (EDGAR / GFEI / EPA) | Per-project, often a single CSV import | Vector reader emitting a `GeoDataFrame`-typed prior on `q_a` |
+
+Cross-cutting: `Credential` and `ByteStore` Protocols (per [`plans/types/`](plans/types/)) handle auth and transport for all of them.
+
+### 4.4 Discovery — `GeoCatalog`
+
+The single biggest leap from "hand-rolled per project" to "shared substrate". The catalog is a **multi-satellite spatiotemporal index** keyed on `(instrument, time, footprint, quality, native_url)`.
+
+**Phase 1 (in-memory, per-basin / per-event):** a `geopandas.GeoDataFrame` plus `pd.IntervalIndex`, built once per session by crawling instrument-specific URL conventions. Sufficient for ≤10⁵ overpasses (a basin × multi-year window). Persisted as GeoParquet via `to_geoparquet()` so the same catalog feeds research and batch.
+
+**Phase 2 (DuckDB on GeoParquet):** when the catalog goes operational and global, the same API but DuckDB-backed with predicate pushdown via the GeoParquet 1.1 bbox column. **Most of MARS's catalog needs probably stay in Phase 1** — operational attribution is event-driven, with each event filtering to a small AOI × time window where Phase 1 is more than fast enough.
+
+**The query that anchors everything:**
+
+```python
+# "All overpasses within 2 hours of this detection, 50 km bbox around the source,
+#  any of the three instruments, quality flag >= 'usable'."
+catalog = GeoCatalog.from_geoparquet("s3://mars/catalog/overpasses_2026.parquet")
+candidates = catalog.query(
+    geometry=event.bbox(50_000),
+    interval=event.window(hours=2),
+    instruments=["EMIT", "TROPOMI", "GHGSat"],
+    quality_min="usable",
+)
+```
+
+That single query replaces the per-project glob+filter+join logic that today every attribution paper re-implements.
+
+### 4.5 Compute — `geotoolz` × `plumax` × `xrtoolz`
+
+The **factory layer** is where the science composition lives. Three libraries with a clean separation of concerns:
+
+| Library | What it owns in the attribution pipeline |
+|---|---|
+| **`geotoolz`** | Generic raster operators: `MatchedFilter` (EMIT methane fingerprint), `ApplyAK` (averaging-kernel application), `Mask` (cloud + QA), `Crop` (AOI extraction), `Reproject`, `Stitch`, `Sequential`/`Graph` composition. |
+| **`plumax`** | Domain-specific science operators: `GaussianPlume` (Tier I forward), `MetField` loader, `BiasCorrect` per instrument, `JointLikelihood` over instruments, `MAPInverter` / `NUTSInverter` wrappers. *Operators in the geotoolz sense — pickleable, Hydra-friendly, carrier-aware.* |
+| **`xrtoolz`** | Met-field operators: `TimeInterpolate` (snapshot / piecewise / advected), `PBLDiagnostic`, `StabilityClassifier`, `RegridToAnalysisGrid`. Operates on `coordax.Dataset` carrier (per [`plumax` adoption](../plume_simulation/notes/roadmap/00_prerequisites.md#open-questions)). |
+
+**The pipeline as one operator graph:**
+
+```python
+# Build once, call from notebook / batch / API
+attribution = Graph(
+    inputs={
+        "emit": Input(GeoTensor),       # EMIT L1B radiance cube
+        "tropomi": Input(GeoTensor),    # TROPOMI L2 XCH₄
+        "ghgsat": Input(GeoTensor),     # GHGSat L2 XCH₄
+        "met": Input(MetField),         # WRF or ERA5 met
+        "prior": Input(GeoDataFrame),   # EDGAR / GFEI prior
+    },
+
+    # Per-instrument preprocessing (geotoolz operators)
+    detect_emit       = MatchedFilter(target=ch4_signature) >> "emit",
+    masked_tropomi    = Mask(qa="qa_value", min=0.5) >> "tropomi",
+    masked_ghgsat     = Mask(qa="quality_flag", min=2) >> "ghgsat",
+
+    # Met-field preparation (xrtoolz operators)
+    pbl               = PBLDiagnostic() >> "met",
+    stability         = StabilityClassifier() >> "met",
+    met_interp        = TimeInterpolate(policy="piecewise") >> "met",
+
+    # Forward model (plumax operators)
+    forward_emit      = GaussianPlume(instrument="EMIT") >> ("met_interp", "stability"),
+    forward_tropomi   = GaussianPlume(instrument="TROPOMI") >> ("met_interp", "stability"),
+    forward_ghgsat    = GaussianPlume(instrument="GHGSat") >> ("met_interp", "stability"),
+
+    # Per-instrument observation operator (geotoolz × plumax)
+    sim_emit_radiance = ApplyRTM() >> ("forward_emit", "stability"),
+    sim_tropomi       = ApplyAK(instrument="TROPOMI") >> "forward_tropomi",
+    sim_ghgsat        = ApplyAK(instrument="GHGSat") >> "forward_ghgsat",
+
+    # Bias correction (plumax)
+    sim_emit_bc       = BiasCorrect(instrument="EMIT") >> "sim_emit_radiance",
+    sim_tropomi_bc    = BiasCorrect(instrument="TROPOMI") >> "sim_tropomi",
+    sim_ghgsat_bc     = BiasCorrect(instrument="GHGSat") >> "sim_ghgsat",
+
+    # Joint multi-instrument likelihood (plumax)
+    posterior         = JointLikelihood(instruments=["EMIT","TROPOMI","GHGSat"]) >> (
+        ("detect_emit",     "sim_emit_bc"),
+        ("masked_tropomi",  "sim_tropomi_bc"),
+        ("masked_ghgsat",   "sim_ghgsat_bc"),
+        "prior",
+    ),
+)
+```
+
+That's **the** graph. Notebook, batch worker, and FastAPI handler all instantiate this same `Graph` and call it. The orchestration changes around it; the graph itself is identical.
+
+### 4.6 Serving
+
+Three orchestration modes share the graph above. See §5 for each.
+
+---
+
+## 5. The three-phase demo plan
+
+Each phase uses the **identical** operator graph from §4.5. What changes is the orchestration around it: how inputs are resolved, where outputs go, what the latency budget is.
+
+### 5.1 Phase 1 — Research notebook
+
+**Goal.** Validate that the unified-stack operator graph runs and produces a posterior consistent with hand-rolled MARS-style outputs on a known event.
+
+**Anchor event.** A single Permian basin methane release with all three instruments observing within a 24-hour window. (Pick a published event from the literature so we have a published posterior to bench against.)
+
+**Notebook flow:**
+
+```python
+import geotoolz as gz
+import plumax as px
+import xrtoolz as xr_t
+from geocatalog import GeoCatalog
+
+# 1. Build / load a small catalog around the event
+catalog = GeoCatalog.from_basin_crawl(basin="permian", year=2024)
+overpasses = catalog.query(
+    geometry=event.bbox(50_000),
+    interval=event.window(hours=12),
+    instruments=["EMIT", "TROPOMI", "GHGSat"],
+)
+
+# 2. Resolve inputs via georeader 2.0
+emit_gt    = read_emit_l1b(overpasses["EMIT"][0].url, slice=event.geoslice(50_000))
+tropomi_gt = read_tropomi_l2(overpasses["TROPOMI"][0].url, slice=event.geoslice(50_000))
+ghgsat_gt  = read_ghgsat_l2(overpasses["GHGSat"][0].url, slice=event.geoslice(50_000))
+met        = read_wrf_metfield(event.window(hours=12), event.bbox(100_000))
+prior      = read_edgar(year=2024, basin="permian")
+
+# 3. Run the same graph as §4.5
+attribution = build_attribution_graph()  # the §4.5 Graph
+posterior_callable = attribution.compile()  # MAP via NumPyro under the hood
+
+# 4. Inference
+posterior = posterior_callable(
+    emit=emit_gt, tropomi=tropomi_gt, ghgsat=ghgsat_gt,
+    met=met, prior=prior,
+)
+
+# 5. Visualisation (matplotlib + lonboard for the geo bits)
+plot_posterior(posterior, event)
+plot_observations_vs_simulated(posterior, emit_gt, tropomi_gt, ghgsat_gt)
+```
+
+**What this validates:**
+
+- Operator graph composes and runs end-to-end.
+- Carrier-aware metadata propagates: the posterior carries `event.location` provenance back to the input AOI.
+- Multi-instrument fusion produces a tighter posterior than any single instrument (the differentiated payoff vs current per-instrument MARS practice).
+- Bench against published posterior for the chosen event — within published uncertainty.
+
+**Estimated effort.** ~2–3 weeks of focused work after georeader 2.0 + the v0.1 geotoolz core land. Most of the work is in `plumax` operator wrappers (`GaussianPlume`, `JointLikelihood`, `BiasCorrect`) — the plumax tier-I math already exists in the roadmap; the work is wrapping it as Operators with `get_config` for Hydra serialisation.
+
+### 5.2 Phase 2 — Batch pipeline
+
+**Goal.** Demonstrate that the **same** operator graph runs at orchestrated scale: last week's detections fanned out across compute, posteriors written to a queryable artifact.
+
+**Pipeline shape:**
+
+```text
+GeoCatalog (phase 1) ── query(week_window) ──▶ list of detection events
+        │
+        ▼
+  for each event:                          (parallelism via Dask / Ray / Modal)
+    ┌──────────────────────────┐
+    │  resolve inputs (Φ.1)    │
+    │  compile attribution     │
+    │  run posterior           │
+    │  write to GeoParquet     │
+    └──────────────────────────┘
+        │
+        ▼
+posteriors.parquet  (per-event posterior + provenance + alert score)
+```
+
+**Concretely:**
+
+```python
+import dask.distributed as dd
+from plumax.batch import attribute_event
+
+client = dd.Client()  # or Ray / Modal
+
+events = catalog.query(
+    interval=last_week,
+    quality_min="usable",
+    detection_channel=["matched_filter", "tropomi_q4"],
+).to_events()
+
+# attribute_event is a thin wrapper around the §5.1 logic — same operator graph
+futures = [client.submit(attribute_event, event) for event in events]
+posteriors = client.gather(futures)
+
+# Persist
+write_posteriors_geoparquet(posteriors, "s3://mars/posteriors/2026-W19.parquet")
+```
+
+**What this validates:**
+
+- The graph is **pickleable** — Dask / Ray serialisation works without per-Operator special-casing. (CI test from [`geotoolz.md` §11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci) directly applies.)
+- Per-event parallelism scales linearly with worker count (no shared global state).
+- Posteriors round-trip to GeoParquet with full provenance — the resulting file is a queryable record of every attribution the pipeline produced, hashable, reproducible.
+- Catalog-driven dispatch (Phase 1 catalog → list of events → graph per event) replaces today's bespoke `glob() + groupby + apply` notebooks.
+
+**Estimated effort.** ~1 week after Phase 1. Most of the work is the `attribute_event` adapter and the GeoParquet posterior schema; the operator graph is unchanged.
+
+### 5.3 Phase 3 — Alert service (FastAPI)
+
+**Goal.** Demonstrate research-to-prod with **zero rewrite**: the same graph, served as a request handler.
+
+**Service shape:**
+
+```python
+from fastapi import FastAPI
+from plumax.attribution import build_attribution_graph, AttributionRequest, AttributionResponse
+
+app = FastAPI()
+attribution_graph = build_attribution_graph().compile()  # same Graph as Phase 1 + 2
+
+@app.post("/attribute", response_model=AttributionResponse)
+async def attribute(req: AttributionRequest) -> AttributionResponse:
+    # 1. Catalog query for overpasses near the event
+    overpasses = catalog.query(
+        geometry=req.bbox(50_000),
+        interval=req.window(hours=12),
+        instruments=req.instruments,
+    )
+
+    # 2. Resolve inputs (async via the AsyncReader Protocol)
+    inputs = await resolve_inputs_async(overpasses, req)
+
+    # 3. Same graph, called as the request handler
+    posterior = attribution_graph(**inputs)
+
+    # 4. Build alert payload
+    return AttributionResponse(
+        event_id=req.event_id,
+        posterior_summary=summarize_posterior(posterior),
+        provenance=overpasses.provenance(),
+        alert_score=compute_alert_score(posterior),
+        latency_ms=...,
+    )
+```
+
+**Operational expectations:**
+
+- Cold-start ≤ 30 s (model + graph load).
+- Warm latency ≤ 5 s end-to-end for a typical event (3 instruments, 50 km bbox, MAP inversion).
+- Pickleable graph means the service can shard across workers transparently.
+- Catalog query is the long pole — depends on Phase 1 vs Phase 2 catalog and AOI size.
+
+**What this validates:**
+
+- The "marquee pitch" — *the same operator graph runs in research and production* — actually delivers. The `attribution_graph` object in the FastAPI handler is the *same Python object* you'd import in a notebook.
+- Async readers (`AsyncReader` Protocol from [`plans/georeader/`](plans/georeader/)) integrate cleanly with FastAPI's async stack.
+- Response payload includes complete provenance — every overpass URL, met source, prior version, operator graph hash — making each attribution audit-able.
+
+**Estimated effort.** ~1 week after Phase 2. Most of the work is the FastAPI scaffolding and async-reader plumbing; the graph and inference are unchanged.
+
+---
+
+## 6. Operator catalog — what the `Sequential` actually contains
+
+For engineers: the concrete operators each library would contribute. This is the *first-pass* surface — exact signatures land in each library's plans.
+
+### 6.1 `geotoolz` operators (existing per [`plans/geotoolz/`](plans/geotoolz/), with one addition)
+
+- `MatchedFilter(target: spectrum)` — hyperspectral plume detection. Hyperspectral module.
+- `ApplyAK(instrument: str)` — averaging-kernel application. New for v0.x — currently lives in plumax; promote when stable.
+- `Mask(qa_band: str, min: int|float)` — cloud + QA masking.
+- `Crop(geoslice: GeoSlice)` — AOI extraction.
+- `Reproject(target_crs: CRS, target_transform: Affine)` — Case-3 (shape-changing) operator.
+- `Stitch(method: str)` — inverse of `GridSampler`.
+- `Sequential([...])`, `Graph({...})`, `Tap`, `ApplyToEach` — composition core.
+
+### 6.2 `plumax` operators (projected — see [plumax roadmap](../plume_simulation/notes/roadmap/README.md))
+
+- `GaussianPlume(instrument, axis_convention)` — Tier I forward, `(Q, x₀, ū, θ_wind, c_bg) → concentration_field → column_via_AK → simulated_observation`. Wraps the existing tier-I math from [`01_tier1_gaussian.md`](../plume_simulation/notes/roadmap/01_tier1_gaussian.md) as an Operator.
+- `LagrangianPlume(...)` — Tier II forward. v2+.
+- `EulerianPlume(...)` — Tier III forward. v3+.
+- `BiasCorrect(instrument: str)` — per-instrument additive bias as a learnable Operator (compute via the split-object pattern from [§4.3 of geotoolz.md](plans/geotoolz/geotoolz.md)).
+- `JointLikelihood(instruments: list[str])` — multi-instrument fusion at native resolution. Returns a callable likelihood; downstream `MAPInverter` / `NUTSInverter` consumes it.
+- `MAPInverter(prior, init)` — wraps NumPyro's MAP. Output: `Posterior` PyTree.
+- `NUTSInverter(prior, n_warmup, n_samples)` — wraps NumPyro's NUTS. Output: `Posterior` PyTree with full chain.
+- `MetFieldLoader(source: str)` — wraps WRF / ERA5 readers from [`prerequisites.md`](../plume_simulation/notes/roadmap/00_prerequisites.md), emits `MetField`.
+
+### 6.3 `xrtoolz` operators (projected — see [github.com/jejjohnson/xr_toolz](https://github.com/jejjohnson/xr_toolz))
+
+- `TimeInterpolate(policy: str)` — `snapshot` / `piecewise` / `advected` per [prerequisites §3](../plume_simulation/notes/roadmap/00_prerequisites.md#open-questions).
+- `PBLDiagnostic()` — derive PBL height from met fields.
+- `StabilityClassifier(scheme: str)` — Pasquill–Gifford or MO similarity.
+- `RegridToAnalysisGrid(target_grid)` — Case-3 op on `coordax.Dataset`.
+
+### 6.4 What lives in `plumax`, not `geotoolz`
+
+The substrate-split rule from [`geotoolz.md` §10.1](plans/geotoolz/geotoolz.md): operators that are *domain-specific* (Gaussian plume math, AK application, methane likelihoods) live in `plumax`. Operators that are *generic* (matched filter, masking, cropping, reprojection) live in `geotoolz`. The split is enforced by import direction — `plumax` imports `geotoolz`, never the reverse.
+
+---
+
+## 7. Out of scope (explicit)
+
+For all three demo phases:
+
+- **Model training.** `geotoolz`, `xrtoolz`, and `plumax` cover *exploration*, *preprocessing*, *inference*, and *serving*. Training (e.g. an emulator surrogate for the forward model, per [plumax Step 3](../plume_simulation/notes/roadmap/README.md#the-data-driven-modeling-cycle)) stays in the user's framework (PyTorch, JAX, equinox). `ModelOp` wraps a *trained* callable for inference; nothing in this stack abstracts over training loops.
+- **Tier IV neural RTM.** The current RTM stack ([`04_rtm_stack.md`](../plume_simulation/notes/roadmap/04_rtm_stack.md)) is matrix-based. A neural-network surrogate for the RTM is a v2+ optional upgrade.
+- **Tier V population / forecasting.** The TMTPP intensity-process work in [`06_tier5_population.md`](../plume_simulation/notes/roadmap/06_tier5_population.md) is downstream of single-event posteriors; it consumes Phase 2's GeoParquet output but isn't part of v1.
+- **Distributed-SQL execution.** Sedona / Spark are not on the path. If catalog scale outgrows DuckDB Phase 2, the next step is sharded GeoParquet, not SQL emission from operator graphs.
+- **Streaming pipelines.** Flink / Beam / Kafka Streams are not modelled. Operator graphs run per-event, not per-byte-stream.
+- **Edge inference.** No mobile / TFLite / ONNX-runtime targets. The amortised predictor (plumax Step 5) could ship as ONNX, but operator-graph orchestration around it remains server-side.
+
+These exclusions are deliberate, per the [scope-honesty discussion in geostack_notes.md](geostack_notes.md#honest-research-to-prod-scope) — keeping the in-scope list deliverable rather than the out-of-scope list aspirational.
+
+---
+
+## 8. Validation plan
+
+Validation is layered to match the [plumax architectural principle 2](../plume_simulation/notes/roadmap/README.md#architectural-principles): *each step validates the next*.
+
+### 8.1 Per-operator (geotoolz / plumax / xrtoolz)
+
+- **Tier A primitive correctness.** Analytic ground truth on numpy arrays. NDVI, matched filter, AK application — each has a textbook-canonical reference output for known inputs.
+- **Tier B Operator metadata round-trip.** Transform / CRS / fill-value preserved through every Operator type (the three cases from [§1.1 of geotoolz.md](plans/geotoolz/geotoolz.md)).
+- **Operator pickleability.** Every Operator in §6 round-trips through `pickle.dumps` / `pickle.loads`. Already a CI test per [§11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci).
+
+### 8.2 Per-graph (the §4.5 attribution `Graph`)
+
+- **Identity-input test.** For a synthetic "no-plume" scene, posterior on `Q` peaks at 0 with credibility-interval covering 0.
+- **Recovery test.** For a synthetic plume of known `Q`, posterior recovers `Q` within the simulated observation noise.
+- **Multi-instrument tightening test.** Posterior with 3 instruments has tighter credibility intervals than with 1 — quantify the tightening per added instrument.
+
+### 8.3 End-to-end (against published events)
+
+- **Anchor event.** Pick one published Permian methane release with documented MARS-style attribution. The unified-stack posterior must be consistent with the published posterior.
+- **Cross-instrument independence.** Posterior obtained from {EMIT only}, {TROPOMI only}, {GHGSat only}, and {all three jointly} — the joint posterior should be the precision-weighted combination of the individual posteriors (within model misspecification).
+
+### 8.4 Operational continuity
+
+- **Phase 3 vs Phase 1 parity.** The FastAPI service, given the same inputs as the Phase 1 notebook, returns the same posterior to within numerical noise. *This is the marquee parity test* — if it fails, the "same graph in research and prod" claim fails.
+
+---
+
+## 9. Migration path from current MARS-style work
+
+For audiences asking *"what changes for the people doing this work today?"* — a concrete mapping.
+
+| Today's piece | Maps to | What changes |
+|---|---|---|
+| Per-project EMIT / TROPOMI / GHGSat ingest scripts | `georeader` 2.0 sensor readers | One library replaces N scripts; auth + transport unified |
+| Project-specific overpass CSVs | `GeoCatalog` Phase 1 | One queryable object replaces ad-hoc CSVs; round-trips to GeoParquet |
+| `matched_filter.py` per project | `geotoolz.hyperspectral.MatchedFilter` | Library-quality, tested, version-pinnable |
+| Per-project `gauss_plume.py` | `plumax.tier1.GaussianPlume` (Operator-wrapped) | Shared math; bug fixes propagate; Hydra-config-friendly |
+| Per-project NumPyro model | `plumax.JointLikelihood` + `MAPInverter` | Likelihood structure becomes a typed, reusable operator |
+| Hand-rolled FastAPI handler | `app.post("/attribute", ...)` calling the same graph | Zero rewrite from research to prod; full provenance for free |
+| Per-project repository / archival | GeoParquet posterior artifact + operator-graph hash | Each attribution is reproducible from artifact alone |
+
+**What does *not* change for current MARS workflows:**
+
+- The science. Tier I math, AK conventions, multi-instrument fusion logic — all stay the same. The substrate changes; the equations don't.
+- The operational reality. UNEP-IMEO partners, alert-response protocols, public reporting cadence — all unchanged.
+- The data sources. EMIT on AWS, TROPOMI on Copernicus, GHGSat on the vendor portal — same buckets, same auth, same products.
+
+---
+
+## 10. Risks and open questions
+
+The full risks tracker for the underlying libraries lives in their own design docs ([`plans/geotoolz/geotoolz.md` §11](plans/geotoolz/geotoolz.md), [`plans/geodatabase/`](plans/geodatabase/), [`plans/georeader/`](plans/georeader/)). The risks specific to *this* attribution pipeline:
+
+### 10.1 Critical-path
+
+- **`georeader 2.0` lands.** Every reader in §4.3 depends on the `feature/geotensor_npapi` branch merging upstream. If it stalls, vendor a `GeoTensor` in `plumax` until upstream catches up — but the contingency cost is one library duplication.
+- **Geocatalog Phase 1 ships.** Without it, Phase 2 / Phase 3 fall back to per-script glob-and-filter — the demo still works for one event, but the *catalog-driven* pitch evaporates.
+
+### 10.2 Per-instrument
+
+- **GHGSat schema stability.** Commercial product, schema changes per release. Pin reader to a documented product version; bump `_v2` per breaking change. Same convention as plumax sensor presets.
+- **EMIT product latency.** EMIT L1B can be hours to days behind acquisition. Phase 3 alert latency claims are bounded by this — no operational fixes available.
+- **TROPOMI L2 averaging-kernel format heterogeneity.** Different processors emit different AK schemas. The `Instrument` registry from [prerequisites §5](../plume_simulation/notes/roadmap/00_prerequisites.md#l1--l2-ingest) absorbs this — but the registry must stay maintained, or the unified pipeline breaks per-product-bump.
+
+### 10.3 Inference
+
+- **Three-instrument MAP convergence.** With heterogeneous noise models and a non-trivial `Q(t)` prior, MAP can be hard to converge. v1 ships with NumPyro-default optimizers; v2 may need basin-hopping or sequential Monte Carlo for hard events.
+- **Posterior representation.** A `Posterior` PyTree on output of `MAPInverter` / `NUTSInverter` needs a stable schema. Pin in v0.1 of `plumax`; bump the artifact `schema_version` (per [`geocatalog.md` §10.4](plans/geodatabase/geocatalog.md)) when changes happen.
+
+### 10.4 Operational
+
+- **Alert-payload schema is operator-defined.** What goes in `AttributionResponse` matters for downstream responders. v1 should mirror MARS's existing alert schema where possible, with extensions for provenance.
+- **Provenance-as-data.** Each posterior must carry: catalog query → resolved overpass URLs → met source + version → operator-graph hash → library versions. Without this, the "auditable" claim doesn't hold. Worth a dedicated `Provenance` PyTree in `plumax`.
+- **Phase 3 cold-start budget.** 30 s is plausible if `attribution_graph.compile()` is cheap; if NumPyro JIT-compiles per request, the budget breaks. Pin compilation to import-time, not request-time.
+
+### 10.5 Open questions to settle before v1
+
+- **Where does `ApplyAK` live — `geotoolz` or `plumax`?** Current proposal: in `geotoolz` (it's a generic operator over averaging-kernel-bearing observations), with the per-instrument AK schema registry in `plumax`. Could go the other way.
+- **Async at the graph boundary or per-Operator?** Phase 3 uses async I/O via `AsyncReader`; the graph itself is sync. Open per [`geotoolz.md` §11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci). Decision affects FastAPI throughput.
+- **`coordax` for `MetField` from day one?** The plumax roadmap leans yes ([prerequisites open questions](../plume_simulation/notes/roadmap/00_prerequisites.md#open-questions)). If `coordax` proves unstable per [geotoolz.md §11.1](plans/geotoolz/geotoolz.md#111-strategic-risks), fall back to plain xarray.
+- **Global vs basin catalogs.** Phase 1 fits ≤10⁵ overpasses, which covers a basin × multi-year window. A *global* catalog (every TROPOMI / EMIT / GHGSat overpass, multi-year) is Phase 2 territory. Decide per-deployment.
+
+---
+
+## 11. References & cross-links
+
+### Plumax internals
+
+- [Plumax roadmap index](../plume_simulation/notes/roadmap/README.md) — full tier structure and the data-driven modeling cycle.
+- [Prerequisites — `MetField`, observation interface](../plume_simulation/notes/roadmap/00_prerequisites.md) — the substrate this pipeline reads from.
+- [Tier I — Gaussian family](../plume_simulation/notes/roadmap/01_tier1_gaussian.md) — the v1 forward model used in §4.5.
+- [Tier IV — Coupled end-to-end](../plume_simulation/notes/roadmap/05_tier4_coupled.md) — the multi-instrument fusion that this demo's v1 target maps onto.
+- [RTM stack](../plume_simulation/notes/roadmap/04_rtm_stack.md) — the AK / radiative-transfer pieces.
+- [Satellite catalog notes](../plume_simulation/notes/satellites.ipynb) — the per-instrument target list this demo selects from.
+
+### Unified-stack design docs
+
+- [Geostack motivation (`geostack_notes.md`)](geostack_notes.md) — the public motivation doc this pipeline serves as the success story for.
+- [Geotoolz design](plans/geotoolz/) — operator algebra, tier model, sharp edges.
+- [Geocatalog design](plans/geodatabase/) — Phase 1 GeoPandas + Phase 2 DuckDB.
+- [Georeader reconciliation](plans/georeader/) — `Reader` Protocol, async, sensor-specific readers.
+- [Per-sensor reader designs](plans/readers/) — geostationary + polar-orbiting.
+- [Cross-cutting types](plans/types/) — `GeoSlice`, `Credential`, `ByteStore`.
+
+### External
+
+- [MARS at UNEP-IMEO](https://methane.unep.org/) — the operational system this pipeline is patterned on.
+- [EMIT mission](https://earth.jpl.nasa.gov/emit/) — NASA hyperspectral imager.
+- [TROPOMI / Sentinel-5P](https://sentinel.esa.int/web/sentinel/missions/sentinel-5p) — ESA/EU.
+- [GHGSat](https://www.ghgsat.com/) — commercial constellation.
+- [`coordax`](https://github.com/neuralgcm/coordax) — the JAX-native carrier candidate for `MetField`.

--- a/projects/geotoolz/operational_attribution.md
+++ b/projects/geotoolz/operational_attribution.md
@@ -300,7 +300,7 @@ Each phase uses the **identical** operator graph from §4.5. What changes is the
 import geotoolz as gz
 import plumax as px
 import xrtoolz as xr_t
-from geocatalog import GeoCatalog
+from georeader.catalog import GeoCatalog  # per `plans/geodatabase/` — module lives under georeader
 
 # 1. Build / load a small catalog around the event
 catalog = GeoCatalog.from_basin_crawl(basin="permian", year=2024)

--- a/projects/geotoolz/plans/geodatabase/README.md
+++ b/projects/geotoolz/plans/geodatabase/README.md
@@ -285,3 +285,19 @@ A 10⁷-row catalog can't fit in RAM during build. Options:
 - **[`geostack.md`](../geostack.md)** — situates the catalog layer in the broader ecosystem (where DuckDB sits relative to titiler / lonboard / obstore).
 
 The catalog layer sits between the reader layer (substrate) and the operator layer (composition). Each side talks to the other through `GeoSlice` — the catalog produces them, the reader+operator consume them.
+
+---
+
+## Open questions, gotchas, and warnings
+
+The unifying GeoCatalog design is sound; cross-cutting concerns to track:
+
+- **Cross-CRS query footgun.** Catalogs are canonicalised to one CRS (Phase 2: EPSG:4326). User AOIs in another CRS silently return no rows. Mitigation lives in [`geocatalog.md` §10.1](geocatalog.md#101-cross-crs-query-footgun) — provide a CRS-aware query helper as the canonical path.
+- **GeoParquet 1.1 writer adoption is uneven** across `geopandas` and `duckdb-spatial`. Pin known-good versions; add a round-trip CI test. See [`geocatalog.md` §10.2](geocatalog.md#102-geoparquet-11-writer-adoption-is-uneven) and [`geoduckdb.md` Open questions](geoduckdb.md#geoparquet-11-writer-support).
+- **Phase 2 risk of bit-rot** if no real user emerges past 10⁶ rows. Gate Phase 2 release behind one real user or a multi-million-row CI fixture. See [`geocatalog.md` §10.3](geocatalog.md#103-phase-2-risk-of-bit-rot).
+- **`schema_version` column** reserved from v0.1; bump on first substantive schema change.
+- **Adapter scope honesty.** v0.1 ships `to_geoparquet` / `from_geoparquet` round-trip; STAC and torch adapters are v0.2+. Don't promise adapters that aren't built.
+- **Concurrent writes** are safe under append-only patterns, not under in-place mutation. Document the recommended write pattern when multi-writer use cases emerge.
+- **`ST_Transform` in WHERE clauses is slow.** The §4-style "store all geometries in 4326, native CRS as a column" convention exists exactly to avoid this. Loud documentation, not a code-level fix.
+
+The full lists live per-doc: [`geocatalog.md` §10](geocatalog.md#10-open-questions-gotchas-and-warnings) for Phase 1; [`geoduckdb.md` Open questions](geoduckdb.md#open-questions-gotchas-and-warnings) for Phase 2.

--- a/projects/geotoolz/plans/geodatabase/geocatalog.md
+++ b/projects/geotoolz/plans/geodatabase/geocatalog.md
@@ -850,3 +850,38 @@ What needs work before promotion to a public georeader API:
 - [ ] Decide if `GeoSlice` should reuse / extend `georeader.slices.py` or be a new sibling — I'd reuse and extend.
 
 If you do those six things, this becomes a real `georeader.catalog` module — the dataset-collection layer that georeader is currently missing — without bloating the dependency footprint.
+
+---
+
+## 10. Open questions, gotchas, and warnings
+
+The Phase 1 / Phase 2 design is sound; several execution-level concerns deserve flags.
+
+### 10.1 Cross-CRS query footgun
+
+The catalog stores all geometries in a uniform target CRS (Phase 1 default: source CRS preserved per-row but reprojected for query; Phase 2 convention from `geoduckdb.md` §4: write all GeoParquet in EPSG:4326). Users querying `WHERE ST_Intersects(geom, AOI)` with AOI in a non-target CRS get **silently empty results** — no error, just no rows. **Mitigation:** provide a `query` helper that takes `(aoi: shapely.Geometry, aoi_crs: pyproj.CRS)` and projects internally before passing to the underlying engine. Make this the canonical path; the raw `gdf.cx[...]` / SQL paths assume the AOI is already in catalog CRS.
+
+### 10.2 GeoParquet 1.1 writer adoption is uneven
+
+`geopandas.to_parquet` defaults to GeoParquet 1.0; the per-row bbox column for predicate pushdown requires **GeoParquet 1.1**, which means an explicit `version="1.1"` flag (or whatever the geopandas writer uses) and a `geopandas` version pin. DuckDB's GeoParquet *write* path is newer than its read path. **Mitigation:** pin `geopandas >= 0.14` (or whatever first-shipped 1.1 writer) and `duckdb >= 1.1` explicitly in the package metadata; add a CI test that round-trips a small catalog through `to_geoparquet` → disk → `from_geoparquet` and verifies the bbox column survives.
+
+### 10.3 Phase 2 risk of bit-rot
+
+Most users will stay on Phase 1 (GeoPandas + IntervalIndex) for the 90% case. Phase 2 (DuckDB) won't get exercised unless someone hits the 10⁶+-row threshold. **Risk:** untested code paths on the upgrade. **Mitigation:** gate the Phase 2 release behind one real Phase 2 user (a multi-million-row catalog from your own work, or a community case study); add a multi-million-row CI fixture if no organic user emerges within v0.2.
+
+### 10.4 `schema_version` column is reserved, not used yet
+
+GeoParquet schemas evolve. Reserve a `schema_version` column from v0.1 so future migrations are tractable; current Phase 1 schema is de facto v0; bump to v1 the first time we change anything substantive (e.g. add a `n_timesteps` column). Document the migration runbook so this doesn't turn into tribal knowledge.
+
+### 10.5 Concurrent write semantics
+
+Phase 1 (GeoPandas in memory) is single-writer. Phase 2 (DuckDB on a shared GeoParquet) is **read-safe** across processes; **write-safe only if you treat Parquet as append-only** (new row groups in new files, not in-place mutation). Document the recommended write pattern; users coordinating multiple crawlers will trip over this.
+
+### 10.6 IntervalIndex edge cases
+
+`pd.IntervalIndex` with `closed="both"` handles overlapping intervals fine, but **back-to-back intervals** (one ends at `t`, next starts at `t`) double-count at the boundary. For sub-daily satellite data this rarely matters; for daily/hourly products it does. Decide on `closed="left"` vs `closed="both"` and stick with it; document the choice.
+
+### 10.7 Adapter scope
+
+The plan mentions STAC read/write adapters and a `GeoDataset` torch adapter. Each adapter is a small library on its own — STAC has its own metadata model that doesn't round-trip cleanly to a GeoDataFrame in all cases (collections vs items, asset-level metadata). **Scope honestly:** v0.1 ships `to_geoparquet` / `from_geoparquet` round-trip; STAC and torch adapters are v0.2+. Don't promise adapters that aren't built.
+

--- a/projects/geotoolz/plans/geodatabase/geoduckdb.md
+++ b/projects/geotoolz/plans/geodatabase/geoduckdb.md
@@ -866,3 +866,37 @@ What I'd defer to Phase 3:
 - A web UI for catalog inspection.
 
 If we get §6 + §7 right, Phase 2 turns the catalog from "a Python object you build at the start of every script" into "a file you build once, version, share, and query lazily from anywhere." That's the upgrade.
+
+---
+
+## Open questions, gotchas, and warnings
+
+The DuckDB-on-GeoParquet path is sound; concerns to manage actively.
+
+### DuckDB `spatial` extension version pinning
+
+The `spatial` extension is pre-1.0 in DuckDB; behaviours change between versions. GeoParquet 1.1 bbox-column predicate pushdown specifically lands at **DuckDB ≥ 1.1**. **Mitigation:** pin `duckdb >= 1.1` (and a known-good spatial-extension pin) in package metadata; add a CI matrix that tests on the latest DuckDB once it crosses 1.0 final. Don't lower the pin even if a user asks — silent query-plan regressions are the worst kind of bug.
+
+### `httpfs` extension and credentials
+
+Reading S3 / GCS / Azure GeoParquet from cloud needs the `httpfs` extension configured with the right credentials. DuckDB's secret API differs from `obstore` / `fsspec` patterns. **Mitigation:** define the `Credential` ↔ DuckDB-secret bridge in the [`Credential`](../types/credentials.md) design (cross-link), so users don't configure auth twice (once for georeader readers, once for DuckDB).
+
+### Concurrent reads/writes from multiple processes
+
+DuckDB on a single GeoParquet file is **read-safe** across processes. Write-safe only under specific patterns:
+- **Append-only** (new row groups in new files, then a manifest concat) — safe.
+- **In-place mutation** (rewrite the file under existing reads) — not safe across concurrent writers; you need an external lock or a Delta-Lake-style manifest.
+
+Phase 2 of `GeoCatalog` should default to the append-only pattern; document the trade-off if/when a concurrent-writer use case shows up.
+
+### GeoParquet 1.1 writer support
+
+DuckDB's GeoParquet *write* path is newer than the read path. Round-trip test (write with DuckDB, read with `geopandas.read_parquet`, check bbox column survives + CRS metadata is preserved) before promising the writer in v0.1. Cross-link [`geocatalog.md` §10.2](geocatalog.md#102-geoparquet-11-writer-adoption-is-uneven).
+
+### Bit-rot risk
+
+Most users will stay on Phase 1 (GeoPandas in-memory) for the 90% case; Phase 2 won't see organic exercise until someone hits 10⁶+ rows. **Risk:** the Phase 2 code paths regress without being noticed. **Mitigation:** maintain a multi-million-row CI fixture from v0.1; gate Phase 2 release behind one real Phase 2 user.
+
+### `ST_Transform` is slow per row
+
+DuckDB's `ST_Transform` requires PROJ data and is expensive when called per row. Hence the §4 design choice to write all GeoParquet in EPSG:4326 and store native CRS as a column for round-trip — reproject at write time, not at query time. **Footgun for users who skip this convention:** a multi-CRS catalog with `ST_Transform` in the WHERE clause will be 100× slower than a 4326-canonical catalog. Document loudly.

--- a/projects/geotoolz/plans/georeader/README.md
+++ b/projects/geotoolz/plans/georeader/README.md
@@ -263,3 +263,18 @@ Once these designs are implemented, the existing tutorial chapters need updates:
 - New chapters can be added for `LazyCOGReader` and `AsyncGeoTIFFReader` once those land — both natural successors to Ch. 3.
 
 The tutorial today describes the **current** package state; updates land alongside each issue's implementation, not before.
+
+---
+
+## Open questions, gotchas, and warnings
+
+The reconciliation is mostly low-risk — pieces exist, the work is plumbing. A few things to manage actively:
+
+- **`feature/geotensor_npapi` merge timing is critical-path** for `geotoolz`. The ndarray-subclass `GeoTensor` with `__array_ufunc__` underpins `geotoolz`'s two-tier model. If the branch stalls upstream, downstream blocks. Track the upstream merge as a v0.1 release blocker; contingency is to vendor `GeoTensor` in `geotoolz` until upstream catches up.
+- **`__array_function__` (NEP-18) coverage.** `__array_ufunc__` covers ufuncs only; `np.fft.*`, `np.linalg.*`, `np.einsum`, `np.percentile` go through `__array_function__`. Verify `GeoTensor` implements both protocols, or document which numpy submodules strip the subclass. Add a CI test that round-trips metadata through every numpy submodule the readers and downstream operators touch.
+- **ndarray subclass survival across third-party libraries.** `GeoTensor` survives numpy + scipy + skimage + matplotlib. It does **not** survive PyTorch (`torch.from_numpy` strips), JAX (`jnp.asarray` strips), or Dask without explicit `meta=` plumbing. Document this boundary in the user docs so consumers don't assume the subclass flows everywhere.
+- **Async ↔ sync boundary.** `AsyncReader` returns awaitables; downstream sync code (Operators, batch loops) needs `asyncio.run()` per call, which costs an event loop per invocation. `geotoolz` will need to pick a strategy (`AsyncOperator` family, or restrict async to the `CatalogPipeline` boundary) — see [`geotoolz.md` §11.2](../geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci). Worth coordinating before v0.1.
+- **Sensor-reader scope reduction for v0.1.** [`readers/`](../readers/) lists ABI, SEVIRI Native, MTG-FCI, Himawari-AHI HSD, SEVIRI HRIT, MODIS, VIIRS. Each "hard" sensor (irregular file formats, bowtie distortion) is 1–2 weeks *with full product spec access*. **Recommendation:** ship MODIS + ABI as v0.1 sensor proofs; defer SEVIRI / MTG / Himawari to v0.5+ unless an active user has a concrete need.
+- **Credential per-reader isolation.** The `Credential` design (`apply()` returning a dict, no global env-var mutation) only works if every reader is updated to consume the per-call dict instead of reading from `os.environ`. Backwards-compat path: legacy `apply_to_os_environ()` is provided but discouraged. Audit each reader on the way through reconciliation.
+- **`ByteStore` adapter parity.** `ObstoreByteStore` and `FsspecByteStore` need to handle the same set of edge cases: large range reads (>64 MB), retries on transient HTTP failures, presigned-URL token expiry. Cross-adapter test parity (same test suite run against both adapters) catches drift.
+- **Per-sensor public bucket helpers** are user-friendly but couple `georeader` to specific cloud-bucket layouts that providers can change without notice (Sentinel-2 on AWS moved twice). Pin reader behaviour to a documented bucket convention; add a smoke test that fails loudly if a bucket layout changes.

--- a/projects/geotoolz/plans/geotoolz/README.md
+++ b/projects/geotoolz/plans/geotoolz/README.md
@@ -36,7 +36,7 @@ The full design report is [`geotoolz.md`](geotoolz.md). It runs through the arch
 | § | Topic |
 |---|---|
 | 0 | Inputs the design draws on (`xr_toolz` patterns, `georeader` substrate, `jej_vc_snippets` empirical vocabulary) |
-| 1 | Inventory — three-tier model (Array / Tensor / Operator), 12 module surface (radiometry, indices, cloud, compositing, sampling, inference, ...) |
+| 1 | Inventory — two-tier model (jaxtyped Array primitives → Operator), 12 module surface (radiometry, indices, cloud, compositing, sampling, inference, ...). The collapse from xr_toolz's three tiers is possible because `GeoTensor` is an `np.ndarray` subclass with `__array_ufunc__`. |
 | 2 | User story — five personas, the goal arc from "load S2 → mask clouds → NDVI → save COG" to "Hydra-YAML pipeline" |
 | 3 | Motivation — why a separate library (not extending `xr_toolz`), why re-implement the composition core, comparison with TorchGeo / xarray-spatial / stackstac |
 | 4 | Mathematics — Operator delegation chain, dual-mode `__call__` (eager vs Graph), split-object stateful pattern, sampler stride, compositing reductions, matched filter, pansharpening, Lee speckle |
@@ -64,12 +64,19 @@ The full design report is [`geotoolz.md`](geotoolz.md). It runs through the arch
 
 ## Open questions
 
-The full design report flags twelve sharp edges in §7 and a smaller set of architectural questions in §3 and §10. The ones most worth surfacing here:
+The full design report flags twelve sharp edges in §7, architectural questions in §3 and §10, and a comprehensive risks/gotchas section in §11. The ones most worth surfacing here:
 
 1. **`Operator` base class — shared with `xr_toolz` or re-implemented?** The current decision (§0) is to re-implement (~300 LOC, freedom to specialise). Worth revisiting if a third sibling library appears.
 2. **Hydra-zen as a hard dep or extra?** §6 currently scopes it to an optional `[hydra]` extra. Some users want it as a baseline.
 3. **`presets/legacy/` for SPOT VGT and Proba-V?** §1.2 doesn't list them. [Tutorial Ch. 17](../../georeader_tutorial/17_legacy_sensors.md) suggests they'd live there if added.
-4. **Async operator support.** The current `Operator` base class is sync. An `AsyncOperator` for use with [`AsyncGeoTIFFReader`](../georeader/reader_async_geotiff.md) is plausible but not designed.
+4. **Async operator support.** The current `Operator` base class is sync. An `AsyncOperator` for use with [`AsyncGeoTIFFReader`](../georeader/reader_async_geotiff.md) is plausible but not designed. **Pick a design before v0.1** — see §11.2.
+5. **`coordax` stability for the JAX path.** The future-work JAX bridge depends on `coordax` (NeuralGCM, research-grade). Spike before committing the v0.5 work; have a fallback (equinox + jaxtyping directly).
+6. **`georeader 2.0` (`feature/geotensor_npapi`) merge timing.** The two-tier model assumes the ndarray-subclass GeoTensor lands. If it stalls, geotoolz blocks.
+7. **`_src` privacy decision.** Primitives are currently "semi-public" — likely a footgun for non-ufunc primitives passed `GeoTensor` inputs. Decide truly-private vs deliberately-public namespace (§11.3 recommends truly-private for v0.1).
+8. **Sensor preset scope reduction for v0.1.** 80 operators in 4 months is tight. Recommendation: cut Himawari-AHI HSD, MTG-FCI, SEVIRI-HRIT to v0.5+; ship MODIS + ABI as v0.1 sensor proofs.
+9. **Array-API compliance from day one or as a retrofit?** If JAX path matters, factoring primitives through the array-API standard at v0.1 is cheap; v0.5 retrofit is expensive. See §11.3.
+
+The full risks/gotchas list lives in [`geotoolz.md` §11](geotoolz.md#11-open-questions-gotchas-and-risks) — covers strategic risks, implementation gotchas to test in CI, and scope honesty.
 
 ---
 

--- a/projects/geotoolz/plans/geotoolz/geotoolz.md
+++ b/projects/geotoolz/plans/geotoolz/geotoolz.md
@@ -40,15 +40,30 @@ keywords: design, geotoolz, operators, remote-sensing
 
 A composable Operator library targeted at remote sensing. Sibling to `xr_toolz` at the architectural level; orthogonal at the substrate level.
 
-### 1.1 The three-tier model (borrowed verbatim from `xr_toolz` D11)
+### 1.1 The two-tier model
+
+`geotoolz` ships **two tiers**, where `xr_toolz` ships three. The collapse is possible because `GeoTensor` is an `np.ndarray` *subclass* with `__array_ufunc__` / `__array_finalize__` — it transparently carries metadata through ufuncs, slicing, copies, and views. The intermediate "tensor function" tier `xr_toolz` needs (because `xarray.DataArray` is *composition* over an ndarray, not a subclass) collapses into the Array tier here.
 
 | Tier | Location | Input | Output | Coordinate semantics |
 | --- | --- | --- | --- | --- |
-| **A — Array** | `geotoolz.<module>._src.array` | `np.ndarray` | `np.ndarray` | `axis=` |
-| **B — Tensor** | `geotoolz.<module>._src.tensor` | `GeoTensor` | `GeoTensor` (or terminal type) | `axis=`, with `dims`-aware helpers |
-| **C — Operator** | `geotoolz.<module>` (public) | `GeoTensor` (or two for multi-input) | `GeoTensor` / scalar / `Figure` | constructor `axis=` / `band=` |
+| **A — Array (primitive)** | `geotoolz.<module>._src.array` | `Float[ndarray, "..."]` (jaxtyped) | `Float[ndarray, "..."]` | `axis=` |
+| **B — Operator** | `geotoolz.<module>` (public) | `GeoTensor` (or two for multi-input) | `GeoTensor` / scalar / `Figure` | constructor `axis=` / `band=` |
 
-Tier A is private, ufunc-pure where possible. Tier B does the `GeoTensor`-subclass dance for non-ufunc upstream calls (skimage / scipy.ndimage). Tier C carries config, composes via `Sequential` and `Graph`.
+**Tier A — primitives.** Pure `np.ndarray → np.ndarray` functions, jaxtyped at the signature so callers see `Float[ndarray, "*batch bands H W"]`. Ufunc-pure where possible; for non-ufunc upstream calls (`skimage`, `scipy.ndimage`, `sklearn`) primitives return a plain `ndarray` — **no subclass dance inside the primitive**. Semi-public: importable, jaxtyped, documented, but the canonical user-facing surface is the Operator.
+
+**Tier B — Operators.** The carrier-aware boundary. There are **three cases** an Operator's `_apply` may need to handle, and each has a distinct pattern:
+
+1. **Shape-preserving + ufunc-pure** (e.g. `NDVI`, `Mask`, arithmetic, slicing): delegate straight to the primitive. `__array_ufunc__` round-trips the metadata automatically — `_apply` is one line.
+2. **Shape-preserving + non-ufunc** (e.g. `LeeSpeckle` via `scipy.ndimage`, `MaskFromQABits` via boolean ops, classification via `sklearn.predict`): strip → run → re-wrap. `out = primitive(np.asarray(gt)); return gt._wrap(out)`. One line of dance per Operator that needs it.
+3. **Shape- or metadata-changing** (`Resize`, `Regrid`, `Pansharpen`, multi-input fusion across CRSs, dim-reducing ops like `MeanComposite`): the primitive returns a plain `ndarray` and the Operator **constructs a fresh `GeoTensor`** with a *new* `transform` / `crs` / `dims`. `_wrap` does **not** apply — `_wrap` preserves metadata, but the metadata is precisely what changes here. Use `georeader`'s `GeoTensor` constructor directly.
+
+Operators carry config (Hydra-friendly) and compose via `Sequential` and `Graph`. The three cases are not exotic edge cases — Case 3 covers most of `compositing`, `pansharpen`, `sampling`, and any reprojection-flavoured op. Treat all three as first-class patterns from day one.
+
+**Why two tiers, not three.** `xr_toolz` has a middle "tensor function" tier because lifting `DataArray ↔ ndarray` is real work (extract `.values`, run, re-attach `.coords` / `.dims`). For `GeoTensor` that work collapses to `gt._wrap(out)` — one line at the Operator boundary. A dedicated tier-of-functions for that one line would be ceremony without value.
+
+**What jaxtyping does (and doesn't) buy us.** Tier A's `Float[ndarray, "..."]` annotations communicate *shape contracts* — IDE-visible, optional runtime-checkable, lower barrier than typing every primitive against `GeoTensor`. They do **not** communicate georef-awareness. The Operator type signature (`GeoTensor → GeoTensor`) remains the canonical place where georef-awareness is asserted. Primitives are "discipline plus jaxtyping"; Operators are "the typed contract".
+
+**Tests.** Tier A for analytic ground truth (math is right on numpy arrays, shapes match jaxtyping); Tier B for config round-trip + GeoTensor metadata propagation. No middle tier means no third place to test.
 
 ### 1.2 Module surface
 
@@ -77,7 +92,7 @@ Twelve modules, organised by RS workflow stage. Roughly 80 Operators in steady s
 
 - **Not `xr_toolz`.** Different substrate (`GeoTensor` vs `xr.Dataset`). Different audience. Same architectural patterns, separately implemented.
 - **Not `georeader`.** No I/O, no CRS plumbing, no reader classes, no catalog construction. Those are `georeader`'s job. `geotoolz` consumes `GeoTensor`s and produces `GeoTensor`s.
-- **Not a numpy primitives library.** Tier A primitives live inside `_src/array.py` per module — internal. If someone wants pure-numpy NDVI without operators, `from geotoolz.indices._src.array import ndvi_array` works, but the public surface is the Operator.
+- **Not a numpy primitives library.** Tier A primitives live inside `_src/array.py` per module — semi-public (importable, jaxtyped, documented), but the **canonical** surface is the Operator. `from geotoolz.indices._src.array import ndvi` works for users who want pure-numpy + jaxtyping; `gz.indices.NDVI(...)(gt)` is what most users will write. Primitives are "discipline + shape contracts"; Operators are "the typed georef-aware contract".
 - **Not framework-coupled.** `ModelOp` doesn't import torch / JAX / sklearn — it duck-types via `getattr(model, "predict")` or `model(arr)`. Optional `[ml]` extra for torch/sklearn presets if needed.
 - **Not a kitchen sink.** Curated. RS-shaped. Sensor presets are pinned to product versions to bound the maintenance surface.
 
@@ -168,33 +183,101 @@ These small differences add up. Sharing across libraries would mean both diverge
 
 ## 4. Mathematics
 
-### 4.1 The three-tier delegation chain (worked example: `NDVI`)
+### 4.1 The two-tier delegation chain (worked examples: `NDVI`, `LeeSpeckle`)
+
+**Ufunc-pure case (the common one).** `NDVI` is arithmetic — closed under ufuncs — so the Operator delegates straight to the jaxtyped primitive and `__array_ufunc__` handles the GeoTensor wrap automatically:
 
 ```python
-# Tier A — array
-def ndvi_array(arr, *, axis, red_idx, nir_idx, eps=1e-6):
+import numpy as np
+from numpy import ndarray
+from jaxtyping import Float
+
+# Tier A — array primitive (jaxtyped, semi-public)
+def ndvi(
+    arr: Float[ndarray, "*batch bands H W"],
+    *, axis: int, red_idx: int, nir_idx: int, eps: float = 1e-6,
+) -> Float[ndarray, "*batch H W"]:
     take = lambda i: np.take(arr, i, axis=axis)
     return (take(nir_idx) - take(red_idx)) / (take(nir_idx) + take(red_idx) + eps)
 
-# Tier B — tensor
-def ndvi_tensor(gt, *, axis=0, red_idx, nir_idx, eps=1e-6):
-    """Returns a GeoTensor of shape gt.shape with the band axis collapsed."""
-    return ndvi_array(gt, axis=axis, red_idx=red_idx, nir_idx=nir_idx, eps=eps)
-    # Closed under ufuncs → GeoTensor metadata round-trips automatically.
-
-# Tier C — operator
+# Tier B — operator
 class NDVI(Operator):
     def __init__(self, *, red_idx, nir_idx, axis=0, eps=1e-6):
         self.red_idx, self.nir_idx, self.axis, self.eps = red_idx, nir_idx, axis, eps
-    def _apply(self, gt):
-        return ndvi_tensor(gt, axis=self.axis, red_idx=self.red_idx,
-                           nir_idx=self.nir_idx, eps=self.eps)
+    def _apply(self, gt: GeoTensor) -> GeoTensor:
+        # Ufunc-pure primitive: GeoTensor metadata round-trips automatically
+        # via __array_ufunc__ / __array_finalize__. Pass the GeoTensor straight in.
+        return ndvi(gt, axis=self.axis, red_idx=self.red_idx,
+                    nir_idx=self.nir_idx, eps=self.eps)
     def get_config(self):
         return {"red_idx": self.red_idx, "nir_idx": self.nir_idx,
                 "axis": self.axis, "eps": self.eps}
 ```
 
-The Operator carries config (Hydra-friendly), delegates to the Tensor function, which delegates to the Array function. **No logic duplicated.** Tests target whichever tier is most informative — usually Tier A for analytic ground truth + Tier C for config round-trip.
+The Operator carries config (Hydra-friendly) and delegates straight to the primitive. **No middle tier, no logic duplicated.**
+
+**Non-ufunc case.** Anything that calls `scipy.ndimage`, `skimage`, or `sklearn` strips the GeoTensor subclass — those upstream libraries call `np.asarray()` internally. The Operator's `_apply` is the wrap boundary:
+
+```python
+from scipy.ndimage import uniform_filter
+
+# Tier A — non-ufunc primitive (jaxtyped, returns plain ndarray)
+def lee_speckle(
+    arr: Float[ndarray, "*batch H W"], *, window: int,
+) -> Float[ndarray, "*batch H W"]:
+    mean = uniform_filter(arr, size=window)
+    var  = uniform_filter(arr ** 2, size=window) - mean ** 2
+    noise_var = float(var.mean())
+    weight = var / (var + noise_var + 1e-12)
+    return mean + weight * (arr - mean)
+
+# Tier B — operator handles the strip / run / wrap dance explicitly
+class LeeSpeckle(Operator):
+    def __init__(self, *, window: int = 7): self.window = window
+    def _apply(self, gt: GeoTensor) -> GeoTensor:
+        out = lee_speckle(np.asarray(gt), window=self.window)  # plain ndarray
+        return gt._wrap(out)                                    # one-line re-wrap
+    def get_config(self): return {"window": self.window}
+```
+
+The wrap is one line, lives in exactly one place per Operator, never propagates upstream.
+
+**Shape- or metadata-changing case.** When the output's shape, transform, or CRS differs from the input — the third case from §1.1 — `_wrap` does **not** apply. The Operator constructs a fresh `GeoTensor`:
+
+```python
+from skimage.transform import resize as _skimage_resize
+
+# Tier A — shape-changing primitive (jaxtyped, returns plain ndarray)
+def resize(
+    arr: Float[ndarray, "*batch H W"],
+    *, target_shape: tuple[int, int], order: int = 1,
+) -> Float[ndarray, "*batch Hp Wp"]:
+    """Bilinear resample. Output spatial dims differ from input."""
+    return _skimage_resize(arr, target_shape, order=order, preserve_range=True)
+
+# Tier B — operator constructs a fresh GeoTensor with a new transform
+class Resize(Operator):
+    def __init__(self, *, target_shape: tuple[int, int], order: int = 1):
+        self.target_shape, self.order = target_shape, order
+    def _apply(self, gt: GeoTensor) -> GeoTensor:
+        out = resize(np.asarray(gt), target_shape=self.target_shape, order=self.order)
+        # New transform = old transform * scale, where scale comes from the resample factor.
+        # `georeader` provides the GeoTensor constructor; concrete API depends on the
+        # final georeader 2.0 surface, but the shape is "build a fresh carrier from
+        # (array, transform, crs, fill_value)".
+        sy = gt.shape[-2] / self.target_shape[0]
+        sx = gt.shape[-1] / self.target_shape[1]
+        new_transform = gt.transform * gt.transform.scale(sx, sy)
+        return GeoTensor(
+            values=out, transform=new_transform, crs=gt.crs,
+            fill_value_default=gt.fill_value_default,
+        )
+    def get_config(self): return {"target_shape": self.target_shape, "order": self.order}
+```
+
+Same shape applies to `Pansharpen` (changes spatial resolution to the pan grid), `Regrid` (changes CRS + transform), `MeanComposite` over time (drops the time axis from `dims`), and any multi-input fusion that lands on a target grid. The Operator owns the metadata construction; `georeader` provides the constructor; primitives stay numpy-typed.
+
+**Tests.** Tier A for analytic ground truth (math is right on numpy arrays, shapes match jaxtyping). Tier B for config round-trip *and* GeoTensor metadata propagation (transform, CRS, fill_value preserved through both ufunc-pure and non-ufunc operators).
 
 ### 4.2 The dual-mode `Operator.__call__` (Graph mode)
 
@@ -269,7 +352,7 @@ $$
 \mathrm{R}'_{h,w} = \mathrm{R}_{h,w} \cdot \frac{\mathrm{P}_{h,w}}{\mathrm{R}_{h,w} + \mathrm{G}_{h,w} + \mathrm{B}_{h,w} + \epsilon}
 $$
 
-Resamples the multispectral bands to the pan grid first (via `skimage.transform.resize` through the Tier B `preserve_subclass` wrapper), then applies the per-channel ratio. Same pattern for Gram-Schmidt and HCS, different math.
+Resamples the multispectral bands to the pan grid first (via `skimage.transform.resize` — a non-ufunc, shape-changing call wrapped at the Operator boundary, where the Operator constructs a fresh `GeoTensor` with the pan-grid transform), then applies the per-channel ratio. Same pattern for Gram-Schmidt and HCS, different math.
 
 ### 4.8 Lee speckle filter (SAR)
 
@@ -287,11 +370,11 @@ with `ȳ`, `σ_y²` from a sliding window, `σ_n²` an estimate of speckle noise
 
 ### 5.1 `georeader` — primary substrate
 
-`geotoolz` operators take and return `GeoTensor`. `__array_ufunc__` handles metadata round-trips for ufunc-y operations; the Tier B layer handles non-ufunc upstream calls via `preserve_subclass`. **Zero changes required to `georeader`.**
+`geotoolz` operators take and return `GeoTensor`. `__array_ufunc__` handles metadata round-trips for ufunc-pure operations transparently; for non-ufunc upstream calls (`skimage`, `scipy.ndimage`, `sklearn`), the Operator's `_apply` does the strip / run / `_wrap` dance at the Operator boundary. **Zero changes required to `georeader`.**
 
 ### 5.2 `numpy / scipy / scikit-image / scikit-learn` — compute
 
-All Tier A primitives. `geotoolz` consumes; never re-implements. Hard deps.
+All Tier A primitives consume `np.ndarray` (jaxtyped) and return `np.ndarray`. `geotoolz` consumes the upstream libraries; never re-implements. Hard deps.
 
 ### 5.3 `xrpatcher` — chip extraction (optional)
 
@@ -330,8 +413,8 @@ geotoolz/
 │   │       ├── operator.py       # Operator base, __call__ dual-mode, get_config
 │   │       ├── sequential.py     # Sequential, __or__ pipe sugar
 │   │       ├── graph.py          # Graph, Input, Node, topological sort
-│   │       └── utils.py          # preserve_subclass decorator, axis helpers
-│   ├── radiometry/{__init__.py, _src/{array.py, tensor.py, operators.py}}
+│   │       └── utils.py          # axis helpers, jaxtyping shape helpers
+│   ├── radiometry/{__init__.py, _src/{array.py, operators.py}}
 │   ├── correction/...            # TOAToBOA, DarkObjectSubtraction, Py6S
 │   ├── indices/...               # NDVI, NDWI, MNDWI, NDMI, EVI, SAVI, BSI, NormalizedDifference, AppendIndex
 │   ├── cloud/...                 # MaskClouds, MaskFromQABits, ApplyMask, CloudSEN12
@@ -344,7 +427,7 @@ geotoolz/
 │   ├── catalog_ops/...           # CatalogPipeline, WriteCOG, WriteParquet
 │   └── presets/
 │       ├── s2.py, landsat.py, emit.py, enmap.py, modis.py
-└── tests/                        # mirroring src/, one test_<tier>.py per module
+└── tests/                        # mirroring src/, test_array.py + test_operators.py per module
 ```
 
 ### 6.2 The Operator base class (the ~80 LOC core)
@@ -505,14 +588,14 @@ Five hard deps. Everything else opt-in.
 
 ### 6.8 Versioning and stability
 
-Pre-1.0 (`0.x`). Operator constructor signatures are the public surface. Internal Tier A/B can change freely. Sensor presets are pinned with version suffixes (`S2_L2A_RGB_v1`) so users can stay on an old preset across breaking sensor changes.
+Pre-1.0 (`0.x`). Operator constructor signatures are the public surface. Tier A primitive signatures are *semi-public* — jaxtyping annotations document the shape contract, but signatures may evolve until 1.0. Sensor presets are pinned with version suffixes (`S2_L2A_RGB_v1`) so users can stay on an old preset across breaking sensor changes.
 
 ---
 
 ## 7. Sharp edges
 
 1. **Don't share `Operator` with `xr_toolz`.** They diverge on call signature and chip semantics. The 300-LOC duplication is cheaper than the coordination tax.
-2. **`GeoTensor` subclass round-trip discipline.** For non-ufunc upstream calls (skimage, scipy.ndimage, sklearn), use the `preserve_subclass` decorator at the Tier B layer. For shape-changing operations (resize, zoom), the wrapper returns a plain ndarray and the Operator wraps a fresh `GeoTensor` with the new transform — `georeader` provides the construction.
+2. **`GeoTensor` subclass round-trip discipline.** For non-ufunc upstream calls (skimage, scipy.ndimage, sklearn), the **Operator's `_apply`** does the wrap — `out = primitive(np.asarray(gt)); return gt._wrap(out)`. One line per Operator that needs it; never inside the Tier A primitive. For shape-changing operations (resize, zoom, regridding), the primitive returns a plain ndarray and the Operator constructs a fresh `GeoTensor` with the new transform — `georeader` provides the construction helpers. **Footgun to document:** users importing primitives directly from `_src/array` get a plain `ndarray` back when the primitive is non-ufunc, even if they passed a `GeoTensor`. Per-primitive docstrings should mark "ufunc-pure" vs "non-ufunc" so the behaviour at primitive level is predictable.
 3. **Time-axis convention.** GeoTensor's `dims` may be `("time", "band", "y", "x")` or `("band", "time", "y", "x")` depending on how it was loaded. **Operators take `axis=` (int), never assume time is at axis 0.** The user passes `axis=` to match their tensor.
 4. **Multi-input arity is positional.** `CloudFreeComposite()(imagery, mask)` — the first GeoTensor is the imagery, the second is the mask. Document per Operator. Don't do `(image=..., mask=...)` keyword form; mixing positional and keyword args in `__call__` makes the dual-mode dispatch (eager vs graph) fragile.
 5. **`Sequential` strict on intermediate types.** Every step except the last must return a `GeoTensor`. Terminal ops (`WriteCOG`, viz operators) are allowed only at the end. Sequential validates and raises a clear `TypeError`.
@@ -691,7 +774,7 @@ gz.catalog_ops.CatalogPipeline(
 ).run()
 ```
 
-`CatalogPipeline` is a Tier C Operator that wraps the catalog iteration. The actual catalog (build / query / persistence) lives in `georeader.catalog`.
+`CatalogPipeline` is a Tier B Operator that wraps the catalog iteration. The actual catalog (build / query / persistence) lives in `georeader.catalog`.
 
 ### 8.7 Composition patterns
 
@@ -764,8 +847,8 @@ What needs to happen to ship v0.1:
 - [ ] Cut the new repo. `src/` layout, five hard deps.
 - [ ] Re-implement the composition core: `Operator`, `Sequential`, `Graph`, `Input`, `Node`, `Tap`. Borrow patterns from `xr_toolz`; ~300 LOC; no shared dep.
 - [ ] Author the v0.1 modules: `radiometry`, `indices`, `cloud`, `sampling`, `inference`, plus the core. ~25 Operators. **2 weeks.**
-- [ ] One `_src/{array, tensor, operators}.py` per module — preserves the three-tier discipline from day one.
-- [ ] `preserve_subclass` decorator + `GeoTensor` round-trip tests.
+- [ ] One `_src/{array, operators}.py` per module — preserves the two-tier discipline from day one. Tier A primitives jaxtyped (`jaxtyping >= 0.2`) at the signature.
+- [ ] Per-Operator `_wrap` discipline (Operators handle non-ufunc primitive output explicitly) + `GeoTensor` round-trip tests covering both ufunc-pure and non-ufunc primitives.
 - [ ] Hydra-zen smoke tests (every Operator's `get_config()` round-trips through `builds()`).
 - [ ] One end-to-end example notebook per category in §8 (six notebooks).
 
@@ -800,16 +883,20 @@ For users with both substrates: install both. Conversion between substrates is `
 
 ### 10.2 Shared architectural patterns
 
-Both libraries follow:
+Most architecture is shared; **the tier model is the one place they diverge**.
 
-- **Three-tier model** (Array → Tensor → Operator).
-- **Split-object pattern for stateful operations** (calculate state → apply state).
-- **Dual-mode `__call__`** (eager vs Graph-symbolic).
-- **Sequential and Graph composition.**
-- **`get_config()` for Hydra round-trip.**
-- **No framework deps in core; ML via duck-typed `ModelOp`.**
+| Pattern | `geotoolz` | `xr_toolz` |
+| --- | --- | --- |
+| **Tier model** | **Two-tier** (Array → Operator) | **Three-tier** (Array → DataArray → Operator) |
+| Split-object pattern for stateful operations | ✓ | ✓ |
+| Dual-mode `__call__` (eager vs Graph-symbolic) | ✓ | ✓ |
+| `Sequential` and `Graph` composition | ✓ | ✓ |
+| `get_config()` for Hydra round-trip | ✓ | ✓ |
+| No framework deps in core; ML via duck-typed `ModelOp` | ✓ | ✓ |
 
-The pattern docs live once (in `xr_toolz` or in a third "design conventions" doc); each library's own docs reference them. Code is independent.
+**Why the tier asymmetry.** `GeoTensor` is an `np.ndarray` *subclass* with `__array_ufunc__` — the wrap from `ndarray` back to the carrier is one line (`gt._wrap(out)`) and lives at the Operator boundary. `xarray.DataArray` is *composition* over an ndarray — lifting `DataArray ↔ ndarray` requires `.values` extraction and explicit `.coords`/`.dims` re-attach, real enough work to deserve its own tier. The substrate dictates the tier count; both libraries land on the same pattern *given their substrate*.
+
+The shared pattern docs live once (in `xr_toolz` or in a third "design conventions" doc); each library's own docs reference them and call out their tier-count specialisation. Code is independent.
 
 ### 10.3 What does NOT cross-pollinate
 
@@ -838,3 +925,58 @@ A short doc page in each library: "I have *X* data, should I use this library or
 ### 10.6 The endpoint
 
 Two libraries, two communities, one shared substrate library underneath, one shared design vocabulary on top. Each library focused, each community served, no awkward unifying compromise. **That's the right shape, and that's the recommendation.**
+
+---
+
+## 11. Open questions, gotchas, and risks
+
+The architecture is sound; several execution-level concerns deserve flags. None are blockers; all are things to manage actively. Strategic risks first, implementation gotchas second, scope honesty third.
+
+### 11.1 Strategic risks
+
+**`georeader 2.0` (`feature/geotensor_npapi`) is critical-path.** The two-tier model assumes the ndarray-subclass `GeoTensor` with `__array_ufunc__` lands cleanly upstream. If that branch stalls, `geotoolz` blocks — the wrap discipline depends on it. Track the merge as a blocker on v0.1; if it slips, the contingency is to ship `geotoolz` against a vendored `GeoTensor` until upstream catches up.
+
+**`coordax` is research-grade.** The future-work JAX path leans on `coordax` (NeuralGCM, Google), which is early and has no stability commitment. Pin known-good versions; spike before committing the JAX path; have a fallback (`equinox` + `jaxtyping` directly, reinventing the small bit of labelled-array machinery you actually need). Treat the JAX path as **v0.5+**, not v0.1, until coordax stabilises.
+
+**80-operator scope vs roadmap pace.** v0.1–v0.4 budgets ~2 months for ~80 operators at ~1.5 day/operator quality. Realistic estimate is 5–6 months at 1 FTE; if it's a side project, double the timeline. **Mitigation:** cut sensor presets to v0.5+ for low-priority sensors (Himawari-AHI HSD, MTG-FCI, SEVIRI-HRIT); ship MODIS + ABI as the v0.1 sensor proofs and let the rest accumulate as need arises.
+
+**Sensor preset maintenance is a forever commitment.** ESA / NASA / EUMETSAT product specs change every 1–2 years; each change spawns a new `_v2` preset. Budget ~5–10 preset bumps/year as steady-state maintenance, not one-time dev cost. Document a version-bump runbook so this doesn't become tribal knowledge.
+
+### 11.2 Implementation gotchas (test these in CI)
+
+**`__array_function__` (NEP-18) coverage in `GeoTensor`.** `__array_ufunc__` covers ufuncs only. Functions like `np.fft.fft2`, `np.linalg.svd`, `np.einsum`, `np.percentile`, and many `np.linalg.*` go through `__array_function__`, not `__array_ufunc__`. Verify `GeoTensor` implements both, or document which numpy submodules strip the subclass. Add a CI test that round-trips metadata through every numpy module the operators touch (`fft`, `linalg`, basic ufuncs, reductions, indexing).
+
+**`gt._wrap(out)` semantic edge cases.** Spec the rule per case so 80 operators don't each invent their own:
+- **Scalar output** (`tensor.mean()`): wrap into 0-d GeoTensor with original transform, or return scalar?
+- **Dim-reducing output** (`tensor.max(axis=-1)`): preserve transform but drop the axis from `dims`?
+- **Multi-input with divergent metadata** (`composite(image, mask)` where mask has no transform): which input's metadata wins?
+- **Boolean indexing** (`tensor[tensor > 0]`): returns 1-D, transform meaningless. Disallow at Operator level?
+
+Pick rules now; document in a `_wrap` design-doc entry that the Operator authors reference.
+
+**ndarray subclass fragility outside numpy.** `GeoTensor` survives numpy + scipy + skimage + matplotlib. It does **not** survive PyTorch (`torch.from_numpy` strips it), JAX (`jnp.asarray` strips it), or Dask without explicit `meta=` plumbing. This bounds the "GeoTensor flows everywhere" mental model — outside numpy-land, conversion is **explicit**. Document the supported boundary in the `GeoTensor` user docs.
+
+**Async ↔ sync Operator boundary.** `Operator._apply` is sync; the async readers (`AsyncGeoTIFFReader`, the `AsyncReader` Protocol) are async. Mixing them inside `_apply` means `asyncio.run()` per Operator call — one event loop per invocation, expensive at batch scale. Pick a design before v0.1: (a) introduce an `AsyncOperator` family with `async def _apply` and an `AsyncSequential` runner; (b) restrict async to the `CatalogPipeline` boundary (sync operators on already-fetched data, async only at the read step — probably the cleanest); (c) sync wrapper that reuses an event loop across calls.
+
+**Pickling discipline for production.** "Operator graph as FastAPI handler" depends on pickling working. `@dataclass`-shaped operators pickle fine; lambdas, closures, unbound methods break silently. Add a CI test that pickles every example operator graph in §8 and unpickles cleanly. If the test ever fails, the failing example is the bug.
+
+**Three-cases-not-two for `_apply`.** §1.1 / §4.1 lay out the three cases (ufunc-pure, non-ufunc shape-preserving, shape/metadata-changing). The third covers most of `compositing`, `pansharpen`, `sampling`, and any reprojection-flavoured op. Treat it as first-class from day one — shape-changing operators construct a fresh `GeoTensor`, they don't `_wrap`.
+
+### 11.3 Scope honesty
+
+**`_src` privacy is fuzzy.** Currently semi-public ("importable, jaxtyped, documented"). Users will import primitives directly and hit subclass-stripping for non-ufunc primitives. Decide before v0.1:
+- **(a)** Make `_src` truly private (single-underscore module names, "do not import" docstrings, optional `__all__` enforcement). Cleanest.
+- **(b)** Expose primitives at a deliberate public namespace (`geotoolz.indices.array.ndvi`). Honest but doubles the API surface.
+- **(c)** Keep the current "semi-public" path and document per-primitive ufunc-pure vs non-ufunc behaviour. Maximum footgun risk.
+
+**Recommendation:** (a) for v0.1; promote to (b) only if real users ask for primitives as a first-class import path.
+
+**Array-API compliance for primitives.** True backend-agnostic primitives use the [array-API standard](https://data-apis.org/array-api/) (`xp.add`, not `np.add`), portable across numpy / JAX / PyTorch. Current primitives use `np.*` directly — JAX requires rewrites. **Cost-now-or-later trade-off:** factoring through array-API at v0.1 is small (some primitives become slightly less readable); doing it as a v0.5 retrofit is expensive. If the JAX path matters, eat the cost now.
+
+**`ModelOp` is inference-only.** Duck-typed `__call__` works for inference across torch / JAX / sklearn. It does *not* unify training (different optimizers, gradient APIs, loss surfaces, batch semantics). State this explicitly in `ModelOp` docs so users don't expect a training abstraction.
+
+**"Same operator everywhere" has limits.** Holds for: numpy, Dask-orchestrated batch, distributed JAX, FastAPI, Airflow, Ray. Does *not* hold for: Sedona/Spark (different paradigm — would need SQL emission), streaming engines (Flink/Beam, not streaming-aware), edge inference (`ModelOp` ships the model, not the operator graph). Keep the in-scope vs out-of-scope list explicit in the public motivation doc ([`geostack_notes.md`](../../geostack_notes.md) "Honest research-to-prod scope").
+
+**Aggregate learning curve.** Two-layer ladder + jaxtyping + Hydra-zen + GeoTensor wrap discipline + dual-mode `__call__` + split-object stateful pattern + sensor presets is more than the "Keras simple" pitch suggests. Tutorial gallery (§8) should introduce concepts one at a time, not in a single kitchen-sink example. *"What you need to know to write your first NDVI pipeline" → "What you need to know to ship a Hydra-driven catalog inference run"* — a curriculum, not a manual.
+
+**Sub-pickle interop risks.** `Sequential` exported as ONNX, used as a `torch.utils.data.Dataset`, tracked by `mlflow` — these are integration questions that *will* come up. Scope which integrations are first-class vs out-of-scope before v0.1, even if the answer is "first-class only mlflow at v0.4, the rest is user-driven".

--- a/projects/geotoolz/plans/types/README.md
+++ b/projects/geotoolz/plans/types/README.md
@@ -106,3 +106,17 @@ When a candidate becomes a real design, it lands here as a sibling to `geoslice.
 - **One file per type family.** A "type family" can include a small number of closely-coupled types — e.g., `GeoSlice` plus the three samplers and `stitch` that produce/consume it — but not unrelated types stuffed together for filing convenience.
 - **Same design-doc skeleton as the other designs:** Status / Scope / Motivation / Goals / Non-goals / Constraints / The type itself / Connections to other designs / Open questions / Alternatives.
 - **Keep concrete enough to implement.** The whole point of pulling a type out is that it gets the same attention as a subsystem — meaning a real Protocol or dataclass spec, not a sketch.
+
+---
+
+## Open questions, gotchas, and warnings
+
+The cross-cutting types are the load-bearing ones — when they're wrong, every downstream design ripples. Things to watch:
+
+- **`Credential.apply()` per-call vs `apply_to_os_environ()` mutation.** The design distinguishes pure (returns a dict) vs mutating (writes `os.environ`) modes. Per-reader isolation only works if every reader consumes the per-call dict; the env-var mode is a backwards-compat hatch, not the recommended path. Audit each reader on the reconciliation path to make sure it accepts the per-call dict.
+- **`ByteStore` adapter parity.** `ObstoreByteStore` and `FsspecByteStore` must handle the same edge cases (large range reads, retries on transient failures, token-expiry refresh). Run the same Protocol-conformance test suite against both.
+- **`GeoSlice` time-axis convention.** `GeoSlice.interval` is a `pd.Interval`; the slice can be spatial-only (no interval) or spatial+temporal. Document the discriminated-union behaviour clearly so samplers and stitchers don't trip over the optional time dimension.
+- **Sampler API stability.** `random_geo_sampler` / `grid_geo_sampler` are bigger than they look — they couple `GeoSlice`, the catalog, and the inference loop. Treat their signatures as v0.1 public API; bump `_v2` if the shape needs to change rather than mutating in place.
+- **`stitch_predictions` reduction semantics.** Average vs first-write-wins vs max-vote — pick a default, document the alternatives, expose a `method=` knob. Without this, every user reinvents stitching.
+- **DuckDB credential bridge.** Reading cloud GeoParquet from DuckDB needs `httpfs` configured with credentials. The `Credential` Protocol should provide a `to_duckdb_secret()` adapter so users don't configure auth twice. Out-of-scope for v0.1, in-scope for the geodatabase Phase 2 design — flag the dependency.
+- **Future-candidate types are not commitments.** `Operator` Protocol, `Chip`/`Window`, `Sensor`/`Mission` are listed for orientation. Each lands here only when a second design references it. Resist promoting speculative types — they're cheap to add later, expensive to retract.

--- a/projects/plume_simulation/notes/roadmap.md
+++ b/projects/plume_simulation/notes/roadmap.md
@@ -20,6 +20,7 @@ The detailed roadmap now lives in [`roadmap/`](roadmap/README.md), one file per 
   - [V.B — Point process model (TMTPP)](roadmap/06b_point_process.md)
   - [V.C — Persistency](roadmap/06c_persistency.md)
   - [V.D — Total emission estimation](roadmap/06d_total_emission.md)
+- [**Operational attribution — unified-stack success-story plan**](../../geotoolz/operational_attribution.md) — projected end-to-end pipeline (3 instruments, 3 orchestration phases) showing how MARS-style attribution rebuilds on `georeader` + `GeoCatalog` + `geotoolz` + `plumax`. *(Lives under `projects/geotoolz/` since it anchors the geotoolz success-story pitch.)*
 
 ---
 


### PR DESCRIPTION
## Summary

- **Rewrite `geostack_notes.md` as the geotoolz motivation doc** — shipping-network ELI5 primer, eight-layer walkthrough, three-stack anatomy with per-stack lifecycle diagrams, library positioning (georeader 2.0 / GeoCatalog / geotoolz / xrtoolz), and explicit research-to-prod scope honesty. Names competitors directly (`eo-learn`, `torchgeo`, `xclim`, `xesmf`, `xarray-spatial`, `coordax`, …) and scopes Sedona/Spark/streaming/edge as out-of-band.
- **Add [`operational_attribution.md`](../blob/docs/geotoolz-motivation-and-success-story/projects/geotoolz/operational_attribution.md) as the projected end-to-end success-story plan** — TROPOMI + GHGSat + EMIT methane attribution rebuilt on the unified stack across three orchestration phases (research notebook → batch pipeline → FastAPI alert service), anchoring the *same operator graph in research and production* claim on real MARS-style work.
- **Collapse `geotoolz` design from three tiers to two** (jaxtyped Array primitives → GeoTensor Operators) since `GeoTensor` is an `np.ndarray` subclass with `__array_ufunc__`. `xrtoolz` keeps three because `DataArray` is composition over ndarray — the substrate dictates the tier count. Three `_apply` cases (ufunc-pure, non-ufunc shape-preserving, shape/metadata-changing) are now first-class with worked examples (`NDVI`, `LeeSpeckle`, `Resize`).
- **Add Open-questions / gotchas / warnings sections** to every design doc (`geotoolz/`, `georeader/`, `geodatabase/`, `types/`) covering strategic risks, implementation gotchas to test in CI, and scope honesty.

## What's new

- `projects/geotoolz/geostack_notes.md` (top-level motivation doc; was previously a rough draft on disk).
- `projects/geotoolz/operational_attribution.md` (projected end-to-end pipeline; the success-story anchor).

## What changed

- `projects/geotoolz/plans/geotoolz/{geotoolz,README}.md` — three-tier → two-tier model, three-cases pattern for `_apply` made first-class, Resize worked example, §11 Open Questions / Gotchas / Risks added.
- `projects/geotoolz/plans/geodatabase/{README,geocatalog,geoduckdb}.md` — Open-questions sections (CRS query footgun, GeoParquet 1.1 writer adoption, Phase 2 bit-rot risk, DuckDB version pinning, concurrent-write semantics, `ST_Transform` performance footgun).
- `projects/geotoolz/plans/georeader/README.md` — Open-questions section (georeader 2.0 critical-path, NEP-18 coverage, ndarray subclass survival, async/sync boundary, sensor-reader scope cut for v0.1).
- `projects/geotoolz/plans/types/README.md` — Open-questions section (`Credential.apply()` vs `apply_to_os_environ()`, `ByteStore` adapter parity, sampler API stability, `stitch_predictions` reduction semantics).
- `projects/plume_simulation/notes/roadmap.md` — cross-link to the new success-story doc.
- `myst.yml` — nav entry for `operational_attribution.md` under the geotoolz section.

## Test plan

- [ ] `myst build` (or your preferred MyST renderer) renders `geostack_notes.md` without errors and Mermaid diagrams display correctly (`{mermaid}` blocks for the Grand Unified diagram, lifecycle sequence diagrams per stack, library-map diagram).
- [ ] Cross-links resolve: from `geostack_notes.md` to plans/, types/, readers/, and `operational_attribution.md`; from `operational_attribution.md` back to `geostack_notes.md`, plans/, and `../plume_simulation/notes/roadmap/*`; from `plume_simulation/notes/roadmap.md` to the new success-story doc.
- [ ] Tutorial chapters (00_index–18_query_and_download, 19 files) all appear in the rendered nav under "georeader tutorial" — these were already listed in `myst.yml` but flagged for visibility-confirmation.
- [ ] Mermaid sequence diagrams render (per-stack lifecycle: COG header read → tile fetch, Zarr coord-to-chunk, GeoParquet predicate pushdown).

## Open questions for review

- **`_src` privacy** — the two-tier collapse leaves "primitives are semi-public" as the current word, but the recommendation in `geotoolz.md` §11.3 is to make `_src` truly private for v0.1. Worth a call before v0.1 ships; flagged as open question 7 in `plans/geotoolz/README.md`.
- **`ApplyAK` lives in `geotoolz` or `plumax`?** — `operational_attribution.md` §10.5 raises this; current take is `geotoolz` for the generic operator with the per-instrument schema registry in `plumax`. Could go the other way.
- **`coordax` stability** — JAX path leans on it; recommended spike before committing v0.5+ (covered in `geotoolz.md` §11.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)