### PR TITLE
docs(geotoolz): replace ascii + mermaid diagrams with html in geostack_notes

### DIFF
--- a/projects/geotoolz/_diagrams/01_five_layer.html
+++ b/projects/geotoolz/_diagrams/01_five_layer.html
@@ -1,0 +1,103 @@
+<style>
+  .gsd-fivelayer {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-tag-bg: #f6f8fa;
+    --gsd-connector: #8c959f;
+    --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 6px rgba(0, 0, 0, 0.04);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--gsd-fg);
+    max-width: 600px;
+    margin: 1.5em auto;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-fivelayer {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-tag-bg: #21262d;
+      --gsd-connector: #6e7681;
+      --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.3);
+    }
+  }
+  .gsd-fivelayer * { box-sizing: border-box; }
+  .gsd-fivelayer__stack { display: flex; flex-direction: column; align-items: stretch; }
+  .gsd-fivelayer__layer {
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 8px;
+    padding: 14px 20px 16px;
+    box-shadow: var(--gsd-shadow);
+    text-align: center;
+  }
+  .gsd-fivelayer__tag {
+    display: inline-block;
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--gsd-muted);
+    background: var(--gsd-tag-bg);
+    padding: 3px 10px;
+    border-radius: 999px;
+    margin-bottom: 10px;
+  }
+  .gsd-fivelayer__role { color: var(--gsd-fg); font-weight: 700; }
+  .gsd-fivelayer__primary { margin: 0 0 4px; font-size: 14px; }
+  .gsd-fivelayer__sub { margin: 0; color: var(--gsd-muted); font-size: 12.5px; }
+  .gsd-fivelayer__arrow {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: var(--gsd-connector);
+    margin: 4px 0;
+  }
+  .gsd-fivelayer__arrow::before {
+    content: "";
+    width: 1px;
+    height: 14px;
+    background: currentColor;
+  }
+  .gsd-fivelayer__arrow::after {
+    content: "▲";
+    font-size: 9px;
+    line-height: 1;
+  }
+</style>
+<div class="gsd-fivelayer">
+  <div class="gsd-fivelayer__stack">
+    <div class="gsd-fivelayer__layer">
+      <span class="gsd-fivelayer__tag">Storefront — <span class="gsd-fivelayer__role">the USER</span></span>
+      <p class="gsd-fivelayer__primary">notebook · web map · tile server</p>
+    </div>
+    <div class="gsd-fivelayer__arrow"></div>
+    <div class="gsd-fivelayer__layer">
+      <span class="gsd-fivelayer__tag">Factories — <span class="gsd-fivelayer__role">the LOGIC</span></span>
+      <p class="gsd-fivelayer__primary">pixel math · joins · regridding</p>
+      <p class="gsd-fivelayer__sub">compose, transform, reduce, render</p>
+    </div>
+    <div class="gsd-fivelayer__arrow"></div>
+    <div class="gsd-fivelayer__layer">
+      <span class="gsd-fivelayer__tag">Shipping registry — <span class="gsd-fivelayer__role">DISCOVERY</span></span>
+      <p class="gsd-fivelayer__primary">&ldquo;what exists, where it lives, what&rsquo;s inside&rdquo;</p>
+      <p class="gsd-fivelayer__sub">a queryable metadata index</p>
+    </div>
+    <div class="gsd-fivelayer__arrow"></div>
+    <div class="gsd-fivelayer__layer">
+      <span class="gsd-fivelayer__tag">Forklifts — <span class="gsd-fivelayer__role">the TRANSPORT</span></span>
+      <p class="gsd-fivelayer__primary">HTTP range requests · concurrent IO</p>
+      <p class="gsd-fivelayer__sub">only fetch the bytes you actually need</p>
+    </div>
+    <div class="gsd-fivelayer__arrow"></div>
+    <div class="gsd-fivelayer__layer">
+      <span class="gsd-fivelayer__tag">Warehouses — <span class="gsd-fivelayer__role">the STORAGE</span></span>
+      <p class="gsd-fivelayer__primary">cloud object stores · S3 / GCS / Azure</p>
+      <p class="gsd-fivelayer__sub">raster files · cube stores · tabular files</p>
+    </div>
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/02_unified_stack.html
+++ b/projects/geotoolz/_diagrams/02_unified_stack.html
@@ -1,0 +1,150 @@
+<style>
+  .gsd-unified {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-connector: #8c959f;
+    --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    --gsd-accent-bg: #ddf4ff;
+    --gsd-accent-border: #54aeff;
+    --gsd-accent-fg: #0969da;
+    --gsd-highlight-bg: #fff8c5;
+    --gsd-highlight-border: #d4a72c;
+    --gsd-highlight-fg: #7d4e00;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--gsd-fg);
+    max-width: 700px;
+    margin: 1.5em auto;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-unified {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-connector: #6e7681;
+      --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --gsd-accent-bg: #0c2d6b;
+      --gsd-accent-border: #1f6feb;
+      --gsd-accent-fg: #79c0ff;
+      --gsd-highlight-bg: #4d3c00;
+      --gsd-highlight-border: #d4a72c;
+      --gsd-highlight-fg: #f1e05a;
+    }
+  }
+  .gsd-unified * { box-sizing: border-box; }
+  .gsd-unified__grid {
+    display: grid;
+    grid-template-columns: 96px 1fr;
+    gap: 8px 14px;
+    align-items: stretch;
+  }
+  .gsd-unified__label {
+    text-align: right;
+    align-self: center;
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--gsd-muted);
+  }
+  .gsd-unified__row { display: flex; gap: 8px; }
+  .gsd-unified__cell {
+    flex: 1;
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 6px;
+    padding: 10px 8px;
+    text-align: center;
+    font-weight: 500;
+    box-shadow: var(--gsd-shadow);
+  }
+  .gsd-unified__cell--accent {
+    background: var(--gsd-accent-bg);
+    border-color: var(--gsd-accent-border);
+    color: var(--gsd-accent-fg);
+    font-weight: 700;
+  }
+  .gsd-unified__cell--highlight {
+    background: var(--gsd-highlight-bg);
+    border-color: var(--gsd-highlight-border);
+    color: var(--gsd-highlight-fg);
+    font-weight: 700;
+  }
+  .gsd-unified__cell small {
+    display: block;
+    font-weight: 400;
+    color: var(--gsd-muted);
+    font-size: 11.5px;
+    margin-top: 2px;
+  }
+  .gsd-unified__cell--accent small,
+  .gsd-unified__cell--highlight small { color: inherit; opacity: 0.85; }
+  .gsd-unified__arrow {
+    grid-column: 2;
+    color: var(--gsd-connector);
+    text-align: center;
+    line-height: 1;
+    font-size: 11px;
+    margin: -2px 0;
+  }
+</style>
+<div class="gsd-unified">
+  <div class="gsd-unified__grid">
+
+    <div class="gsd-unified__label">Viz / UX</div>
+    <div class="gsd-unified__row">
+      <div class="gsd-unified__cell">lonboard</div>
+      <div class="gsd-unified__cell">titiler</div>
+      <div class="gsd-unified__cell">Felt</div>
+    </div>
+
+    <div class="gsd-unified__arrow">▼</div>
+
+    <div class="gsd-unified__label">Logic<br><small style="font-weight:400">Engines</small></div>
+    <div class="gsd-unified__row">
+      <div class="gsd-unified__cell gsd-unified__cell--accent">geotoolz<small>imagery</small></div>
+      <div class="gsd-unified__cell gsd-unified__cell--accent">xrtoolz<small>dense</small></div>
+      <div class="gsd-unified__cell">DuckDB<small>vector</small></div>
+    </div>
+
+    <div class="gsd-unified__arrow">▼</div>
+
+    <div class="gsd-unified__label">Discovery<br><small style="font-weight:400">The Glue</small></div>
+    <div class="gsd-unified__row">
+      <div class="gsd-unified__cell gsd-unified__cell--highlight">★ GeoCatalog ★<small>GeoParquet / GeoJSON / STAC</small></div>
+    </div>
+
+    <div class="gsd-unified__arrow">▼</div>
+
+    <div class="gsd-unified__label">Substrate<br><small style="font-weight:400">Readers</small></div>
+    <div class="gsd-unified__row">
+      <div class="gsd-unified__cell">georeader</div>
+      <div class="gsd-unified__cell">xarray</div>
+      <div class="gsd-unified__cell">GeoPandas</div>
+      <div class="gsd-unified__cell">async-geotiff</div>
+    </div>
+
+    <div class="gsd-unified__arrow">▼</div>
+
+    <div class="gsd-unified__label">Transport<br><small style="font-weight:400">IO</small></div>
+    <div class="gsd-unified__row">
+      <div class="gsd-unified__cell">obstore</div>
+      <div class="gsd-unified__cell">kerchunk</div>
+      <div class="gsd-unified__cell">GDAL / VSI</div>
+    </div>
+
+    <div class="gsd-unified__arrow">▼</div>
+
+    <div class="gsd-unified__label">Storage<br><small style="font-weight:400">Cloud</small></div>
+    <div class="gsd-unified__row">
+      <div class="gsd-unified__cell">COG</div>
+      <div class="gsd-unified__cell">Zarr</div>
+      <div class="gsd-unified__cell">GeoParquet</div>
+    </div>
+
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/03_stack_imagery.html
+++ b/projects/geotoolz/_diagrams/03_stack_imagery.html
@@ -1,0 +1,137 @@
+<style>
+  .gsd-stackA {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-connector: #8c959f;
+    --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    --gsd-accent-bg: #ddf4ff;
+    --gsd-accent-border: #54aeff;
+    --gsd-accent-fg: #0969da;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--gsd-fg);
+    max-width: 660px;
+    margin: 1.5em auto;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-stackA {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-connector: #6e7681;
+      --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --gsd-accent-bg: #0c2d6b;
+      --gsd-accent-border: #1f6feb;
+      --gsd-accent-fg: #79c0ff;
+    }
+  }
+  .gsd-stackA * { box-sizing: border-box; }
+  .gsd-stackA__grid {
+    display: grid;
+    grid-template-columns: 92px 1fr;
+    gap: 8px 14px;
+    align-items: stretch;
+  }
+  .gsd-stackA__label {
+    text-align: right;
+    align-self: center;
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--gsd-muted);
+  }
+  .gsd-stackA__row { display: flex; gap: 8px; }
+  .gsd-stackA__cell {
+    flex: 1;
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 6px;
+    padding: 10px 10px;
+    text-align: center;
+    font-weight: 600;
+    box-shadow: var(--gsd-shadow);
+  }
+  .gsd-stackA__cell--accent {
+    background: var(--gsd-accent-bg);
+    border-color: var(--gsd-accent-border);
+    color: var(--gsd-accent-fg);
+  }
+  .gsd-stackA__cell small {
+    display: block;
+    font-weight: 400;
+    color: var(--gsd-muted);
+    font-size: 11.5px;
+    margin-top: 2px;
+  }
+  .gsd-stackA__cell--accent small { color: inherit; opacity: 0.85; }
+  .gsd-stackA__arrow {
+    grid-column: 2;
+    color: var(--gsd-connector);
+    text-align: center;
+    line-height: 1;
+    font-size: 11px;
+    margin: -2px 0;
+  }
+  .gsd-stackA__caption {
+    grid-column: 2;
+    color: var(--gsd-muted);
+    font-size: 11px;
+    text-align: center;
+    font-style: italic;
+    margin: -2px 0;
+  }
+</style>
+<div class="gsd-stackA">
+  <div class="gsd-stackA__grid">
+
+    <div class="gsd-stackA__label">Viz / UX</div>
+    <div class="gsd-stackA__row">
+      <div class="gsd-stackA__cell">lonboard<small>Jupyter / GPU</small></div>
+      <div class="gsd-stackA__cell">titiler<small>flexible API</small></div>
+    </div>
+
+    <div class="gsd-stackA__arrow">▼</div>
+
+    <div class="gsd-stackA__label">Compute</div>
+    <div class="gsd-stackA__row">
+      <div class="gsd-stackA__cell gsd-stackA__cell--accent">geotoolz<small>Operator · Sequential · Graph</small></div>
+    </div>
+
+    <div class="gsd-stackA__caption">GeoTensor in / out</div>
+
+    <div class="gsd-stackA__label">Substrate</div>
+    <div class="gsd-stackA__row">
+      <div class="gsd-stackA__cell">georeader<small>GeoTensor · GeoSlice · GeoCatalog</small></div>
+    </div>
+
+    <div class="gsd-stackA__arrow">▼</div>
+
+    <div class="gsd-stackA__label">Readers</div>
+    <div class="gsd-stackA__row">
+      <div class="gsd-stackA__cell">RasterioReader</div>
+      <div class="gsd-stackA__cell">async-geotiff</div>
+      <div class="gsd-stackA__cell">rio-tiler</div>
+    </div>
+
+    <div class="gsd-stackA__arrow">▼</div>
+
+    <div class="gsd-stackA__label">Transport</div>
+    <div class="gsd-stackA__row">
+      <div class="gsd-stackA__cell">GDAL / VSI<small>legacy IO</small></div>
+      <div class="gsd-stackA__cell">obstore<small>Rust byte mover</small></div>
+    </div>
+
+    <div class="gsd-stackA__arrow">▼</div>
+
+    <div class="gsd-stackA__label">Storage</div>
+    <div class="gsd-stackA__row">
+      <div class="gsd-stackA__cell">COG<small>Cloud Optimized GeoTIFF</small></div>
+    </div>
+
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/04_lifecycle_imagery.html
+++ b/projects/geotoolz/_diagrams/04_lifecycle_imagery.html
@@ -81,10 +81,10 @@
     min-height: 28px;
   }
   .gsd-seqA__msg {
-    grid-column: var(--from) / calc(var(--to) + 1);
+    grid-column: var(--from) / span var(--span);
     /* shrink the bar inward so it starts/ends at column centers (where lifelines sit) */
-    padding-left: calc(50% / (var(--to) - var(--from) + 1));
-    padding-right: calc(50% / (var(--to) - var(--from) + 1));
+    padding-left: calc(50% / var(--span));
+    padding-right: calc(50% / var(--span));
     display: flex;
     align-items: center;
     gap: 0;
@@ -123,8 +123,8 @@
   .gsd-seqA__msg--reverse { flex-direction: row-reverse; }
 
   .gsd-seqA__self {
-    grid-column: var(--from) / calc(var(--to) + 1);
-    padding-left: 50%;
+    grid-column: var(--from) / span var(--span);
+    padding-left: calc(50% / var(--span));
     display: flex;
     align-items: center;
     color: var(--gsd-muted);
@@ -132,8 +132,9 @@
     font-style: italic;
     position: relative;
     z-index: 2;
-    overflow: visible;
-    white-space: nowrap;
+    /* allow self-call labels to wrap on narrow viewports */
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
   .gsd-seqA__self-marker {
     width: 16px; height: 16px;
@@ -190,7 +191,7 @@
     <div class="gsd-seqA__rows">
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg" style="--from:1; --to:2;">
+        <div class="gsd-seqA__msg" style="--from:1; --span:2;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label"><code class="gsd-seqA__code">SQL: bbox ∩ Paris ∧ date ∈ 2024 ∧ cloud &lt; 10</code></span>
           <span class="gsd-seqA__msg-line"></span>
@@ -199,7 +200,7 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:1; --to:2;">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:1; --span:2;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label">list of COG URLs + metadata</span>
           <span class="gsd-seqA__msg-line"></span>
@@ -208,7 +209,7 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg" style="--from:1; --to:3;">
+        <div class="gsd-seqA__msg" style="--from:1; --span:3;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label"><code class="gsd-seqA__code">open(urls, slice=GeoSlice(bbox))</code></span>
           <span class="gsd-seqA__msg-line"></span>
@@ -217,7 +218,7 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg" style="--from:3; --to:4;">
+        <div class="gsd-seqA__msg" style="--from:3; --span:2;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label">HEAD + small range read</span>
           <span class="gsd-seqA__msg-line"></span>
@@ -226,7 +227,7 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg" style="--from:4; --to:5;">
+        <div class="gsd-seqA__msg" style="--from:4; --span:2;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label">HTTP Range (header)</span>
           <span class="gsd-seqA__msg-line"></span>
@@ -235,7 +236,7 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:4; --to:5;">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:4; --span:2;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label">COG IFD bytes</span>
           <span class="gsd-seqA__msg-line"></span>
@@ -244,7 +245,7 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:3; --to:4;">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:3; --span:2;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label">tile offsets + nodata + CRS</span>
           <span class="gsd-seqA__msg-line"></span>
@@ -253,7 +254,7 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__self" style="--from:3; --to:3;">
+        <div class="gsd-seqA__self" style="--from:3; --span:1;">
           <span class="gsd-seqA__self-marker"></span>
           compute overlapping tile indices
         </div>
@@ -263,7 +264,7 @@
         <span class="gsd-seqA__par-tag">par — parallel tile fetch</span>
 
         <div class="gsd-seqA__row">
-          <div class="gsd-seqA__msg" style="--from:3; --to:4;">
+          <div class="gsd-seqA__msg" style="--from:3; --span:2;">
             <span class="gsd-seqA__msg-line"></span>
             <span class="gsd-seqA__msg-label">range read (tile <em>k</em>)</span>
             <span class="gsd-seqA__msg-line"></span>
@@ -272,7 +273,7 @@
         </div>
 
         <div class="gsd-seqA__row">
-          <div class="gsd-seqA__msg" style="--from:4; --to:5;">
+          <div class="gsd-seqA__msg" style="--from:4; --span:2;">
             <span class="gsd-seqA__msg-line"></span>
             <span class="gsd-seqA__msg-label">HTTP Range (tile <em>k</em>)</span>
             <span class="gsd-seqA__msg-line"></span>
@@ -281,7 +282,7 @@
         </div>
 
         <div class="gsd-seqA__row">
-          <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:4; --to:5;">
+          <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:4; --span:2;">
             <span class="gsd-seqA__msg-line"></span>
             <span class="gsd-seqA__msg-label">compressed tile bytes</span>
             <span class="gsd-seqA__msg-line"></span>
@@ -290,7 +291,7 @@
         </div>
 
         <div class="gsd-seqA__row">
-          <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:3; --to:4;">
+          <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:3; --span:2;">
             <span class="gsd-seqA__msg-line"></span>
             <span class="gsd-seqA__msg-label">tile bytes</span>
             <span class="gsd-seqA__msg-line"></span>
@@ -300,14 +301,14 @@
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__self" style="--from:3; --to:3;">
+        <div class="gsd-seqA__self" style="--from:3; --span:1;">
           <span class="gsd-seqA__self-marker"></span>
           decompress + assemble window
         </div>
       </div>
 
       <div class="gsd-seqA__row">
-        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:1; --to:3;">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:1; --span:3;">
           <span class="gsd-seqA__msg-line"></span>
           <span class="gsd-seqA__msg-label"><code class="gsd-seqA__code">GeoTensor</code> (CRS + affine + array)</span>
           <span class="gsd-seqA__msg-line"></span>

--- a/projects/geotoolz/_diagrams/04_lifecycle_imagery.html
+++ b/projects/geotoolz/_diagrams/04_lifecycle_imagery.html
@@ -1,0 +1,320 @@
+<style>
+  .gsd-seqA {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-soft: #f6f8fa;
+    --gsd-arrow: #0969da;
+    --gsd-return: #8c959f;
+    --gsd-par-bg: #fff8c5;
+    --gsd-par-border: #d4a72c;
+    --gsd-lifeline: #d0d7de;
+    --gsd-bg: #ffffff;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--gsd-fg);
+    max-width: 760px;
+    margin: 1.5em auto;
+    --cols: 5;
+    position: relative;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-seqA {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-soft: #21262d;
+      --gsd-arrow: #58a6ff;
+      --gsd-return: #6e7681;
+      --gsd-par-bg: #4d3c00;
+      --gsd-par-border: #d4a72c;
+      --gsd-lifeline: #30363d;
+      --gsd-bg: #0d1117;
+    }
+  }
+  .gsd-seqA * { box-sizing: border-box; }
+  .gsd-seqA__hdr {
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    background: var(--gsd-bg);
+    padding: 6px 0 10px;
+  }
+  .gsd-seqA__actor {
+    text-align: center;
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 6px;
+    padding: 8px 4px;
+    font-weight: 700;
+    font-size: 12px;
+    margin: 0 4px;
+  }
+  .gsd-seqA__actor small {
+    display: block; font-weight: 400; color: var(--gsd-muted); font-size: 11px;
+  }
+
+  .gsd-seqA__body { position: relative; padding: 4px 0 8px; }
+  .gsd-seqA__lifelines {
+    position: absolute; inset: 0;
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    pointer-events: none;
+    z-index: 1;
+  }
+  .gsd-seqA__lifelines > div {
+    border-left: 1px dashed var(--gsd-lifeline);
+    margin-left: calc(50% - 0.5px);
+    width: 1px;
+  }
+
+  .gsd-seqA__rows { position: relative; display: flex; flex-direction: column; gap: 4px; }
+  .gsd-seqA__row {
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    align-items: center;
+    min-height: 28px;
+  }
+  .gsd-seqA__msg {
+    grid-column: var(--from) / calc(var(--to) + 1);
+    /* shrink the bar inward so it starts/ends at column centers (where lifelines sit) */
+    padding-left: calc(50% / (var(--to) - var(--from) + 1));
+    padding-right: calc(50% / (var(--to) - var(--from) + 1));
+    display: flex;
+    align-items: center;
+    gap: 0;
+    color: var(--gsd-arrow);
+  }
+  .gsd-seqA__msg-line {
+    flex: 1; height: 1.5px; background: currentColor; border-radius: 1px;
+    position: relative; z-index: 2;
+  }
+  .gsd-seqA__msg-head {
+    font-size: 11px; line-height: 1; flex: 0 0 auto;
+    position: relative; z-index: 2;
+  }
+  .gsd-seqA__msg-label {
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 4px;
+    padding: 3px 8px;
+    color: var(--gsd-fg);
+    font-size: 12px;
+    line-height: 1.35;
+    margin: 0 4px;
+    /* wrap long messages instead of truncating with ellipsis */
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-align: center;
+    position: relative;
+    z-index: 2;
+  }
+  .gsd-seqA__msg--return { color: var(--gsd-return); }
+  .gsd-seqA__msg--return .gsd-seqA__msg-line {
+    background: transparent;
+    border-top: 1.5px dashed currentColor;
+    height: 0;
+  }
+  .gsd-seqA__msg--reverse { flex-direction: row-reverse; }
+
+  .gsd-seqA__self {
+    grid-column: var(--from) / calc(var(--to) + 1);
+    padding-left: 50%;
+    display: flex;
+    align-items: center;
+    color: var(--gsd-muted);
+    font-size: 11.5px;
+    font-style: italic;
+    position: relative;
+    z-index: 2;
+    overflow: visible;
+    white-space: nowrap;
+  }
+  .gsd-seqA__self-marker {
+    width: 16px; height: 16px;
+    border: 1.5px solid var(--gsd-muted);
+    border-radius: 50%;
+    margin-right: 6px;
+    background: var(--gsd-bg);
+    flex: 0 0 auto;
+  }
+
+  .gsd-seqA__par {
+    background: var(--gsd-par-bg);
+    border: 1px solid var(--gsd-par-border);
+    border-radius: 6px;
+    margin: 6px 0;
+    padding: 10px 0 8px;
+    position: relative;
+  }
+  .gsd-seqA__par-tag {
+    position: absolute; top: -8px; left: 12px;
+    background: var(--gsd-par-border);
+    color: var(--gsd-bg);
+    font-size: 9.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 3px;
+    z-index: 3;
+  }
+
+  code.gsd-seqA__code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11.5px;
+    background: var(--gsd-soft);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+</style>
+<div class="gsd-seqA">
+  <div class="gsd-seqA__hdr">
+    <div class="gsd-seqA__actor">User<small>U</small></div>
+    <div class="gsd-seqA__actor">GeoCatalog<small>C</small></div>
+    <div class="gsd-seqA__actor">Reader<small>R · georeader</small></div>
+    <div class="gsd-seqA__actor">obstore<small>O</small></div>
+    <div class="gsd-seqA__actor">S3<small>S</small></div>
+  </div>
+
+  <div class="gsd-seqA__body">
+    <div class="gsd-seqA__lifelines">
+      <div></div><div></div><div></div><div></div><div></div>
+    </div>
+
+    <div class="gsd-seqA__rows">
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg" style="--from:1; --to:2;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label"><code class="gsd-seqA__code">SQL: bbox ∩ Paris ∧ date ∈ 2024 ∧ cloud &lt; 10</code></span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:1; --to:2;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label">list of COG URLs + metadata</span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg" style="--from:1; --to:3;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label"><code class="gsd-seqA__code">open(urls, slice=GeoSlice(bbox))</code></span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg" style="--from:3; --to:4;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label">HEAD + small range read</span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg" style="--from:4; --to:5;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label">HTTP Range (header)</span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:4; --to:5;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label">COG IFD bytes</span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:3; --to:4;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label">tile offsets + nodata + CRS</span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__self" style="--from:3; --to:3;">
+          <span class="gsd-seqA__self-marker"></span>
+          compute overlapping tile indices
+        </div>
+      </div>
+
+      <div class="gsd-seqA__par">
+        <span class="gsd-seqA__par-tag">par — parallel tile fetch</span>
+
+        <div class="gsd-seqA__row">
+          <div class="gsd-seqA__msg" style="--from:3; --to:4;">
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-label">range read (tile <em>k</em>)</span>
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-head">▶</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqA__row">
+          <div class="gsd-seqA__msg" style="--from:4; --to:5;">
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-label">HTTP Range (tile <em>k</em>)</span>
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-head">▶</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqA__row">
+          <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:4; --to:5;">
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-label">compressed tile bytes</span>
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-head">◀</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqA__row">
+          <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:3; --to:4;">
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-label">tile bytes</span>
+            <span class="gsd-seqA__msg-line"></span>
+            <span class="gsd-seqA__msg-head">◀</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__self" style="--from:3; --to:3;">
+          <span class="gsd-seqA__self-marker"></span>
+          decompress + assemble window
+        </div>
+      </div>
+
+      <div class="gsd-seqA__row">
+        <div class="gsd-seqA__msg gsd-seqA__msg--return gsd-seqA__msg--reverse" style="--from:1; --to:3;">
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-label"><code class="gsd-seqA__code">GeoTensor</code> (CRS + affine + array)</span>
+          <span class="gsd-seqA__msg-line"></span>
+          <span class="gsd-seqA__msg-head">◀</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/05_stack_dense.html
+++ b/projects/geotoolz/_diagrams/05_stack_dense.html
@@ -1,0 +1,137 @@
+<style>
+  .gsd-stackB {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-connector: #8c959f;
+    --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    --gsd-accent-bg: #ddf4ff;
+    --gsd-accent-border: #54aeff;
+    --gsd-accent-fg: #0969da;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--gsd-fg);
+    max-width: 660px;
+    margin: 1.5em auto;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-stackB {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-connector: #6e7681;
+      --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --gsd-accent-bg: #0c2d6b;
+      --gsd-accent-border: #1f6feb;
+      --gsd-accent-fg: #79c0ff;
+    }
+  }
+  .gsd-stackB * { box-sizing: border-box; }
+  .gsd-stackB__grid {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    gap: 8px 14px;
+    align-items: stretch;
+  }
+  .gsd-stackB__label {
+    text-align: right;
+    align-self: center;
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--gsd-muted);
+  }
+  .gsd-stackB__row { display: flex; gap: 8px; }
+  .gsd-stackB__row--center { justify-content: center; }
+  .gsd-stackB__cell {
+    flex: 1;
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 6px;
+    padding: 10px 10px;
+    text-align: center;
+    font-weight: 600;
+    box-shadow: var(--gsd-shadow);
+  }
+  .gsd-stackB__cell--accent {
+    background: var(--gsd-accent-bg);
+    border-color: var(--gsd-accent-border);
+    color: var(--gsd-accent-fg);
+  }
+  .gsd-stackB__cell--narrow { flex: 0 0 60%; }
+  .gsd-stackB__cell small {
+    display: block;
+    font-weight: 400;
+    color: var(--gsd-muted);
+    font-size: 11.5px;
+    margin-top: 2px;
+  }
+  .gsd-stackB__cell--accent small { color: inherit; opacity: 0.85; }
+  .gsd-stackB__arrow {
+    grid-column: 2;
+    color: var(--gsd-connector);
+    text-align: center;
+    line-height: 1;
+    font-size: 11px;
+    margin: -2px 0;
+  }
+</style>
+<div class="gsd-stackB">
+  <div class="gsd-stackB__grid">
+
+    <div class="gsd-stackB__label">Viz / UX</div>
+    <div class="gsd-stackB__row">
+      <div class="gsd-stackB__cell">lonboard<small>GPU render</small></div>
+      <div class="gsd-stackB__cell">Holoviz<small>aggregation</small></div>
+    </div>
+
+    <div class="gsd-stackB__arrow">▼</div>
+
+    <div class="gsd-stackB__label">Compute</div>
+    <div class="gsd-stackB__row">
+      <div class="gsd-stackB__cell gsd-stackB__cell--accent">xrtoolz<small>N-D algebra · regridding · means</small></div>
+    </div>
+
+    <div class="gsd-stackB__arrow">▼</div>
+
+    <div class="gsd-stackB__label">Substrate</div>
+    <div class="gsd-stackB__row">
+      <div class="gsd-stackB__cell">xarray<small>coordinates · dimensions · chunks</small></div>
+    </div>
+
+    <div class="gsd-stackB__arrow">▼</div>
+
+    <div class="gsd-stackB__label">Readers</div>
+    <div class="gsd-stackB__row">
+      <div class="gsd-stackB__cell">Zarr<small>standard</small></div>
+      <div class="gsd-stackB__cell">Icechunk<small>versioned</small></div>
+      <div class="gsd-stackB__cell">stackstac · odc-stac · lazycogs</div>
+    </div>
+
+    <div class="gsd-stackB__arrow">▼</div>
+
+    <div class="gsd-stackB__label">Virtual</div>
+    <div class="gsd-stackB__row gsd-stackB__row--center">
+      <div class="gsd-stackB__cell gsd-stackB__cell--narrow">kerchunk<small>HDF5 / NetCDF virtualisation</small></div>
+    </div>
+
+    <div class="gsd-stackB__arrow">▼</div>
+
+    <div class="gsd-stackB__label">Transport</div>
+    <div class="gsd-stackB__row gsd-stackB__row--center">
+      <div class="gsd-stackB__cell gsd-stackB__cell--narrow">obstore</div>
+    </div>
+
+    <div class="gsd-stackB__arrow">▼</div>
+
+    <div class="gsd-stackB__label">Storage</div>
+    <div class="gsd-stackB__row">
+      <div class="gsd-stackB__cell">Zarr · HDF5 · NetCDF</div>
+    </div>
+
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/06_lifecycle_dense.html
+++ b/projects/geotoolz/_diagrams/06_lifecycle_dense.html
@@ -1,0 +1,336 @@
+<style>
+  .gsd-seqB {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-soft: #f6f8fa;
+    --gsd-arrow: #0969da;
+    --gsd-return: #8c959f;
+    --gsd-par-bg: #fff8c5;
+    --gsd-par-border: #d4a72c;
+    --gsd-lifeline: #d0d7de;
+    --gsd-bg: #ffffff;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--gsd-fg);
+    max-width: 760px;
+    margin: 1.5em auto;
+    --cols: 5;
+    position: relative;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-seqB {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-soft: #21262d;
+      --gsd-arrow: #58a6ff;
+      --gsd-return: #6e7681;
+      --gsd-par-bg: #4d3c00;
+      --gsd-par-border: #d4a72c;
+      --gsd-lifeline: #30363d;
+      --gsd-bg: #0d1117;
+    }
+  }
+  .gsd-seqB * { box-sizing: border-box; }
+  .gsd-seqB__hdr {
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    background: var(--gsd-bg);
+    padding: 6px 0 10px;
+  }
+  .gsd-seqB__actor {
+    text-align: center;
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 6px;
+    padding: 8px 4px;
+    font-weight: 700;
+    font-size: 12px;
+    margin: 0 4px;
+  }
+  .gsd-seqB__actor small {
+    display: block; font-weight: 400; color: var(--gsd-muted); font-size: 11px;
+  }
+
+  .gsd-seqB__body { position: relative; padding: 4px 0 8px; }
+  .gsd-seqB__lifelines {
+    position: absolute; inset: 0;
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    pointer-events: none;
+    z-index: 1;
+  }
+  .gsd-seqB__lifelines > div {
+    border-left: 1px dashed var(--gsd-lifeline);
+    margin-left: calc(50% - 0.5px);
+    width: 1px;
+  }
+
+  .gsd-seqB__rows { position: relative; display: flex; flex-direction: column; gap: 4px; }
+  .gsd-seqB__row {
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    align-items: center;
+    min-height: 28px;
+  }
+  .gsd-seqB__msg {
+    grid-column: var(--from) / calc(var(--to) + 1);
+    padding-left: calc(50% / (var(--to) - var(--from) + 1));
+    padding-right: calc(50% / (var(--to) - var(--from) + 1));
+    display: flex;
+    align-items: center;
+    gap: 0;
+    color: var(--gsd-arrow);
+  }
+  .gsd-seqB__msg-line {
+    flex: 1; height: 1.5px; background: currentColor; border-radius: 1px;
+    position: relative; z-index: 2;
+  }
+  .gsd-seqB__msg-head {
+    font-size: 11px; line-height: 1; flex: 0 0 auto;
+    position: relative; z-index: 2;
+  }
+  .gsd-seqB__msg-label {
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 4px;
+    padding: 3px 8px;
+    color: var(--gsd-fg);
+    font-size: 12px;
+    line-height: 1.35;
+    margin: 0 4px;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-align: center;
+    position: relative;
+    z-index: 2;
+  }
+  .gsd-seqB__msg--return { color: var(--gsd-return); }
+  .gsd-seqB__msg--return .gsd-seqB__msg-line {
+    background: transparent;
+    border-top: 1.5px dashed currentColor;
+    height: 0;
+  }
+  .gsd-seqB__msg--reverse { flex-direction: row-reverse; }
+
+  .gsd-seqB__self {
+    grid-column: var(--from) / calc(var(--to) + 1);
+    padding-left: 50%;
+    display: flex;
+    align-items: center;
+    color: var(--gsd-muted);
+    font-size: 11.5px;
+    font-style: italic;
+    position: relative;
+    z-index: 2;
+    overflow: visible;
+    white-space: nowrap;
+  }
+  .gsd-seqB__self-marker {
+    width: 16px; height: 16px;
+    border: 1.5px solid var(--gsd-muted);
+    border-radius: 50%;
+    margin-right: 6px;
+    background: var(--gsd-bg);
+    flex: 0 0 auto;
+  }
+
+  .gsd-seqB__par {
+    background: var(--gsd-par-bg);
+    border: 1px solid var(--gsd-par-border);
+    border-radius: 6px;
+    margin: 6px 0;
+    padding: 10px 0 8px;
+    position: relative;
+  }
+  .gsd-seqB__par-tag {
+    position: absolute; top: -8px; left: 12px;
+    background: var(--gsd-par-border);
+    color: var(--gsd-bg);
+    font-size: 9.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 3px;
+    z-index: 3;
+  }
+
+  code.gsd-seqB__code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11.5px;
+    background: var(--gsd-soft);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+</style>
+<div class="gsd-seqB">
+  <div class="gsd-seqB__hdr">
+    <div class="gsd-seqB__actor">User<small>U</small></div>
+    <div class="gsd-seqB__actor">GeoCatalog<small>C</small></div>
+    <div class="gsd-seqB__actor">xarray<small>X</small></div>
+    <div class="gsd-seqB__actor">obstore<small>O</small></div>
+    <div class="gsd-seqB__actor">S3<small>S</small></div>
+  </div>
+
+  <div class="gsd-seqB__body">
+    <div class="gsd-seqB__lifelines">
+      <div></div><div></div><div></div><div></div><div></div>
+    </div>
+
+    <div class="gsd-seqB__rows">
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg" style="--from:1; --to:2;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label">query: <code class="gsd-seqB__code">collection=ERA5, var=sst</code></span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:1; --to:2;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label">Zarr URL</span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg" style="--from:1; --to:3;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">xr.open_zarr(url)</code></span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg" style="--from:3; --to:4;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label">GET <code class="gsd-seqB__code">.zmetadata</code> (consolidated)</span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg" style="--from:4; --to:5;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label">HTTP GET</span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:4; --to:5;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label">schema + chunk grid + coords</span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:3; --to:4;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label">lazy <code class="gsd-seqB__code">Dataset</code> (no chunks read yet)</span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg" style="--from:1; --to:3;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">ds.sst.sel(lat=slice(20,60), lon=slice(-80,0), time=slice("1990","2024"))</code></span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__self" style="--from:3; --to:3;">
+          <span class="gsd-seqB__self-marker"></span>
+          map coord ranges → chunk indices
+        </div>
+      </div>
+
+      <div class="gsd-seqB__par">
+        <span class="gsd-seqB__par-tag">par — parallel chunk fetch</span>
+
+        <div class="gsd-seqB__row">
+          <div class="gsd-seqB__msg" style="--from:3; --to:4;">
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-label">GET chunk (<em>t<sub>i</sub>, lat<sub>j</sub>, lon<sub>k</sub></em>)</span>
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-head">▶</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqB__row">
+          <div class="gsd-seqB__msg" style="--from:4; --to:5;">
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-label">HTTP GET</span>
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-head">▶</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqB__row">
+          <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:4; --to:5;">
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-label">compressed chunk bytes</span>
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-head">◀</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqB__row">
+          <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:3; --to:4;">
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-label">chunk array</span>
+            <span class="gsd-seqB__msg-line"></span>
+            <span class="gsd-seqB__msg-head">◀</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__self" style="--from:3; --to:3;">
+          <span class="gsd-seqB__self-marker"></span>
+          decompress + assemble + (optional) Dask graph
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg" style="--from:1; --to:3;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">.groupby("time.month").mean()</code></span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqB__row">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:1; --to:3;">
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">DataArray</code> (12, n_lat, n_lon)</span>
+          <span class="gsd-seqB__msg-line"></span>
+          <span class="gsd-seqB__msg-head">◀</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/06_lifecycle_dense.html
+++ b/projects/geotoolz/_diagrams/06_lifecycle_dense.html
@@ -81,9 +81,10 @@
     min-height: 28px;
   }
   .gsd-seqB__msg {
-    grid-column: var(--from) / calc(var(--to) + 1);
-    padding-left: calc(50% / (var(--to) - var(--from) + 1));
-    padding-right: calc(50% / (var(--to) - var(--from) + 1));
+    grid-column: var(--from) / span var(--span);
+    /* shrink the bar inward so it starts/ends at column centers (where lifelines sit) */
+    padding-left: calc(50% / var(--span));
+    padding-right: calc(50% / var(--span));
     display: flex;
     align-items: center;
     gap: 0;
@@ -121,8 +122,8 @@
   .gsd-seqB__msg--reverse { flex-direction: row-reverse; }
 
   .gsd-seqB__self {
-    grid-column: var(--from) / calc(var(--to) + 1);
-    padding-left: 50%;
+    grid-column: var(--from) / span var(--span);
+    padding-left: calc(50% / var(--span));
     display: flex;
     align-items: center;
     color: var(--gsd-muted);
@@ -130,8 +131,9 @@
     font-style: italic;
     position: relative;
     z-index: 2;
-    overflow: visible;
-    white-space: nowrap;
+    /* allow self-call labels to wrap on narrow viewports */
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
   .gsd-seqB__self-marker {
     width: 16px; height: 16px;
@@ -188,7 +190,7 @@
     <div class="gsd-seqB__rows">
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg" style="--from:1; --to:2;">
+        <div class="gsd-seqB__msg" style="--from:1; --span:2;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label">query: <code class="gsd-seqB__code">collection=ERA5, var=sst</code></span>
           <span class="gsd-seqB__msg-line"></span>
@@ -197,7 +199,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:1; --to:2;">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:1; --span:2;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label">Zarr URL</span>
           <span class="gsd-seqB__msg-line"></span>
@@ -206,7 +208,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg" style="--from:1; --to:3;">
+        <div class="gsd-seqB__msg" style="--from:1; --span:3;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">xr.open_zarr(url)</code></span>
           <span class="gsd-seqB__msg-line"></span>
@@ -215,7 +217,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg" style="--from:3; --to:4;">
+        <div class="gsd-seqB__msg" style="--from:3; --span:2;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label">GET <code class="gsd-seqB__code">.zmetadata</code> (consolidated)</span>
           <span class="gsd-seqB__msg-line"></span>
@@ -224,7 +226,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg" style="--from:4; --to:5;">
+        <div class="gsd-seqB__msg" style="--from:4; --span:2;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label">HTTP GET</span>
           <span class="gsd-seqB__msg-line"></span>
@@ -233,7 +235,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:4; --to:5;">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:4; --span:2;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label">schema + chunk grid + coords</span>
           <span class="gsd-seqB__msg-line"></span>
@@ -242,7 +244,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:3; --to:4;">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:3; --span:2;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label">lazy <code class="gsd-seqB__code">Dataset</code> (no chunks read yet)</span>
           <span class="gsd-seqB__msg-line"></span>
@@ -251,7 +253,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg" style="--from:1; --to:3;">
+        <div class="gsd-seqB__msg" style="--from:1; --span:3;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">ds.sst.sel(lat=slice(20,60), lon=slice(-80,0), time=slice("1990","2024"))</code></span>
           <span class="gsd-seqB__msg-line"></span>
@@ -260,7 +262,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__self" style="--from:3; --to:3;">
+        <div class="gsd-seqB__self" style="--from:3; --span:1;">
           <span class="gsd-seqB__self-marker"></span>
           map coord ranges → chunk indices
         </div>
@@ -270,7 +272,7 @@
         <span class="gsd-seqB__par-tag">par — parallel chunk fetch</span>
 
         <div class="gsd-seqB__row">
-          <div class="gsd-seqB__msg" style="--from:3; --to:4;">
+          <div class="gsd-seqB__msg" style="--from:3; --span:2;">
             <span class="gsd-seqB__msg-line"></span>
             <span class="gsd-seqB__msg-label">GET chunk (<em>t<sub>i</sub>, lat<sub>j</sub>, lon<sub>k</sub></em>)</span>
             <span class="gsd-seqB__msg-line"></span>
@@ -279,7 +281,7 @@
         </div>
 
         <div class="gsd-seqB__row">
-          <div class="gsd-seqB__msg" style="--from:4; --to:5;">
+          <div class="gsd-seqB__msg" style="--from:4; --span:2;">
             <span class="gsd-seqB__msg-line"></span>
             <span class="gsd-seqB__msg-label">HTTP GET</span>
             <span class="gsd-seqB__msg-line"></span>
@@ -288,7 +290,7 @@
         </div>
 
         <div class="gsd-seqB__row">
-          <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:4; --to:5;">
+          <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:4; --span:2;">
             <span class="gsd-seqB__msg-line"></span>
             <span class="gsd-seqB__msg-label">compressed chunk bytes</span>
             <span class="gsd-seqB__msg-line"></span>
@@ -297,7 +299,7 @@
         </div>
 
         <div class="gsd-seqB__row">
-          <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:3; --to:4;">
+          <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:3; --span:2;">
             <span class="gsd-seqB__msg-line"></span>
             <span class="gsd-seqB__msg-label">chunk array</span>
             <span class="gsd-seqB__msg-line"></span>
@@ -307,14 +309,14 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__self" style="--from:3; --to:3;">
+        <div class="gsd-seqB__self" style="--from:3; --span:1;">
           <span class="gsd-seqB__self-marker"></span>
           decompress + assemble + (optional) Dask graph
         </div>
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg" style="--from:1; --to:3;">
+        <div class="gsd-seqB__msg" style="--from:1; --span:3;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">.groupby("time.month").mean()</code></span>
           <span class="gsd-seqB__msg-line"></span>
@@ -323,7 +325,7 @@
       </div>
 
       <div class="gsd-seqB__row">
-        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:1; --to:3;">
+        <div class="gsd-seqB__msg gsd-seqB__msg--return gsd-seqB__msg--reverse" style="--from:1; --span:3;">
           <span class="gsd-seqB__msg-line"></span>
           <span class="gsd-seqB__msg-label"><code class="gsd-seqB__code">DataArray</code> (12, n_lat, n_lon)</span>
           <span class="gsd-seqB__msg-line"></span>

--- a/projects/geotoolz/_diagrams/07_stack_vector.html
+++ b/projects/geotoolz/_diagrams/07_stack_vector.html
@@ -1,0 +1,132 @@
+<style>
+  .gsd-stackC {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-connector: #8c959f;
+    --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    --gsd-accent-bg: #ddf4ff;
+    --gsd-accent-border: #54aeff;
+    --gsd-accent-fg: #0969da;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--gsd-fg);
+    max-width: 660px;
+    margin: 1.5em auto;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-stackC {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-connector: #6e7681;
+      --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --gsd-accent-bg: #0c2d6b;
+      --gsd-accent-border: #1f6feb;
+      --gsd-accent-fg: #79c0ff;
+    }
+  }
+  .gsd-stackC * { box-sizing: border-box; }
+  .gsd-stackC__grid {
+    display: grid;
+    grid-template-columns: 92px 1fr;
+    gap: 8px 14px;
+    align-items: stretch;
+  }
+  .gsd-stackC__label {
+    text-align: right;
+    align-self: center;
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--gsd-muted);
+  }
+  .gsd-stackC__row { display: flex; gap: 8px; }
+  .gsd-stackC__row--center { justify-content: center; }
+  .gsd-stackC__cell {
+    flex: 1;
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 6px;
+    padding: 10px 10px;
+    text-align: center;
+    font-weight: 600;
+    box-shadow: var(--gsd-shadow);
+  }
+  .gsd-stackC__cell--accent {
+    background: var(--gsd-accent-bg);
+    border-color: var(--gsd-accent-border);
+    color: var(--gsd-accent-fg);
+  }
+  .gsd-stackC__cell--narrow { flex: 0 0 60%; }
+  .gsd-stackC__cell small {
+    display: block;
+    font-weight: 400;
+    color: var(--gsd-muted);
+    font-size: 11.5px;
+    margin-top: 2px;
+  }
+  .gsd-stackC__cell--accent small { color: inherit; opacity: 0.85; }
+  .gsd-stackC__arrow {
+    grid-column: 2;
+    color: var(--gsd-connector);
+    text-align: center;
+    line-height: 1;
+    font-size: 11px;
+    margin: -2px 0;
+  }
+</style>
+<div class="gsd-stackC">
+  <div class="gsd-stackC__grid">
+
+    <div class="gsd-stackC__label">Viz / UX</div>
+    <div class="gsd-stackC__row">
+      <div class="gsd-stackC__cell">lonboard<small>GeoArrow / GPU</small></div>
+      <div class="gsd-stackC__cell">Felt<small>collaborative</small></div>
+    </div>
+
+    <div class="gsd-stackC__arrow">▼</div>
+
+    <div class="gsd-stackC__label">Engines</div>
+    <div class="gsd-stackC__row">
+      <div class="gsd-stackC__cell gsd-stackC__cell--accent">DuckDB SQL · GeoPandas<small>spatial joins · buffers · filters</small></div>
+    </div>
+
+    <div class="gsd-stackC__arrow">▼</div>
+
+    <div class="gsd-stackC__label">Substrate</div>
+    <div class="gsd-stackC__row">
+      <div class="gsd-stackC__cell">GeoArrow<small>zero-copy tabular spatial streams</small></div>
+    </div>
+
+    <div class="gsd-stackC__arrow">▼</div>
+
+    <div class="gsd-stackC__label">Readers</div>
+    <div class="gsd-stackC__row">
+      <div class="gsd-stackC__cell">pyogrio<small>fast OGR</small></div>
+      <div class="gsd-stackC__cell">PostGIS<small>database</small></div>
+      <div class="gsd-stackC__cell">SedonaDB<small>big data</small></div>
+    </div>
+
+    <div class="gsd-stackC__arrow">▼</div>
+
+    <div class="gsd-stackC__label">Transport</div>
+    <div class="gsd-stackC__row gsd-stackC__row--center">
+      <div class="gsd-stackC__cell gsd-stackC__cell--narrow">obstore</div>
+    </div>
+
+    <div class="gsd-stackC__arrow">▼</div>
+
+    <div class="gsd-stackC__label">Storage</div>
+    <div class="gsd-stackC__row">
+      <div class="gsd-stackC__cell">GeoParquet</div>
+      <div class="gsd-stackC__cell">PostgreSQL</div>
+      <div class="gsd-stackC__cell">FlatGeobuf</div>
+    </div>
+
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/08_lifecycle_vector.html
+++ b/projects/geotoolz/_diagrams/08_lifecycle_vector.html
@@ -1,0 +1,306 @@
+<style>
+  .gsd-seqC {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-soft: #f6f8fa;
+    --gsd-arrow: #0969da;
+    --gsd-return: #8c959f;
+    --gsd-par-bg: #fff8c5;
+    --gsd-par-border: #d4a72c;
+    --gsd-lifeline: #d0d7de;
+    --gsd-bg: #ffffff;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--gsd-fg);
+    max-width: 760px;
+    margin: 1.5em auto;
+    --cols: 4;
+    position: relative;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-seqC {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-soft: #21262d;
+      --gsd-arrow: #58a6ff;
+      --gsd-return: #6e7681;
+      --gsd-par-bg: #4d3c00;
+      --gsd-par-border: #d4a72c;
+      --gsd-lifeline: #30363d;
+      --gsd-bg: #0d1117;
+    }
+  }
+  .gsd-seqC * { box-sizing: border-box; }
+  .gsd-seqC__hdr {
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    background: var(--gsd-bg);
+    padding: 6px 0 10px;
+  }
+  .gsd-seqC__actor {
+    text-align: center;
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 6px;
+    padding: 8px 4px;
+    font-weight: 700;
+    font-size: 12px;
+    margin: 0 4px;
+  }
+  .gsd-seqC__actor small {
+    display: block; font-weight: 400; color: var(--gsd-muted); font-size: 11px;
+  }
+
+  .gsd-seqC__body { position: relative; padding: 4px 0 8px; }
+  .gsd-seqC__lifelines {
+    position: absolute; inset: 0;
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    pointer-events: none;
+    z-index: 1;
+  }
+  .gsd-seqC__lifelines > div {
+    border-left: 1px dashed var(--gsd-lifeline);
+    margin-left: calc(50% - 0.5px);
+    width: 1px;
+  }
+
+  .gsd-seqC__rows { position: relative; display: flex; flex-direction: column; gap: 4px; }
+  .gsd-seqC__row {
+    display: grid;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    gap: 0;
+    align-items: center;
+    min-height: 28px;
+  }
+  .gsd-seqC__msg {
+    grid-column: var(--from) / calc(var(--to) + 1);
+    padding-left: calc(50% / (var(--to) - var(--from) + 1));
+    padding-right: calc(50% / (var(--to) - var(--from) + 1));
+    display: flex;
+    align-items: center;
+    gap: 0;
+    color: var(--gsd-arrow);
+  }
+  .gsd-seqC__msg-line {
+    flex: 1; height: 1.5px; background: currentColor; border-radius: 1px;
+    position: relative; z-index: 2;
+  }
+  .gsd-seqC__msg-head {
+    font-size: 11px; line-height: 1; flex: 0 0 auto;
+    position: relative; z-index: 2;
+  }
+  .gsd-seqC__msg-label {
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 4px;
+    padding: 3px 8px;
+    color: var(--gsd-fg);
+    font-size: 12px;
+    line-height: 1.35;
+    margin: 0 4px;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-align: center;
+    position: relative;
+    z-index: 2;
+  }
+  .gsd-seqC__msg--return { color: var(--gsd-return); }
+  .gsd-seqC__msg--return .gsd-seqC__msg-line {
+    background: transparent;
+    border-top: 1.5px dashed currentColor;
+    height: 0;
+  }
+  .gsd-seqC__msg--reverse { flex-direction: row-reverse; }
+
+  .gsd-seqC__self {
+    grid-column: var(--from) / calc(var(--to) + 1);
+    padding-left: 50%;
+    display: flex;
+    align-items: center;
+    color: var(--gsd-muted);
+    font-size: 11.5px;
+    font-style: italic;
+    position: relative;
+    z-index: 2;
+    overflow: visible;
+    white-space: nowrap;
+  }
+  .gsd-seqC__self-marker {
+    width: 16px; height: 16px;
+    border: 1.5px solid var(--gsd-muted);
+    border-radius: 50%;
+    margin-right: 6px;
+    background: var(--gsd-bg);
+    flex: 0 0 auto;
+  }
+
+  .gsd-seqC__par {
+    background: var(--gsd-par-bg);
+    border: 1px solid var(--gsd-par-border);
+    border-radius: 6px;
+    margin: 6px 0;
+    padding: 10px 0 8px;
+    position: relative;
+  }
+  .gsd-seqC__par-tag {
+    position: absolute; top: -8px; left: 12px;
+    background: var(--gsd-par-border);
+    color: var(--gsd-bg);
+    font-size: 9.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 3px;
+    z-index: 3;
+  }
+
+  code.gsd-seqC__code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11.5px;
+    background: var(--gsd-soft);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+</style>
+<div class="gsd-seqC">
+  <div class="gsd-seqC__hdr">
+    <div class="gsd-seqC__actor">User<small>U</small></div>
+    <div class="gsd-seqC__actor">DuckDB<small>D · spatial</small></div>
+    <div class="gsd-seqC__actor">obstore<small>O</small></div>
+    <div class="gsd-seqC__actor">S3<small>S</small></div>
+  </div>
+
+  <div class="gsd-seqC__body">
+    <div class="gsd-seqC__lifelines">
+      <div></div><div></div><div></div><div></div>
+    </div>
+
+    <div class="gsd-seqC__rows">
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__msg" style="--from:1; --to:2;">
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-label"><code class="gsd-seqC__code">SELECT * FROM 's3://buildings.parquet' WHERE ST_Intersects(geom, :flood_bbox)</code></span>
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__msg" style="--from:2; --to:3;">
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-label">GET Parquet footer (small range)</span>
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__msg" style="--from:3; --to:4;">
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-label">HTTP Range</span>
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-head">▶</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:3; --to:4;">
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-label">row-group stats (bbox per group)</span>
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:2; --to:3;">
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-label">footer parsed</span>
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__self" style="--from:2; --to:2;">
+          <span class="gsd-seqC__self-marker"></span>
+          predicate pushdown — drop non-intersecting groups
+        </div>
+      </div>
+
+      <div class="gsd-seqC__par">
+        <span class="gsd-seqC__par-tag">par — parallel row-group fetch</span>
+
+        <div class="gsd-seqC__row">
+          <div class="gsd-seqC__msg" style="--from:2; --to:3;">
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-label">GET row-group <em>k</em> (geom + attr columns only)</span>
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-head">▶</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqC__row">
+          <div class="gsd-seqC__msg" style="--from:3; --to:4;">
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-label">HTTP Range</span>
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-head">▶</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqC__row">
+          <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:3; --to:4;">
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-label">column chunks</span>
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-head">◀</span>
+          </div>
+        </div>
+
+        <div class="gsd-seqC__row">
+          <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:2; --to:3;">
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-label">Arrow record batch</span>
+            <span class="gsd-seqC__msg-line"></span>
+            <span class="gsd-seqC__msg-head">◀</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__self" style="--from:2; --to:2;">
+          <span class="gsd-seqC__self-marker"></span>
+          <code class="gsd-seqC__code">ST_Intersects</code> on candidates (refine)
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:1; --to:2;">
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-label">GeoArrow result table</span>
+          <span class="gsd-seqC__msg-line"></span>
+          <span class="gsd-seqC__msg-head">◀</span>
+        </div>
+      </div>
+
+      <div class="gsd-seqC__row">
+        <div class="gsd-seqC__self" style="--from:1; --to:1;">
+          <span class="gsd-seqC__self-marker"></span>
+          hand to lonboard / GeoPandas (zero-copy)
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/projects/geotoolz/_diagrams/08_lifecycle_vector.html
+++ b/projects/geotoolz/_diagrams/08_lifecycle_vector.html
@@ -81,9 +81,10 @@
     min-height: 28px;
   }
   .gsd-seqC__msg {
-    grid-column: var(--from) / calc(var(--to) + 1);
-    padding-left: calc(50% / (var(--to) - var(--from) + 1));
-    padding-right: calc(50% / (var(--to) - var(--from) + 1));
+    grid-column: var(--from) / span var(--span);
+    /* shrink the bar inward so it starts/ends at column centers (where lifelines sit) */
+    padding-left: calc(50% / var(--span));
+    padding-right: calc(50% / var(--span));
     display: flex;
     align-items: center;
     gap: 0;
@@ -121,8 +122,8 @@
   .gsd-seqC__msg--reverse { flex-direction: row-reverse; }
 
   .gsd-seqC__self {
-    grid-column: var(--from) / calc(var(--to) + 1);
-    padding-left: 50%;
+    grid-column: var(--from) / span var(--span);
+    padding-left: calc(50% / var(--span));
     display: flex;
     align-items: center;
     color: var(--gsd-muted);
@@ -130,8 +131,9 @@
     font-style: italic;
     position: relative;
     z-index: 2;
-    overflow: visible;
-    white-space: nowrap;
+    /* allow self-call labels to wrap on narrow viewports */
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
   .gsd-seqC__self-marker {
     width: 16px; height: 16px;
@@ -187,7 +189,7 @@
     <div class="gsd-seqC__rows">
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__msg" style="--from:1; --to:2;">
+        <div class="gsd-seqC__msg" style="--from:1; --span:2;">
           <span class="gsd-seqC__msg-line"></span>
           <span class="gsd-seqC__msg-label"><code class="gsd-seqC__code">SELECT * FROM 's3://buildings.parquet' WHERE ST_Intersects(geom, :flood_bbox)</code></span>
           <span class="gsd-seqC__msg-line"></span>
@@ -196,7 +198,7 @@
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__msg" style="--from:2; --to:3;">
+        <div class="gsd-seqC__msg" style="--from:2; --span:2;">
           <span class="gsd-seqC__msg-line"></span>
           <span class="gsd-seqC__msg-label">GET Parquet footer (small range)</span>
           <span class="gsd-seqC__msg-line"></span>
@@ -205,7 +207,7 @@
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__msg" style="--from:3; --to:4;">
+        <div class="gsd-seqC__msg" style="--from:3; --span:2;">
           <span class="gsd-seqC__msg-line"></span>
           <span class="gsd-seqC__msg-label">HTTP Range</span>
           <span class="gsd-seqC__msg-line"></span>
@@ -214,7 +216,7 @@
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:3; --to:4;">
+        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:3; --span:2;">
           <span class="gsd-seqC__msg-line"></span>
           <span class="gsd-seqC__msg-label">row-group stats (bbox per group)</span>
           <span class="gsd-seqC__msg-line"></span>
@@ -223,7 +225,7 @@
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:2; --to:3;">
+        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:2; --span:2;">
           <span class="gsd-seqC__msg-line"></span>
           <span class="gsd-seqC__msg-label">footer parsed</span>
           <span class="gsd-seqC__msg-line"></span>
@@ -232,7 +234,7 @@
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__self" style="--from:2; --to:2;">
+        <div class="gsd-seqC__self" style="--from:2; --span:1;">
           <span class="gsd-seqC__self-marker"></span>
           predicate pushdown — drop non-intersecting groups
         </div>
@@ -242,7 +244,7 @@
         <span class="gsd-seqC__par-tag">par — parallel row-group fetch</span>
 
         <div class="gsd-seqC__row">
-          <div class="gsd-seqC__msg" style="--from:2; --to:3;">
+          <div class="gsd-seqC__msg" style="--from:2; --span:2;">
             <span class="gsd-seqC__msg-line"></span>
             <span class="gsd-seqC__msg-label">GET row-group <em>k</em> (geom + attr columns only)</span>
             <span class="gsd-seqC__msg-line"></span>
@@ -251,7 +253,7 @@
         </div>
 
         <div class="gsd-seqC__row">
-          <div class="gsd-seqC__msg" style="--from:3; --to:4;">
+          <div class="gsd-seqC__msg" style="--from:3; --span:2;">
             <span class="gsd-seqC__msg-line"></span>
             <span class="gsd-seqC__msg-label">HTTP Range</span>
             <span class="gsd-seqC__msg-line"></span>
@@ -260,7 +262,7 @@
         </div>
 
         <div class="gsd-seqC__row">
-          <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:3; --to:4;">
+          <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:3; --span:2;">
             <span class="gsd-seqC__msg-line"></span>
             <span class="gsd-seqC__msg-label">column chunks</span>
             <span class="gsd-seqC__msg-line"></span>
@@ -269,7 +271,7 @@
         </div>
 
         <div class="gsd-seqC__row">
-          <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:2; --to:3;">
+          <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:2; --span:2;">
             <span class="gsd-seqC__msg-line"></span>
             <span class="gsd-seqC__msg-label">Arrow record batch</span>
             <span class="gsd-seqC__msg-line"></span>
@@ -279,14 +281,14 @@
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__self" style="--from:2; --to:2;">
+        <div class="gsd-seqC__self" style="--from:2; --span:1;">
           <span class="gsd-seqC__self-marker"></span>
           <code class="gsd-seqC__code">ST_Intersects</code> on candidates (refine)
         </div>
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:1; --to:2;">
+        <div class="gsd-seqC__msg gsd-seqC__msg--return gsd-seqC__msg--reverse" style="--from:1; --span:2;">
           <span class="gsd-seqC__msg-line"></span>
           <span class="gsd-seqC__msg-label">GeoArrow result table</span>
           <span class="gsd-seqC__msg-line"></span>
@@ -295,7 +297,7 @@
       </div>
 
       <div class="gsd-seqC__row">
-        <div class="gsd-seqC__self" style="--from:1; --to:1;">
+        <div class="gsd-seqC__self" style="--from:1; --span:1;">
           <span class="gsd-seqC__self-marker"></span>
           hand to lonboard / GeoPandas (zero-copy)
         </div>

--- a/projects/geotoolz/_diagrams/09_libraries_fit.html
+++ b/projects/geotoolz/_diagrams/09_libraries_fit.html
@@ -1,0 +1,116 @@
+<style>
+  .gsd-libfit {
+    --gsd-fg: #1f2328;
+    --gsd-muted: #57606a;
+    --gsd-border: #d0d7de;
+    --gsd-card: #ffffff;
+    --gsd-connector: #8c959f;
+    --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    --gsd-highlight-bg: #fff8c5;
+    --gsd-highlight-border: #d4a72c;
+    --gsd-highlight-fg: #7d4e00;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--gsd-fg);
+    max-width: 560px;
+    margin: 1.5em auto;
+  }
+  @media (prefers-color-scheme: dark) {
+    .gsd-libfit {
+      --gsd-fg: #e6edf3;
+      --gsd-muted: #8b949e;
+      --gsd-border: #30363d;
+      --gsd-card: #161b22;
+      --gsd-connector: #6e7681;
+      --gsd-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --gsd-highlight-bg: #4d3c00;
+      --gsd-highlight-border: #d4a72c;
+      --gsd-highlight-fg: #f1e05a;
+    }
+  }
+  .gsd-libfit * { box-sizing: border-box; }
+  .gsd-libfit__stack { display: flex; flex-direction: column; align-items: stretch; }
+  .gsd-libfit__layer {
+    background: var(--gsd-card);
+    border: 1px solid var(--gsd-border);
+    border-radius: 8px;
+    padding: 10px 18px 12px;
+    text-align: center;
+    box-shadow: var(--gsd-shadow);
+  }
+  .gsd-libfit__layer--star {
+    background: var(--gsd-highlight-bg);
+    border-color: var(--gsd-highlight-border);
+  }
+  .gsd-libfit__tag {
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--gsd-muted);
+    display: block;
+    margin-bottom: 4px;
+  }
+  .gsd-libfit__layer--star .gsd-libfit__tag { color: var(--gsd-highlight-fg); }
+  .gsd-libfit__primary { margin: 0; font-size: 14px; font-weight: 600; }
+  .gsd-libfit__sub { margin: 2px 0 0; color: var(--gsd-muted); font-size: 12px; font-style: italic; }
+  .gsd-libfit__layer--star .gsd-libfit__primary { color: var(--gsd-highlight-fg); }
+  .gsd-libfit__layer--star .gsd-libfit__sub { color: var(--gsd-highlight-fg); opacity: 0.85; }
+  .gsd-libfit__arrow {
+    color: var(--gsd-connector);
+    text-align: center;
+    line-height: 1;
+    font-size: 11px;
+    margin: 4px 0;
+  }
+  .gsd-libfit__star { color: var(--gsd-highlight-border); margin-right: 4px; }
+</style>
+<div class="gsd-libfit">
+  <div class="gsd-libfit__stack">
+
+    <div class="gsd-libfit__layer">
+      <span class="gsd-libfit__tag">User</span>
+      <p class="gsd-libfit__primary">notebook · API · map</p>
+    </div>
+
+    <div class="gsd-libfit__arrow">▼</div>
+
+    <div class="gsd-libfit__layer gsd-libfit__layer--star">
+      <span class="gsd-libfit__tag">Logic</span>
+      <p class="gsd-libfit__primary"><span class="gsd-libfit__star">★</span>geotoolz · <span class="gsd-libfit__star">★</span>xrtoolz</p>
+      <p class="gsd-libfit__sub">future: geoarrax (JAX bridge)</p>
+    </div>
+
+    <div class="gsd-libfit__arrow">▼</div>
+
+    <div class="gsd-libfit__layer gsd-libfit__layer--star">
+      <span class="gsd-libfit__tag">Discovery</span>
+      <p class="gsd-libfit__primary"><span class="gsd-libfit__star">★</span>GeoCatalog</p>
+      <p class="gsd-libfit__sub">GeoParquet + DuckDB</p>
+    </div>
+
+    <div class="gsd-libfit__arrow">▼</div>
+
+    <div class="gsd-libfit__layer gsd-libfit__layer--star">
+      <span class="gsd-libfit__tag">Substrate</span>
+      <p class="gsd-libfit__primary"><span class="gsd-libfit__star">★</span>georeader</p>
+      <p class="gsd-libfit__sub">unified Reader Protocol</p>
+    </div>
+
+    <div class="gsd-libfit__arrow">▼</div>
+
+    <div class="gsd-libfit__layer">
+      <span class="gsd-libfit__tag">Transport</span>
+      <p class="gsd-libfit__primary">obstore · GDAL / VSI</p>
+    </div>
+
+    <div class="gsd-libfit__arrow">▼</div>
+
+    <div class="gsd-libfit__layer">
+      <span class="gsd-libfit__tag">Storage</span>
+      <p class="gsd-libfit__primary">COG · Zarr · GeoParquet</p>
+    </div>
+
+  </div>
+</div>

--- a/projects/geotoolz/geostack_notes.md
+++ b/projects/geotoolz/geostack_notes.md
@@ -31,36 +31,8 @@ keywords: geospatial, ecosystem, motivation, geotoolz, xrtoolz, geocatalog
 
 A flattened picture of the whole stack, before the detailed walk-through:
 
-```text
-                       [ STOREFRONT  —  the USER ]
-              ┌─────────────────────────────────────────────┐
-              │     notebook  ·  web map  ·  tile server    │
-              └──────────────────────▲──────────────────────┘
-                                     │
-                       [ FACTORIES  —  the LOGIC ]
-              ┌──────────────────────┴──────────────────────┐
-              │     pixel math  ·  joins  ·  regridding     │
-              │     compose, transform, reduce, render       │
-              └──────────────────────▲──────────────────────┘
-                                     │
-                  [ SHIPPING REGISTRY  —  DISCOVERY ]
-              ┌──────────────────────┴──────────────────────┐
-              │     "what exists, where it lives, what's     │
-              │      inside" — a queryable metadata index    │
-              └──────────────────────▲──────────────────────┘
-                                     │
-                    [ FORKLIFTS  —  the TRANSPORT ]
-              ┌──────────────────────┴──────────────────────┐
-              │   HTTP range requests  ·  concurrent IO     │
-              │   (only fetch the bytes you actually need)  │
-              └──────────────────────▲──────────────────────┘
-                                     │
-                    [ WAREHOUSES  —  the STORAGE ]
-              ┌──────────────────────┴──────────────────────┐
-              │  cloud object stores  ·  S3 / GCS / Azure   │
-              │  raster files · cube stores · tabular files │
-              └─────────────────────────────────────────────┘
-```
+:::{include} _diagrams/01_five_layer.html
+:::
 
 Read it from the bottom: bytes sit in **warehouses**, **forklifts** haul them out only when asked, the **registry** tells the forklift *which* warehouse to go to, **factories** turn raw cargo into finished products, and the **storefront** shows it to the human. Every layer above is useless without the one below — but the *registry* is the layer most people skip and then regret.
 
@@ -127,88 +99,8 @@ The cloud-native geospatial ecosystem is **mature at the edges** (storage format
 
 The full stack, with `GeoCatalog` as the discovery layer that ties the three data-plane stacks together:
 
-```{mermaid}
-flowchart TB
-    subgraph UX["Viz / UX"]
-        lonboard
-        titiler
-        Felt
-    end
-
-    subgraph LOGIC["Logic — Engines"]
-        geotoolz["geotoolz<br/>(imagery)"]
-        xrtoolz["xrtoolz<br/>(dense)"]
-        duckdb["DuckDB<br/>(vector)"]
-    end
-
-    subgraph DISC["Discovery — The Glue"]
-        cat["★ GeoCatalog ★<br/>GeoParquet / GeoJSON / STAC"]
-    end
-
-    subgraph SUB["Substrate — Readers"]
-        georeader
-        xarray
-        geopandas[GeoPandas]
-        agt[async-geotiff]
-    end
-
-    subgraph TRANSPORT["Transport — IO"]
-        obstore
-        kerchunk
-        vsi[GDAL / VSI]
-    end
-
-    subgraph STORAGE["Storage — Cloud"]
-        cog[COG]
-        zarr[Zarr]
-        gpq[GeoParquet]
-    end
-
-    UX --> LOGIC
-    LOGIC --> DISC
-    DISC --> SUB
-    SUB --> TRANSPORT
-    TRANSPORT --> STORAGE
-
-    style cat fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
-    style geotoolz fill:#e1f5ff,stroke:#0288d1
-    style xrtoolz fill:#e1f5ff,stroke:#0288d1
-```
-
-ASCII version (kept as the source of truth for terminal/PR review):
-
-```text
-                     [ THE USER / UI LAYER ]
-             ┌──────────────┬──────────────┬──────────────┐
-             │   lonboard   │   titiler    │     Felt     │
-             └──────▲───────┴──────▲───────┴──────▲───────┘
-                    │              │              │
-    ┌─────────────────────────────────────────────────────────────┐
-    │                 [ THE LOGIC LAYER (Engines) ]               │
-    │  geotoolz (Imagery)  ·  xrtoolz (Dense)  ·  DuckDB (Vector) │
-    └──────────────▲───────────────▲───────────────▲──────────────┘
-                   │               │               │
-    ┌──────────────┴───────────────┴───────────────┴──────────────┐
-    │               [ THE DISCOVERY LAYER (The Glue) ]            │
-    │                      ★ GeoCatalog ★                         │
-    │        (Metadata DB: GeoParquet / GeoJSON / STAC)           │
-    └──────────────┬───────────────┬───────────────┬──────────────┘
-                   │               │               │
-    ┌──────────────▼───────────────▼───────────────▼──────────────┐
-    │               [ THE SUBSTRATE / READERS ]                   │
-    │  georeader  ·  xarray  ·  GeoPandas  ·  async-geotiff       │
-    └──────────────┬───────────────┬───────────────┬──────────────┘
-                   │               │               │
-    ┌──────────────▼───────────────▼───────────────▼──────────────┐
-    │               [ THE TRANSPORT LAYER (IO) ]                  │
-    │               obstore  ·  kerchunk  ·  VSI                  │
-    └──────────────┬───────────────┬───────────────┬──────────────┘
-                   │               │               │
-    ┌──────────────▼───────────────▼───────────────▼──────────────┐
-    │               [ THE STORAGE LAYER (Cloud) ]                 │
-    │      COG      ·      Zarr     ·     GeoParquet              │
-    └─────────────────────────────────────────────────────────────┘
-```
+:::{include} _diagrams/02_unified_stack.html
+:::
 
 ### The catalog is the glue
 
@@ -238,37 +130,8 @@ The same six layers repeat across all three stacks; only the row contents change
 **Focus.** 2D/3D satellite and aerial imagery.
 **Philosophy.** Window-based processing — crop spatial slices from massive COGs via HTTP range requests.
 
-```text
-                ┌──────────────────┐    ┌─────────────────┐
-                │    lonboard      │    │    titiler      │
-   VIZ / UX  →  │  (Jupyter/GPU)   │    │ (Flexible API)  │
-                └────────┬─────────┘    └────────┬────────┘
-                         │                       │
-                ┌────────▼───────────────────────▼───────┐
-   COMPUTE   →  │              geotoolz                  │
-                │   Operator · Sequential · Graph        │
-                └────────────────┬───────────────────────┘
-                                 │ GeoTensor in / out
-                ┌────────────────▼───────────────────────┐
-   SUBSTRATE →  │       georeader (The Object Model)     │
-                │  GeoTensor · GeoSlice · GeoCatalog     │
-                └─────┬─────────────┬───────────────┬────┘
-                      │             │               │
-              ┌───────▼─────┐ ┌─────▼───────┐ ┌─────▼──────┐
-   READERS   →│ Rasterio-   │ │ async-      │ │  rio-      │
-              │ Reader      │ │ geotiff     │ │  tiler     │
-              └──────┬──────┘ └─────┬───────┘ └─────┬──────┘
-                     │              │               │
-              ┌──────▼──────┐       └───────┬───────┘
-   TRANSPORT →│  GDAL / VSI │               ▼
-              │ (Legacy IO) │      ┌─────────────────┐
-              └──────┬──────┘      │     obstore     │
-                     │             │(Rust Byte Mover)│
-                     ▼             └───────┬─────────┘
-              ┌──────────────────────────────────────┐
-   STORAGE   →│   COG (Cloud Optimized GeoTIFF)      │
-              └──────────────────────────────────────┘
-```
+:::{include} _diagrams/03_stack_imagery.html
+:::
 
 #### Layers
 
@@ -304,30 +167,8 @@ The same six layers repeat across all three stacks; only the row contents change
 
 A user asks for a low-cloud Sentinel-2 mosaic of Paris in 2024:
 
-```{mermaid}
-sequenceDiagram
-    participant U as User
-    participant C as GeoCatalog
-    participant R as Reader<br/>(georeader)
-    participant O as obstore
-    participant S as S3
-    U->>C: SQL: bbox ∩ Paris ∧ date ∈ 2024 ∧ cloud < 10
-    C-->>U: list of COG URLs + metadata
-    U->>R: open(urls, slice=GeoSlice(bbox))
-    R->>O: HEAD + small range read
-    O->>S: HTTP Range (header)
-    S-->>O: COG IFD bytes
-    O-->>R: tile offsets + nodata + CRS
-    R->>R: compute overlapping tile indices
-    par parallel tile fetch
-        R->>O: range read (tile k)
-        O->>S: HTTP Range (tile k)
-        S-->>O: compressed tile bytes
-        O-->>R: tile bytes
-    end
-    R->>R: decompress + assemble window
-    R-->>U: GeoTensor (CRS + affine + array)
-```
+:::{include} _diagrams/04_lifecycle_imagery.html
+:::
 
 **The trick.** The reader makes *two* round trips — first a cheap header read to learn tile layout, then a fan-out of concurrent range reads for just the tiles that overlap the AOI. That's how you turn a 10 GB scene into a 3 MB transfer.
 
@@ -338,41 +179,8 @@ sequenceDiagram
 **Focus.** Multi-dimensional scientific grids — climate, weather, oceanography.
 **Philosophy.** Coordinate-based DataCubes. Time, altitude, and variable are physical dimensions of a single labelled array.
 
-```text
-                ┌──────────────────┐    ┌─────────────────┐
-   VIZ / UX  →  │    lonboard      │    │    Holoviz      │
-                │  (GPU Render)    │    │ (Aggregation)   │
-                └────────┬─────────┘    └────────┬────────┘
-                         │                       │
-                ┌────────▼───────────────────────▼───────┐
-   COMPUTE   →  │              xrtoolz                   │
-                │   (N-D Algebra / Regridding / Means)   │
-                └────────────────┬───────────────────────┘
-                                 │ Dataset / DataArray
-                ┌────────────────▼───────────────────────┐
-   SUBSTRATE →  │       xarray (The DataCube Model)      │
-                │     Coordinates · Dimensions · Chunks  │
-                └─────┬──────────────┬──────────────┬────┘
-                      │              │              │
-              ┌───────▼─────┐ ┌──────▼──────┐ ┌─────▼──────┐
-   READERS   →│    Zarr     │ │  Icechunk   │ │ stackstac /│
-              │ (Standard)  │ │ (Versioned) │ │ odc-stac / │
-              │             │ │             │ │ lazycogs   │
-              └──────┬──────┘ └──────┬──────┘ └─────┬──────┘
-                     │               │              │
-              ┌──────▼───────────────▼──────┐       │
-   VIRTUAL   →│          kerchunk           │◀──────┘
-              │ (HDF5/NetCDF Virtualization)│
-              └──────────────┬──────────────┘
-                             │
-   TRANSPORT →      ┌────────▼─────────┐
-                    │     obstore      │
-                    └────────┬─────────┘
-                             ▼
-              ┌──────────────────────────────────────┐
-   STORAGE   →│     Zarr  ·  HDF5  ·  NetCDF         │
-              └──────────────────────────────────────┘
-```
+:::{include} _diagrams/05_stack_dense.html
+:::
 
 #### Layers
 
@@ -413,32 +221,8 @@ sequenceDiagram
 
 A climate scientist asks for monthly mean SST over the North Atlantic for 1990–2024:
 
-```{mermaid}
-sequenceDiagram
-    participant U as User
-    participant C as GeoCatalog
-    participant X as xarray
-    participant O as obstore
-    participant S as S3
-    U->>C: query: collection=ERA5, var=sst
-    C-->>U: Zarr URL
-    U->>X: xr.open_zarr(url)
-    X->>O: GET .zmetadata (consolidated)
-    O->>S: HTTP GET
-    S-->>O: schema + chunk grid + coords
-    O-->>X: lazy Dataset (no chunks read yet)
-    U->>X: ds.sst.sel(lat=slice(20,60), lon=slice(-80,0), time=slice("1990","2024"))
-    X->>X: map coord ranges → chunk indices
-    par parallel chunk fetch
-        X->>O: GET chunk (t_i, lat_j, lon_k)
-        O->>S: HTTP GET
-        S-->>O: compressed chunk bytes
-        O-->>X: chunk array
-    end
-    X->>X: decompress + assemble + (optional) Dask graph
-    U->>X: .groupby("time.month").mean()
-    X-->>U: DataArray (12, n_lat, n_lon)
-```
+:::{include} _diagrams/06_lifecycle_dense.html
+:::
 
 **The trick.** Coordinate selection (`.sel`) is translated into chunk indices *before* any bytes are read; only the chunks intersecting the requested coordinate hyperrectangle are fetched. Lazy evaluation through Dask means downstream reductions (`.mean()`) collapse the chunk-fetch + compute graph into a single optimised pass.
 
@@ -449,37 +233,8 @@ sequenceDiagram
 **Focus.** Discrete features — points, lines, polygons, and their attributes.
 **Philosophy.** Tabular and relational. Geography is just another column in a high-performance database.
 
-```text
-                ┌──────────────────┐    ┌─────────────────┐
-   VIZ / UX  →  │    lonboard      │    │      Felt       │
-                │ (GeoArrow/GPU)   │    │ (Collaborative) │
-                └────────┬─────────┘    └────────┬────────┘
-                         │                       │
-                ┌────────▼───────────────────────▼───────┐
-   ENGINES   →  │      DuckDB SQL  /  GeoPandas          │
-                │    (Spatial Joins / Buffers / Filters) │
-                └────────────────┬───────────────────────┘
-                                 │ GeoArrow / DataFrames
-                ┌────────────────▼───────────────────────┐
-   SUBSTRATE →  │    GeoArrow (The Memory Layout)        │
-                │   Zero-copy Tabular Spatial Streams    │
-                └─────┬──────────────┬──────────────┬────┘
-                      │              │              │
-              ┌───────▼─────┐ ┌──────▼──────┐ ┌─────▼──────┐
-   READERS   →│   pyogrio   │ │   PostGIS   │ │  SedonaDB  │
-              │ (Fast OGR)  │ │ (Database)  │ │ (Big Data) │
-              └──────┬──────┘ └──────┬──────┘ └─────┬──────┘
-                     │               │              │
-   TRANSPORT →       └───────┬───────┴──────────────┘
-                             ▼
-                    ┌─────────────────┐
-                    │     obstore     │
-                    └────────┬────────┘
-                             ▼
-              ┌──────────────────────────────────────┐
-   STORAGE   →│  GeoParquet · PostgreSQL · FlatGeobuf│
-              └──────────────────────────────────────┘
-```
+:::{include} _diagrams/07_stack_vector.html
+:::
 
 #### Layers
 
@@ -522,28 +277,8 @@ sequenceDiagram
 
 An analyst asks for all building footprints in a flood zone:
 
-```{mermaid}
-sequenceDiagram
-    participant U as User
-    participant D as DuckDB<br/>(spatial)
-    participant O as obstore
-    participant S as S3
-    U->>D: SELECT * FROM 's3://buildings.parquet'<br/>WHERE ST_Intersects(geom, :flood_bbox)
-    D->>O: GET Parquet footer (small range)
-    O->>S: HTTP Range
-    S-->>O: row-group stats (bbox per group)
-    O-->>D: footer parsed
-    D->>D: predicate pushdown — drop non-intersecting groups
-    par parallel row-group fetch
-        D->>O: GET row-group k (geom + attr columns only)
-        O->>S: HTTP Range
-        S-->>O: column chunks
-        O-->>D: Arrow record batch
-    end
-    D->>D: ST_Intersects on candidates (refine)
-    D-->>U: GeoArrow result table
-    U->>U: hand to lonboard / GeoPandas (zero-copy)
-```
+:::{include} _diagrams/08_lifecycle_vector.html
+:::
 
 **The trick.** Two stages of filtering: (1) **row-group pruning** using the bbox statistics in the Parquet footer skips entire row groups that can't possibly intersect, and only the surviving groups are fetched. (2) **column pruning** means non-needed attribute columns are never read off the wire. The result lands as Arrow buffers, so the hand-off to `lonboard` or GeoPandas is zero-copy.
 
@@ -555,21 +290,8 @@ sequenceDiagram
 
 Most of the modern stack is **already there**. Two of the three libraries below (`georeader` modernisation, `GeoCatalog`) are *reconciliation* work — taking pieces that already work and giving them a coherent surface. The third (`geotoolz` + `xrtoolz`) is the genuinely missing piece: the **factory layer** that doesn't yet have a good general-purpose shape.
 
-```{mermaid}
-flowchart TB
-    USER["<b>USER</b><br/>notebook · API · map"]
-    LOGIC["<b>LOGIC</b><br/>★ geotoolz   ·   ★ xrtoolz<br/><i>future: geoarrax (JAX bridge)</i>"]
-    DISC["<b>DISCOVERY</b><br/>★ GeoCatalog<br/>(GeoParquet + DuckDB)"]
-    SUBS["<b>SUBSTRATE</b><br/>★ georeader (unified Reader Protocol)"]
-    TRANS["<b>TRANSPORT</b><br/>obstore · GDAL/VSI"]
-    STOR["<b>STORAGE</b><br/>COG · Zarr · GeoParquet"]
-
-    USER --> LOGIC --> DISC --> SUBS --> TRANS --> STOR
-
-    style LOGIC fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
-    style DISC fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
-    style SUBS fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px
-```
+:::{include} _diagrams/09_libraries_fit.html
+:::
 
 Stars mark where my libraries plug in. Read it from the top: a user wants something → engines compose carriers → the registry tells them which files to open → readers translate cloud bytes into typed carriers → transport hauls only the bytes needed → cloud storage is the source of truth.
 


### PR DESCRIPTION
## Summary
- Replaces all 10 ASCII / mermaid diagrams in `projects/geotoolz/geostack_notes.md` with scoped self-contained HTML fragments under `projects/geotoolz/_diagrams/`, embedded via mystmd `:::{include}` directives.
- Layered stacks (five-layer view, Grand Unified GeoStack, Stack A/B/C, "Where my libraries fit") render as CSS-grid layouts with row labels and inline highlights for the starred libraries.
- Lifecycle / sequence diagrams (Sentinel-2, ERA5, buildings) render as swimlane diagrams: actor headers on top, dashed lifelines, blue forward arrows + grey dashed return arrows, with `par` blocks highlighted in a yellow card while the lifelines pass continuously through.
- Collapsed the dual `{mermaid}` + "ASCII version (kept as the source of truth for terminal/PR review)" pair for the Grand Unified GeoStack into a single HTML embed (the prose intro to the ASCII variant is gone too).

## Visual fixes baked in
- Lifecycle messages align to lifeline centres: drop grid `gap` and pad the message bar inward by `50% / span_count`.
- `par` block sits behind the lifelines via `z-index`, with message labels/arrows above both.
- Long messages wrap to multiple lines (no ellipsis truncation), so the figure stays the same width when text is long.
- All fragments are theme-aware via `prefers-color-scheme`; styles are class-scoped (`.gsd-fivelayer`, `.gsd-unified`, `.gsd-stackA/B/C`, `.gsd-seqA/B/C`, `.gsd-libfit`) so multiple diagrams on one page do not collide.

## Files
- `projects/geotoolz/_diagrams/01_five_layer.html` — five-layer view (warehouse / forklift / registry / factory / storefront)
- `projects/geotoolz/_diagrams/02_unified_stack.html` — Grand Unified GeoStack (collapsed mermaid + ASCII pair)
- `projects/geotoolz/_diagrams/03_stack_imagery.html` — Stack A (imagery)
- `projects/geotoolz/_diagrams/04_lifecycle_imagery.html` — Sentinel-2 query swimlane
- `projects/geotoolz/_diagrams/05_stack_dense.html` — Stack B (dense)
- `projects/geotoolz/_diagrams/06_lifecycle_dense.html` — ERA5 SST query swimlane
- `projects/geotoolz/_diagrams/07_stack_vector.html` — Stack C (vector)
- `projects/geotoolz/_diagrams/08_lifecycle_vector.html` — buildings query swimlane (4 lanes)
- `projects/geotoolz/_diagrams/09_libraries_fit.html` — Where my libraries fit
- `projects/geotoolz/geostack_notes.md` — fenced ASCII / mermaid blocks replaced with `:::{include}` directives

## Test plan
- [ ] `myst start` renders `projects/geotoolz/geostack_notes.md` without sanitisation errors and all 9 figures appear inline.
- [ ] Lifecycle swimlane arrows terminate exactly on the dashed lifelines (no overhang).
- [ ] `par` block lifelines pass through the yellow band, message labels still float above them.
- [ ] Long labels (e.g. the SQL string in 04 / 08) wrap inside the bar instead of being clipped with `…`.
- [ ] Light and dark themes both render acceptably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)