### PR TITLE
docs(geotoolz): sklearn + skimage bridges; ventilated prose across all docs

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -133,6 +133,14 @@ project:
                       children:
                         - file: projects/geotoolz/plans/geotoolz/examples/usecases.md
                         - file: projects/geotoolz/plans/geotoolz/examples/tips_n_tricks.md
+                    - title: scikit-image bridge
+                      children:
+                        - file: projects/geotoolz/plans/geotoolz/skimage/design_skimage.md
+                        - file: projects/geotoolz/plans/geotoolz/skimage/examples_skimage.md
+                    - title: scikit-learn bridge
+                      children:
+                        - file: projects/geotoolz/plans/geotoolz/sklearn/design_sklearn.md
+                        - file: projects/geotoolz/plans/geotoolz/sklearn/examples_sklearn.md
                 - title: Reader reconciliation
                   children:
                     - file: projects/geotoolz/plans/georeader/README.md

--- a/projects/geotoolz/georeader_tutorial/00_index.md
+++ b/projects/geotoolz/georeader_tutorial/00_index.md
@@ -15,8 +15,7 @@ license: CC-BY-4.0
 keywords: tutorial, georeader
 ---
 
-> **Source:** [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader/tree/f0d92f0) @ branch `feature/geotensor_npapi`, commit [`f0d92f0`](https://github.com/spaceml-org/georeader/tree/f0d92f0)
-> **Goal:** a module-by-module tutorial that captures the package's capabilities **and preserves all ASCII diagrams** before they're cleaned up downstream.
+> **Source:** [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader/tree/f0d92f0) @ branch `feature/geotensor_npapi`, commit [`f0d92f0`](https://github.com/spaceml-org/georeader/tree/f0d92f0) **Goal:** a module-by-module tutorial that captures the package's capabilities **and preserves all ASCII diagrams** before they're cleaned up downstream.
 
 The package is ~20k LOC across 17 top-level files + 14 reader modules. ~1100 lines of box-drawing ASCII art are scattered across docstrings — this is the doc treasure we're rescuing.
 
@@ -24,7 +23,9 @@ The package is ~20k LOC across 17 top-level files + 14 reader modules. ~1100 lin
 
 ## Recommended tutorial structure
 
-Each chapter = one file under `georeader_tutorial/`. We work through them one at a time. Diagrams are copied verbatim into the tutorial; surrounding prose explains the concept and adds runnable examples.
+Each chapter = one file under `georeader_tutorial/`.
+We work through them one at a time.
+Diagrams are copied verbatim into the tutorial; surrounding prose explains the concept and adds runnable examples.
 
 ### Part I — Core data model
 
@@ -95,7 +96,8 @@ emit.py                  27    ← EMIT NetCDF layout
 TOTAL                  ~1148 box-drawing chars across 17 files
 ```
 
-(Plus pipe-tables and `+--+`-style diagrams not counted above. Per-chapter we'll grep these out exhaustively.)
+(Plus pipe-tables and `+--+`-style diagrams not counted above.
+Per-chapter we'll grep these out exhaustively.)
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/01_geotensor.md
+++ b/projects/geotoolz/georeader_tutorial/01_geotensor.md
@@ -15,9 +15,8 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, geotensor, numpy
 ---
 
-> **Module:** `georeader/geotensor.py` (2532 LOC)
-> **Branch:** `feature/geotensor_npapi` — this module *is* the headline change of that branch.
-> **Role:** the package's central data structure. Every reader in georeader produces a `GeoTensor`; every writer consumes one; every operator in `geotoolz` will be `GeoTensor → GeoTensor`.
+> **Module:** `georeader/geotensor.py` (2532 LOC) **Branch:** `feature/geotensor_npapi` — this module *is* the headline change of that branch. **Role:** the package's central data structure.
+> Every reader in georeader produces a `GeoTensor`; every writer consumes one; every operator in `geotoolz` will be `GeoTensor → GeoTensor`.
 
 ---
 
@@ -25,9 +24,11 @@ keywords: tutorial, georeader, geotensor, numpy
 
 A `numpy.ndarray` **subclass** that carries `(transform, crs, fill_value_default, attrs)` alongside the buffer, and propagates that metadata through ufuncs, slicing, copies, and views — so `gt + 1`, `np.sqrt(gt)`, and `gt[:, 100:200, 100:200]` all return correctly georeferenced `GeoTensor`s with **zero** boilerplate at the call site.
 
-This is a fundamentally different design from the previous `GeoTensor` (which was a wrapper holding a `.values` array). On this branch:
+This is a fundamentally different design from the previous `GeoTensor` (which was a wrapper holding a `.values` array).
+On this branch:
 
-- `gt` *is* an ndarray. You can pass it to anything that takes one.
+- `gt` *is* an ndarray.
+  You can pass it to anything that takes one.
 - `gt.values` exists as a back-compat property returning `self.view(np.ndarray)`.
 - `__array_ufunc__` intercepts ufuncs to re-wrap the result with the original metadata.
 - `__array_finalize__` propagates metadata across views/copies/slices.
@@ -37,7 +38,8 @@ This is a fundamentally different design from the previous `GeoTensor` (which wa
 
 ## 2. Memory layout and dim conventions
 
-`GeoTensor` supports 2D, 3D, and 4D arrays. **The last two dimensions are always spatial** — `(..., y, x)` — and are the only dimensions whose semantics the class is opinionated about.
+`GeoTensor` supports 2D, 3D, and 4D arrays.
+**The last two dimensions are always spatial** — `(..., y, x)` — and are the only dimensions whose semantics the class is opinionated about.
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -60,7 +62,8 @@ This is a fundamentally different design from the previous `GeoTensor` (which wa
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-`dims` is computed from the array's `ndim` — it isn't free-form like xarray's. The constructor raises `ValueError` for `ndim < 2` or `ndim > 4`.
+`dims` is computed from the array's `ndim` — it isn't free-form like xarray's.
+The constructor raises `ValueError` for `ndim < 2` or `ndim > 4`.
 
 ---
 
@@ -97,9 +100,11 @@ This is a fundamentally different design from the previous `GeoTensor` (which wa
 
 A few things this diagram is doing implicitly:
 
-- **The y-axis is flipped.** Image-space convention is row 0 at the top; geographic-space convention is y increasing northward. The negative `e` reconciles them.
+- **The y-axis is flipped.** Image-space convention is row 0 at the top; geographic-space convention is y increasing northward.
+  The negative `e` reconciles them.
 - **`b` and `d` are nonzero only for rotated/sheared rasters.** Most readers in georeader assume north-up; some readers (PRISMA, EnMAP, MODIS swath) deliberately don't and route through `griddata` instead — see [Chapter 7](07_griddata.md).
-- **`bounds` is derived, not stored.** `gt.bounds` returns `(minx, miny, maxx, maxy)` computed from `transform` and `shape` on every access. Likewise `gt.res = (|a|, |e|)`.
+- **`bounds` is derived, not stored.** `gt.bounds` returns `(minx, miny, maxx, maxy)` computed from `transform` and `shape` on every access.
+  Likewise `gt.res = (|a|, |e|)`.
 
 ---
 
@@ -135,7 +140,8 @@ The mechanics behind this — three numpy hooks doing the heavy lifting:
 | `__array_ufunc__` | called on every ufunc (`np.add`, `np.sqrt`, …) | Strips inputs to plain ndarrays, applies the ufunc, re-wraps the output as a `GeoTensor` with metadata copied from the first `GeoTensor` input. |
 | `__getitem__` | called on `gt[...]` | Standard ndarray slice, then **rewrites `transform`** if the spatial axes (last two) were sliced — origin shifts by `start * res`, resolution rescales by `step`. |
 
-The aggregation case (`.mean()`, `.sum(axis=0)`) returns a scalar or lower-dim array; a *spatial* reduction usually returns a plain ndarray because the result no longer has a meaningful transform. (See `_preserved_spatial` at [geotensor.py:385](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L385).)
+The aggregation case (`.mean()`, `.sum(axis=0)`) returns a scalar or lower-dim array; a *spatial* reduction usually returns a plain ndarray because the result no longer has a meaningful transform.
+(See `_preserved_spatial` at [geotensor.py:385](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L385).)
 
 ---
 
@@ -163,7 +169,8 @@ Round-trip helpers: `gt.to_json()` / `GeoTensor.from_json(d)` — useful for cat
 
 ## 6. xarray-style indexing: `isel`
 
-`__getitem__` is the numpy-positional path. `isel` is the **named-dimension** path — closer to xarray ergonomics and the recommended API for geotoolz operators.
+`__getitem__` is the numpy-positional path.
+`isel` is the **named-dimension** path — closer to xarray ergonomics and the recommended API for geotoolz operators.
 
 ```text
 Standard dimension names for 3D GeoTensor (C, H, W):
@@ -176,7 +183,9 @@ Standard dimension names for 3D GeoTensor (C, H, W):
 └──────────┴────────────────┴────────────────────┘
 ```
 
-`isel` accepts a dict mapping dim names to `slice`, `list[int]`, or `int`. Spatial dims (`"x"`, `"y"`) only accept slices — fancy indexing on spatial axes would invalidate the affine transform. Examples (per the docstring):
+`isel` accepts a dict mapping dim names to `slice`, `list[int]`, or `int`.
+Spatial dims (`"x"`, `"y"`) only accept slices — fancy indexing on spatial axes would invalidate the affine transform.
+Examples (per the docstring):
 
 - `gt.isel({"x": slice(10, 110)})` — columns 10..109
 - `gt.isel({"band": [3, 2, 1]})` — pick + reorder bands (RGB from S2 BGR)
@@ -188,7 +197,8 @@ Source: [geotensor.py:1330](https://github.com/spaceml-org/georeader/blob/f0d92f
 
 ## 7. Padding for fixed-size tiles
 
-`gt.pad(pad_width=...)` extends a `GeoTensor` with the fill value. Useful when CNN inference needs a fixed input size and your tile lands at a scene edge.
+`gt.pad(pad_width=...)` extends a `GeoTensor` with the fill value.
+Useful when CNN inference needs a fixed input size and your tile lands at a scene edge.
 
 ```text
 pad_width = {"x": (2, 3), "y": (1, 4)}
@@ -210,13 +220,15 @@ Original (5×5):           Padded (10×10):
                             left        right
 ```
 
-Padding shifts `transform.c` (origin x) leftward by `pad_left * res_x` and `transform.f` (origin y) upward by `pad_top * res_y` so the geographic position of the original pixels is unchanged. There's a sister method `pad_array` that pads only the buffer without touching the transform — used internally by readers.
+Padding shifts `transform.c` (origin x) leftward by `pad_left * res_x` and `transform.f` (origin y) upward by `pad_top * res_y` so the geographic position of the original pixels is unchanged.
+There's a sister method `pad_array` that pads only the buffer without touching the transform — used internally by readers.
 
 ---
 
 ## 8. Window-based reads: boundless vs bounded
 
-`gt.read_from_window(window, boundless=True|False)` extracts a sub-region using a `rasterio.windows.Window`. The same interface as rasterio's lazy windowed reads, so you can swap a `RasterioReader` for an in-memory `GeoTensor` without changing call sites — this is the whole point of the [abstract reader protocol](02_abstract_reader.md).
+`gt.read_from_window(window, boundless=True|False)` extracts a sub-region using a `rasterio.windows.Window`.
+The same interface as rasterio's lazy windowed reads, so you can swap a `RasterioReader` for an in-memory `GeoTensor` without changing call sites — this is the whole point of the [abstract reader protocol](02_abstract_reader.md).
 
 ```text
 Window extends beyond data:     boundless=True:      boundless=False:
@@ -230,7 +242,8 @@ Window extends beyond data:     boundless=True:      boundless=False:
      request                  fill_value
 ```
 
-`boundless=True` (the default for `RasterioReader` reads in georeader) is the right choice for tiled inference: every chip comes back with the requested shape, so batches stack cleanly. `boundless=False` is useful when you want to *know* you're at an edge.
+`boundless=True` (the default for `RasterioReader` reads in georeader) is the right choice for tiled inference: every chip comes back with the requested shape, so batches stack cleanly.
+`boundless=False` is useful when you want to *know* you're at an edge.
 
 Source: [geotensor.py:2227](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L2227).
 
@@ -238,7 +251,8 @@ Source: [geotensor.py:2227](https://github.com/spaceml-org/georeader/blob/f0d92f
 
 ## 9. Stacking — building time series
 
-`GeoTensor.stack([gt1, gt2, gt3])` is a classmethod that prepends a new axis. All inputs must share `transform`, `crs`, and `shape` (checked via `same_extent`).
+`GeoTensor.stack([gt1, gt2, gt3])` is a classmethod that prepends a new axis.
+All inputs must share `transform`, `crs`, and `shape` (checked via `same_extent`).
 
 ```text
 Input: 3 GeoTensors each (3, H, W)
@@ -249,7 +263,8 @@ gt3: (3, 100, 100)  ─┘     ↑
                         new time/batch dim
 ```
 
-Result `dims = ("time", "band", "y", "x")`. There's also `concatenate(geotensors, axis=0)` for joining along an existing axis (e.g., concatenating bands from two coregistered scenes).
+Result `dims = ("time", "band", "y", "x")`.
+There's also `concatenate(geotensors, axis=0)` for joining along an existing axis (e.g., concatenating bands from two coregistered scenes).
 
 ---
 
@@ -304,19 +319,25 @@ Grouped roughly by lifecycle:
 
 Three concrete wins for the operator-composition layer:
 
-1. **Operators stop unwrapping.** Pre-redesign code looked like `out = my_func(gt.values); return GeoTensor(out, gt.transform, gt.crs, ...)`. Now it's `return my_func(gt)` — the ufunc protocol carries the metadata for free.
-2. **scikit-image / scipy.ndimage interop is half-free.** Anything that goes through ufuncs round-trips automatically. Functions that don't (`skimage.transform.resize`, `scipy.ndimage.uniform_filter`) need a small `preserve_subclass` decorator at the Tier B layer — see [geotoolz.md §5.2](../plans/geotoolz/geotoolz.md).
+1. **Operators stop unwrapping.** Pre-redesign code looked like `out = my_func(gt.values); return GeoTensor(out, gt.transform, gt.crs, ...)`.
+   Now it's `return my_func(gt)` — the ufunc protocol carries the metadata for free.
+2. **scikit-image / scipy.ndimage interop is half-free.** Anything that goes through ufuncs round-trips automatically.
+   Functions that don't (`skimage.transform.resize`, `scipy.ndimage.uniform_filter`) need a small `preserve_subclass` decorator at the Tier B layer — see [geotoolz.md §5.2](../plans/geotoolz/geotoolz.md).
 3. **Time becomes a first-class axis** without inventing a new container. 4D `(T, C, H, W)` is just an ndarray shape; `GeoTensor.stack` builds it; numpy reductions slice it.
 
-The downside to be aware of: spatial reductions (e.g., `gt.sum(axis=(-2,-1))`) drop to a plain ndarray because the result has no transform. Operators that want to keep a `GeoTensor`-shaped result for *non-spatial* reductions must wrap the output explicitly via `gt.array_as_geotensor(...)`.
+The downside to be aware of: spatial reductions (e.g., `gt.sum(axis=(-2,-1))`) drop to a plain ndarray because the result has no transform.
+Operators that want to keep a `GeoTensor`-shaped result for *non-spatial* reductions must wrap the output explicitly via `gt.array_as_geotensor(...)`.
 
 ---
 
 ## 12. Sharp edges
 
-- **Same-extent rule for binary ops.** `gt1 + gt2` raises if the transforms or shapes don't match (see `same_extent` and the `__add__` body at [geotensor.py:625](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L625)). Reproject first, don't try to "broadcast" across spatial extent.
-- **`fill_value_default` is metadata, not a mask.** It's used by `read_from_window(boundless=True)`, `validmask()`, `invalidmask()`, and `pad`. It does *not* turn arithmetic into masked arithmetic — `gt + 1` still adds 1 to nodata pixels.
+- **Same-extent rule for binary ops.** `gt1 + gt2` raises if the transforms or shapes don't match (see `same_extent` and the `__add__` body at [geotensor.py:625](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/geotensor.py#L625)).
+  Reproject first, don't try to "broadcast" across spatial extent.
+- **`fill_value_default` is metadata, not a mask.** It's used by `read_from_window(boundless=True)`, `validmask()`, `invalidmask()`, and `pad`.
+  It does *not* turn arithmetic into masked arithmetic — `gt + 1` still adds 1 to nodata pixels.
 - **Spatial slicing must use `slice`, not lists.** `gt.isel({"x": [0, 5, 10]})` is rejected; the resulting raster wouldn't be regularly sampled and the transform wouldn't be definable.
-- **`crs` is whatever rasterio accepts.** EPSG int, EPSG string, WKT, or `pyproj.CRS`. The class doesn't normalise — be consistent within a pipeline.
+- **`crs` is whatever rasterio accepts.** EPSG int, EPSG string, WKT, or `pyproj.CRS`.
+  The class doesn't normalise — be consistent within a pipeline.
 
 Next chapter: [02_abstract_reader.md](02_abstract_reader.md) — the type hierarchy and protocols that make `GeoTensor` and `RasterioReader` interchangeable.

--- a/projects/geotoolz/georeader_tutorial/02_abstract_reader.md
+++ b/projects/geotoolz/georeader_tutorial/02_abstract_reader.md
@@ -15,14 +15,15 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, protocol
 ---
 
-> **Module:** `georeader/abstract_reader.py` (257 LOC)
-> **Role:** the duck-typing contract that lets `GeoTensor` (in-memory) and `RasterioReader` (lazy on-disk) be passed interchangeably to every function in the package.
+> **Module:** `georeader/abstract_reader.py` (257 LOC) **Role:** the duck-typing contract that lets `GeoTensor` (in-memory) and `RasterioReader` (lazy on-disk) be passed interchangeably to every function in the package.
 
 ---
 
 ## 1. The one-line idea
 
-Anything with `transform`, `crs`, `shape` is **`GeoDataBase`**. Anything that *additionally* knows how to materialise its data (`values`, `load()`, `read_from_window()`) is **`GeoData`** (alias `AbstractGeoData`). Most of `georeader.read`, `georeader.window_utils`, `georeader.mosaic` etc. type-annotate against these protocols, so the same function body works on either substrate.
+Anything with `transform`, `crs`, `shape` is **`GeoDataBase`**.
+Anything that *additionally* knows how to materialise its data (`values`, `load()`, `read_from_window()`) is **`GeoData`** (alias `AbstractGeoData`).
+Most of `georeader.read`, `georeader.window_utils`, `georeader.mosaic` etc. type-annotate against these protocols, so the same function body works on either substrate.
 
 This is the seam that the [Reader reconciliation design](../plans/georeader/README.md) wants to widen — make `RasterioReader` and `AsyncGeoTIFFReader` (and any future sensor-specific or raw-byte reader) all honour the same protocol, then user code does `reader_class=...` strategy injection.
 
@@ -57,7 +58,8 @@ This is the seam that the [Reader reconciliation design](../plans/georeader/READ
 
 Two splits to notice:
 
-- **Vertical:** `GeoDataBase` (just enough to *describe* a raster — useful for window math without ever loading bytes) vs `GeoData` (can materialise). The `FakeGeoData` dataclass below is the canonical `GeoDataBase`-only object.
+- **Vertical:** `GeoDataBase` (just enough to *describe* a raster — useful for window math without ever loading bytes) vs `GeoData` (can materialise).
+  The `FakeGeoData` dataclass below is the canonical `GeoDataBase`-only object.
 - **Horizontal:** `RasterioReader` (lazy, file-backed), `GeoTensor` (in-memory ndarray subclass), and any third-party reader that conforms.
 
 In the file, `AbstractGeoData = GeoData` is set as a back-compat alias — older code refers to `AbstractGeoData`; new code should prefer `GeoData`.
@@ -103,17 +105,28 @@ The base class deliberately raises `NotImplementedError` for `dtype`, `dims`, an
 
 ## 4. Reading the source
 
-The whole file is short enough to read in one sitting. Key landmarks:
+The whole file is short enough to read in one sitting.
+Key landmarks:
 
-- **`GeoDataBase`** — [abstract_reader.py:147](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L147). Pure `Protocol` with `transform`, `crs`, `shape` and computed `width`/`height`. No `load`. Any class that has these three attrs satisfies it without inheriting (structural typing via `typing.Protocol`).
+- **`GeoDataBase`** — [abstract_reader.py:147](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L147).
+  Pure `Protocol` with `transform`, `crs`, `shape` and computed `width`/`height`.
+  No `load`.
+  Any class that has these three attrs satisfies it without inheriting (structural typing via `typing.Protocol`).
 
-- **`FakeGeoData`** — [abstract_reader.py:169](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L169). A `@dataclass` placeholder used for window/bounds math when you don't want to allocate the array. Three fields: `crs`, `transform`, `shape` (optional). Used heavily inside `read.py` to do "what window would I read?" calculations before deciding whether to actually fetch bytes.
+- **`FakeGeoData`** — [abstract_reader.py:169](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L169).
+  A `@dataclass` placeholder used for window/bounds math when you don't want to allocate the array.
+  Three fields: `crs`, `transform`, `shape` (optional).
+  Used heavily inside `read.py` to do "what window would I read?" calculations before deciding whether to actually fetch bytes.
 
-- **`GeoData`** — [abstract_reader.py:188](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L188). The full reader interface. Defines `load(boundless=True)`, `read_from_window(window, boundless)`, plus the derived `bounds` / `res` / `footprint` / `values` (which delegates to `load`).
+- **`GeoData`** — [abstract_reader.py:188](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L188).
+  The full reader interface.
+  Defines `load(boundless=True)`, `read_from_window(window, boundless)`, plus the derived `bounds` / `res` / `footprint` / `values` (which delegates to `load`).
 
-- **`AbstractGeoData = GeoData`** — [abstract_reader.py:249](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L249). Back-compat alias.
+- **`AbstractGeoData = GeoData`** — [abstract_reader.py:249](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L249).
+  Back-compat alias.
 
-- **`same_extent(geo1, geo2, precision=1e-3)`** — [abstract_reader.py:252](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L252). The canonical "are these two rasters geographically interchangeable" check: transform-almost-equal, CRS-compare, last-two-dims-equal. Used by `GeoTensor`'s binary arithmetic and by `mosaic` / `read` before broadcasting operations.
+- **`same_extent(geo1, geo2, precision=1e-3)`** — [abstract_reader.py:252](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/abstract_reader.py#L252).
+  The canonical "are these two rasters geographically interchangeable" check: transform-almost-equal, CRS-compare, last-two-dims-equal. Used by `GeoTensor`'s binary arithmetic and by `mosaic` / `read` before broadcasting operations.
 
 ---
 
@@ -133,7 +146,8 @@ Why this exists:
 2. **Designing output grids.** When mosaicking or reprojecting, you build a `FakeGeoData` describing the *target* grid, then pass it to `read.read_reproject_like(src, dst=fake)`.
 3. **Testing.** Cheap fixtures for window-math tests.
 
-`shape` is `Optional[Tuple[int, ...]]` — if you only need `transform` + `crs` for a coordinate calc, you can leave it as `None`. `width` and `height` then raise `ValueError("Shape is not defined")` if accessed, which is correct: you said you didn't have one.
+`shape` is `Optional[Tuple[int, ...]]` — if you only need `transform` + `crs` for a coordinate calc, you can leave it as `None`.
+`width` and `height` then raise `ValueError("Shape is not defined")` if accessed, which is correct: you said you didn't have one.
 
 ---
 
@@ -150,9 +164,11 @@ def same_extent(geo1: GeoData, geo2: GeoData, precision: float = 1e-3) -> bool:
 
 Three observations on the design:
 
-- **`transform.almost_equals(precision=1e-3)`** — not exact. Floating-point transforms drift through reprojection round-trips; an exact comparison would be too strict.
+- **`transform.almost_equals(precision=1e-3)`** — not exact.
+  Floating-point transforms drift through reprojection round-trips; an exact comparison would be too strict.
 - **`compare_crs`** is in `window_utils` — it normalises across "EPSG:4326" / `4326` / `pyproj.CRS.from_epsg(4326)` so the user doesn't have to.
-- **Only the last two dims** are checked. A 3-band stack and a 5-band stack at the same footprint are "same-extent" — what matters is the spatial grid.
+- **Only the last two dims** are checked.
+  A 3-band stack and a 5-band stack at the same footprint are "same-extent" — what matters is the spatial grid.
 
 Used by `GeoTensor.__add__` etc. to refuse `gt1 + gt2` when extents disagree (see [Chapter 1 §12](01_geotensor.md)).
 
@@ -160,7 +176,8 @@ Used by `GeoTensor.__add__` etc. to refuse `gt1 + gt2` when extents disagree (se
 
 ## 7. How this protocol shows up downstream
 
-Almost every public function in `georeader.read` and `georeader.window_utils` is annotated `data: GeoData` or `data: GeoDataBase`. Concretely:
+Almost every public function in `georeader.read` and `georeader.window_utils` is annotated `data: GeoData` or `data: GeoDataBase`.
+Concretely:
 
 | Caller-side type | What you typically pass |
 |---|---|
@@ -174,15 +191,22 @@ This means most of your geotoolz operators should be typed `data: GeoData` (not 
 
 ## 8. Sharp edges
 
-- **`Protocol` doesn't enforce at runtime.** `isinstance(obj, GeoDataBase)` works only if you've decorated `GeoDataBase` with `@runtime_checkable` (this module does *not*). So duck-typing is by static checker (mypy/ty) or by `try/except AttributeError`. In practice: be liberal in what you accept, raise loud errors in `__init__`/factory functions if a required attribute is missing.
-- **`load(boundless=True)` is the universal handshake.** Every reader must implement it. The default contract: return a `GeoTensor` of the same shape, padding with `fill_value_default` for any out-of-bounds region.
-- **Subclasses, not Protocol implementations.** Despite the docstring talking about "Protocol", `GeoData` is a regular base class with `NotImplementedError` stubs — `RasterioReader` and the hyperspectral readers actually subclass it. The `Protocol` form is only `GeoDataBase`. That asymmetry is historical; treat both as duck-typed contracts in your own code.
-- **Last two dims are spatial.** This is enforced nowhere in the protocol — it's a convention, and the rest of the package relies on it. A reader returning `(H, W, C)` ("channels-last") would silently break things.
+- **`Protocol` doesn't enforce at runtime.** `isinstance(obj, GeoDataBase)` works only if you've decorated `GeoDataBase` with `@runtime_checkable` (this module does *not*).
+  So duck-typing is by static checker (mypy/ty) or by `try/except AttributeError`.
+  In practice: be liberal in what you accept, raise loud errors in `__init__`/factory functions if a required attribute is missing.
+- **`load(boundless=True)` is the universal handshake.** Every reader must implement it.
+  The default contract: return a `GeoTensor` of the same shape, padding with `fill_value_default` for any out-of-bounds region.
+- **Subclasses, not Protocol implementations.** Despite the docstring talking about "Protocol", `GeoData` is a regular base class with `NotImplementedError` stubs — `RasterioReader` and the hyperspectral readers actually subclass it.
+  The `Protocol` form is only `GeoDataBase`.
+  That asymmetry is historical; treat both as duck-typed contracts in your own code.
+- **Last two dims are spatial.** This is enforced nowhere in the protocol — it's a convention, and the rest of the package relies on it.
+  A reader returning `(H, W, C)` ("channels-last") would silently break things.
 
 ---
 
 ## 9. The shape of a custom reader (what's in the next chapter)
 
-The next chapter unpacks `RasterioReader` — the canonical `GeoData` subclass. Reading it is the fastest way to understand what a real implementation of this protocol looks like and what conveniences (`.isel`, `.read_from_window`, multi-file stacks, overviews, VSI cloud paths) sit on top of the bare contract above.
+The next chapter unpacks `RasterioReader` — the canonical `GeoData` subclass.
+Reading it is the fastest way to understand what a real implementation of this protocol looks like and what conveniences (`.isel`, `.read_from_window`, multi-file stacks, overviews, VSI cloud paths) sit on top of the bare contract above.
 
 Next chapter: [03_rasterio_reader.md](03_rasterio_reader.md).

--- a/projects/geotoolz/georeader_tutorial/03_rasterio_reader.md
+++ b/projects/geotoolz/georeader_tutorial/03_rasterio_reader.md
@@ -15,8 +15,8 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, rasterio
 ---
 
-> **Module:** `georeader/rasterio_reader.py` (1630 LOC)
-> **Role:** the canonical `GeoData` implementation. Wraps `rasterio` to give you a `GeoTensor`-shaped interface over a file (local, S3, GCS, Azure, HTTP) **without** reading the bytes until you ask.
+> **Module:** `georeader/rasterio_reader.py` (1630 LOC) **Role:** the canonical `GeoData` implementation.
+> Wraps `rasterio` to give you a `GeoTensor`-shaped interface over a file (local, S3, GCS, Azure, HTTP) **without** reading the bytes until you ask.
 
 ---
 
@@ -24,9 +24,14 @@ keywords: tutorial, georeader, rasterio
 
 Three concrete reasons rasterio alone isn't enough:
 
-1. **Process-safety.** `RasterioReader` opens the file *fresh on every `read()` call*. That's the unlock for `multiprocessing` / `joblib` / Dask workers — you can pickle the reader, send it to workers, and each worker opens its own dataset handle. A cached `rasterio.DatasetReader` cannot be pickled safely.
-2. **A `GeoTensor`-shaped surface without the bytes.** `reader.shape`, `reader.transform`, `reader.bounds`, `reader.dtype`, `reader.isel(...)` all work without reading data. Only `read()` / `load()` / `read_from_window().load()` materialise.
-3. **Multi-file stacks as one object.** Pass a list of paths, get a `(T, C, H, W)` reader. `isel({"time": 0})` returns a single-time-step reader. The time dimension is a structural feature, not a wrapper.
+1. **Process-safety.** `RasterioReader` opens the file *fresh on every `read()` call*.
+   That's the unlock for `multiprocessing` / `joblib` / Dask workers — you can pickle the reader, send it to workers, and each worker opens its own dataset handle.
+   A cached `rasterio.DatasetReader` cannot be pickled safely.
+2. **A `GeoTensor`-shaped surface without the bytes.** `reader.shape`, `reader.transform`, `reader.bounds`, `reader.dtype`, `reader.isel(...)` all work without reading data.
+   Only `read()` / `load()` / `read_from_window().load()` materialise.
+3. **Multi-file stacks as one object.** Pass a list of paths, get a `(T, C, H, W)` reader.
+   `isel({"time": 0})` returns a single-time-step reader.
+   The time dimension is a structural feature, not a wrapper.
 
 This is the class your operators should accept whenever they don't strictly need the data in memory.
 
@@ -58,9 +63,12 @@ This is the class your operators should accept whenever they don't strictly need
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The mental model: `RasterioReader` is the **address book**, `GeoTensor` is the **delivered package**. `reader.load()` is the postman.
+The mental model: `RasterioReader` is the **address book**, `GeoTensor` is the **delivered package**.
+`reader.load()` is the postman.
 
-The arithmetic ops (`+`, `*`, etc.) only exist on `GeoTensor`. If you write `reader * 2` you get an error — and that's deliberate. Arithmetic on a lazy reader implies you've decided to materialise; the explicit `.load()` makes that decision visible at the call site.
+The arithmetic ops (`+`, `*`, etc.) only exist on `GeoTensor`.
+If you write `reader * 2` you get an error — and that's deliberate.
+Arithmetic on a lazy reader implies you've decided to materialise; the explicit `.load()` makes that decision visible at the call site.
 
 ---
 
@@ -92,10 +100,15 @@ The arithmetic ops (`+`, `*`, etc.) only exist on `GeoTensor`. If you write `rea
 
 Two modes worth distinguishing:
 
-- **`stack=True` (default, time-as-axis).** Result `dims = ("time", "band", "y", "x")`. This is what you almost always want for time-series analysis. `isel({"time": 0})` returns a (C, H, W) reader pointing at one file.
-- **`stack=False` (concat along bands).** Result `(T*C, H, W)`. Useful when files are *band groups* of a single observation rather than time steps — e.g., S2 SAFE where each band is its own JP2 and there's no time meaning to the file list.
+- **`stack=True` (default, time-as-axis).** Result `dims = ("time", "band", "y", "x")`.
+  This is what you almost always want for time-series analysis.
+  `isel({"time": 0})` returns a (C, H, W) reader pointing at one file.
+- **`stack=False` (concat along bands).** Result `(T*C, H, W)`.
+  Useful when files are *band groups* of a single observation rather than time steps — e.g., S2 SAFE where each band is its own JP2 and there's no time meaning to the file list.
 
-Validation is strict: `__init__` checks CRS / transform / shape match across files unless you opt out via `allow_different_shape=True`. The check only relaxes shape — CRS and transform mismatches always raise. (See [rasterio_reader.py:301](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/rasterio_reader.py#L301).)
+Validation is strict: `__init__` checks CRS / transform / shape match across files unless you opt out via `allow_different_shape=True`.
+The check only relaxes shape — CRS and transform mismatches always raise.
+(See [rasterio_reader.py:301](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/rasterio_reader.py#L301).)
 
 ---
 
@@ -156,8 +169,11 @@ RasterioReader(
 
 A few non-obvious ones:
 
-- **`indexes`** is **1-based** because rasterio is. `indexes=[1, 2, 3]` on a 4-band S2 image gives you BGR (the first three bands). The reader stores the requested indices and lazily honours them on every read.
-- **`overview_level=2`** lets you skip the full-res file entirely for previews. COGs ship overviews at 2×, 4×, 8× downsampled levels; reading from `overview_level=2` is roughly 64× cheaper than full-res reads.
+- **`indexes`** is **1-based** because rasterio is.
+  `indexes=[1, 2, 3]` on a 4-band S2 image gives you BGR (the first three bands).
+  The reader stores the requested indices and lazily honours them on every read.
+- **`overview_level=2`** lets you skip the full-res file entirely for previews.
+  COGs ship overviews at 2×, 4×, 8× downsampled levels; reading from `overview_level=2` is roughly 64× cheaper than full-res reads.
 - **`rio_env_options`** is the escape hatch for GDAL config — proxy creds, custom timeout, AWS_REGION, etc. Defaults to a sensible `RIO_ENV_OPTIONS_DEFAULT` defined near the top of the file.
 - **`fill_value_default=None`** means "use the file's nodata value if it has one, else 0." Set it explicitly if you have a reason — the default is rarely wrong but rarely what you'd choose if asked.
 
@@ -165,7 +181,8 @@ A few non-obvious ones:
 
 ## 6. The four read paths
 
-Each method emphasises a different ergonomic. They all ultimately call into `rasterio.DatasetReader.read`.
+Each method emphasises a different ergonomic.
+They all ultimately call into `rasterio.DatasetReader.read`.
 
 | Method | Returns | Use for |
 |---|---|---|
@@ -174,7 +191,8 @@ Each method emphasises a different ergonomic. They all ultimately call into `ras
 | `read_from_window(window, boundless=True)` | `RasterioReader` (focused) | tiled inference; chain with `.load()` to materialise |
 | `read_from_tile(x, y, z, ...)` | `np.ndarray` | XYZ web-tile schema (used by `tileserver` reader) |
 
-The `boundless=True` default on `read_from_window`/`load` matches `GeoTensor.read_from_window` — you get the requested shape no matter where the window lands, padded with `fill_value_default`. This is critical for batched CNN inference: every chip has the same shape, batches stack cleanly.
+The `boundless=True` default on `read_from_window`/`load` matches `GeoTensor.read_from_window` — you get the requested shape no matter where the window lands, padded with `fill_value_default`.
+This is critical for batched CNN inference: every chip has the same shape, batches stack cleanly.
 
 ---
 
@@ -184,9 +202,13 @@ The `boundless=True` default on `read_from_window`/`load` matches `GeoTensor.rea
 reader.isel({"time": [0, 2], "band": [1, 2, 3]})
 ```
 
-Same dim-name vocabulary as `GeoTensor.isel` (Chapter 1 §6) but with `"time"` admitted for stacked multi-file readers. Returns a *new reader* — still lazy. Spatial dims (`"x"`, `"y"`) accept slices and rewrite the focus window.
+Same dim-name vocabulary as `GeoTensor.isel` (Chapter 1 §6) but with `"time"` admitted for stacked multi-file readers.
+Returns a *new reader* — still lazy.
+Spatial dims (`"x"`, `"y"`) accept slices and rewrite the focus window.
 
-The internal mechanism: `isel` returns a copied reader with `indexes` adjusted (band selection), `paths` filtered (time selection), and `window_focus` updated (spatial slice). Nothing reads. Source: [rasterio_reader.py:739](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/rasterio_reader.py#L739).
+The internal mechanism: `isel` returns a copied reader with `indexes` adjusted (band selection), `paths` filtered (time selection), and `window_focus` updated (spatial slice).
+Nothing reads.
+Source: [rasterio_reader.py:739](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/rasterio_reader.py#L739).
 
 ---
 
@@ -199,8 +221,10 @@ preview = reader.load()  # ~64× cheaper than full res
 
 Two methods to know:
 
-- **`reader.overviews(index=1, time_index=0)`** — list available decimation factors for a band. Empty list means no overviews in the file (it's not a COG, or it's a single-resolution GeoTIFF).
-- **`reader.reader_overview(overview_level)`** — return a *new reader* configured to read from that level. Useful when you've already opened a full-res reader and decide you want a thumbnail without re-instantiating from the path.
+- **`reader.overviews(index=1, time_index=0)`** — list available decimation factors for a band.
+  Empty list means no overviews in the file (it's not a COG, or it's a single-resolution GeoTIFF).
+- **`reader.reader_overview(overview_level)`** — return a *new reader* configured to read from that level.
+  Useful when you've already opened a full-res reader and decide you want a thumbnail without re-instantiating from the path.
 
 This is also the right tool for "should I load this whole scene to decide if it's cloudy?" — read overview level 3, run your cloud check on the small image, then go full-res only if it's worth it.
 
@@ -217,7 +241,8 @@ This is also the right tool for "should I load this whole scene to decide if it'
 | `https://...cog.tif` | `/vsicurl/` (range requests) |
 | `az://account/key.tif` | `/vsiaz/` |
 
-Internal helper `_get_rio_options_path(path)` (and the module-level `_vsi_path` in `geotensor.py`) translate user-friendly URIs to VSI form. Credentials come from `rio_env_options` or from environment (`AWS_*`, `GOOGLE_APPLICATION_CREDENTIALS`, etc.) — same as plain rasterio.
+Internal helper `_get_rio_options_path(path)` (and the module-level `_vsi_path` in `geotensor.py`) translate user-friendly URIs to VSI form.
+Credentials come from `rio_env_options` or from environment (`AWS_*`, `GOOGLE_APPLICATION_CREDENTIALS`, etc.) — same as plain rasterio.
 
 ### GDAL options: `RIO_ENV_OPTIONS_DEFAULT`
 
@@ -235,9 +260,11 @@ RIO_ENV_OPTIONS_DEFAULT = dict(
 
 What each does:
 
-- **`GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR"`** — don't list the bucket directory when opening one file. Critical for cloud reads: without it, opening a single COG can trigger a full `LIST` of the bucket, which is slow and may not even be permitted.
+- **`GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR"`** — don't list the bucket directory when opening one file.
+  Critical for cloud reads: without it, opening a single COG can trigger a full `LIST` of the bucket, which is slow and may not even be permitted.
 - **`GDAL_HTTP_MERGE_CONSECUTIVE_RANGES="YES"`** — when reading a window that spans multiple adjacent tiles, merge their byte-range requests into one HTTP call.
-- **`GDAL_CACHEMAX=2_000_000_000`** — 2 GB process-wide block cache. Speeds up repeated reads of the same tiles within one process.
+- **`GDAL_CACHEMAX=2_000_000_000`** — 2 GB process-wide block cache.
+  Speeds up repeated reads of the same tiles within one process.
 - **`GDAL_HTTP_MULTIPLEX="YES"`** — enable HTTP/2 multiplexing for parallel range requests over one connection.
 
 Override via the `rio_env_options=` kwarg on the constructor when defaults aren't right (rare) or when you need to add specific options like `AWS_REQUEST_PAYER="requester"`.
@@ -253,13 +280,15 @@ with rasterio.Env(**self._get_rio_options_path(paths[0])):
         ...
 ```
 
-GDAL is configured once per `rasterio.open` call via the env context manager, and **credentials are picked up from `os.environ` at the moment the context is entered**. This is the seam that makes the next subsection's pattern work.
+GDAL is configured once per `rasterio.open` call via the env context manager, and **credentials are picked up from `os.environ` at the moment the context is entered**.
+This is the seam that makes the next subsection's pattern work.
 
 ### Credentials: env-var-first
 
 The mental model:
 
-> **GDAL reads credentials from process environment variables.** The pattern is to **set the env vars once at app startup**, then construct `RasterioReader` instances anywhere with no per-call credential threading. The reader's `rasterio.Env(...)` wrap inherits whatever's in `os.environ` at the moment of open.
+> **GDAL reads credentials from process environment variables.** The pattern is to **set the env vars once at app startup**, then construct `RasterioReader` instances anywhere with no per-call credential threading.
+> The reader's `rasterio.Env(...)` wrap inherits whatever's in `os.environ` at the moment of open.
 
 Per-cloud env vars GDAL recognises:
 
@@ -292,7 +321,8 @@ Three orthogonal env vars; setting any combination of them is fine — GDAL's pr
 
 #### Mode 2 — Managed identity
 
-When running inside Azure compute (VMs, AKS pods, Functions, etc.), there's no static credential — the platform mints a short-lived bearer token via the IMDS endpoint. We fetch the token via `azure.identity.DefaultAzureCredential` and hand it to GDAL as an env var:
+When running inside Azure compute (VMs, AKS pods, Functions, etc.), there's no static credential — the platform mints a short-lived bearer token via the IMDS endpoint.
+We fetch the token via `azure.identity.DefaultAzureCredential` and hand it to GDAL as an env var:
 
 ```python
 # mars_data_ops/utils/filesystem.py:765-789
@@ -305,11 +335,15 @@ os.environ['AZURE_STORAGE_ACCOUNT'] = account_name
 os.environ['AZURE_STORAGE_ACCESS_TOKEN'] = token
 ```
 
-**Sharp edge:** the token typically expires in ~1 hour. This snippet calls `get_token(...)` *once* at startup. If a long-running process tries to read after expiry, GDAL gets a 401 with no refresh path. For pipelines that run longer than the token TTL, refresh logic is the user's responsibility today — see the [`reader_rasterio.md` proposal](../plans/georeader/reader_rasterio.md) for what an opinionated solution would look like.
+**Sharp edge:** the token typically expires in ~1 hour.
+This snippet calls `get_token(...)` *once* at startup.
+If a long-running process tries to read after expiry, GDAL gets a 401 with no refresh path.
+For pipelines that run longer than the token TTL, refresh logic is the user's responsibility today — see the [`reader_rasterio.md` proposal](../plans/georeader/reader_rasterio.md) for what an opinionated solution would look like.
 
 #### Mode 3 — HTTPS with embedded SAS fallback
 
-GDAL's `AZURE_STORAGE_SAS_TOKEN` env var doesn't always kick in for paths that don't go through the canonical `az://` form. The fallback is to rewrite the path as an HTTPS URL with the SAS token embedded as a query string:
+GDAL's `AZURE_STORAGE_SAS_TOKEN` env var doesn't always kick in for paths that don't go through the canonical `az://` form.
+The fallback is to rewrite the path as an HTTPS URL with the SAS token embedded as a query string:
 
 ```python
 # mars_data_ops/utils/filesystem.py:336-358
@@ -353,11 +387,14 @@ End-to-end, the production pattern looks like this:
 
 1. App calls `fs_access_from_config(config)` → reads the `[azure.storage]` section.
 2. `config_storage_access(...)` sets `AZURE_STORAGE_*` env vars (or fetches a bearer token via `DefaultAzureCredential` for managed identity and sets `AZURE_STORAGE_ACCESS_TOKEN`).
-3. Code reads rasters via `RasterioReader(...)` from anywhere in the codebase. The reader wraps `rasterio.open` in `rasterio.Env(**RIO_ENV_OPTIONS_DEFAULT)` per call.
+3. Code reads rasters via `RasterioReader(...)` from anywhere in the codebase.
+   The reader wraps `rasterio.open` in `rasterio.Env(**RIO_ENV_OPTIONS_DEFAULT)` per call.
 4. GDAL picks credentials up from the process env — **no per-call credential threading needed**.
 5. **Fallback** when env-var auth misbehaves: `pathasroothttps(path)` builds an HTTPS URL with the SAS token embedded as a query string and `RasterioReader` reads that directly.
 
-The [Reader reconciliation design](../plans/georeader/README.md) is about widening this seam: [`AsyncGeoTIFFReader`](../plans/georeader/reader_async_geotiff.md) plugs in here as an alternative implementation of the same interface, swapping GDAL VSI for direct HTTP-range / obstore reads. The credential pattern stays env-var-first for the GDAL-VSI default; the new path has its own credential locus — see [`reader_protocol.md` §"Credential handling"](../plans/georeader/reader_protocol.md). For a proposal that would reduce the env-var-soup ergonomics with a typed `Credential` Protocol, see [`plans/types/credentials.md`](../plans/types/credentials.md).
+The [Reader reconciliation design](../plans/georeader/README.md) is about widening this seam: [`AsyncGeoTIFFReader`](../plans/georeader/reader_async_geotiff.md) plugs in here as an alternative implementation of the same interface, swapping GDAL VSI for direct HTTP-range / obstore reads.
+The credential pattern stays env-var-first for the GDAL-VSI default; the new path has its own credential locus — see [`reader_protocol.md` §"Credential handling"](../plans/georeader/reader_protocol.md).
+For a proposal that would reduce the env-var-soup ergonomics with a typed `Credential` Protocol, see [`plans/types/credentials.md`](../plans/types/credentials.md).
 
 ---
 
@@ -398,12 +435,17 @@ The [Reader reconciliation design](../plans/georeader/README.md) is about wideni
 
 ## 11. Sharp edges
 
-- **`indexes` is 1-based** (rasterio convention), but `block_windows` and overview-level integers are 0-based. Easy to flip without realising.
-- **`set_window` mutates state.** If you're sharing a reader across functions or threads, prefer `read_from_window` / `isel` which return new readers. The mutating form exists because some legacy call sites needed it.
+- **`indexes` is 1-based** (rasterio convention), but `block_windows` and overview-level integers are 0-based.
+  Easy to flip without realising.
+- **`set_window` mutates state.** If you're sharing a reader across functions or threads, prefer `read_from_window` / `isel` which return new readers.
+  The mutating form exists because some legacy call sites needed it.
 - **`stack=True` requires identical metadata across files.** When that's not true (e.g., bands at different resolutions), `mosaic` or `griddata` is the right tool, not `RasterioReader`.
-- **Cloud reads are *not* free.** Each `read_from_window().load()` issues HTTP range requests. For tile-loops over the same scene, a `set_window` + `load()` of a coarse window into memory followed by `GeoTensor` slicing is often dramatically faster than N small cloud reads.
-- **Files are opened on every read.** This is a feature (process-safety) but it costs ~ms per call. For tight inner loops over the same file in one process, batching reads matters.
-- **Overviews don't always exist.** Plain GeoTIFFs without pyramids have empty `reader.overviews()`. The reader doesn't *create* overviews on the fly; that's `gdaladdo` territory.
+- **Cloud reads are *not* free.** Each `read_from_window().load()` issues HTTP range requests.
+  For tile-loops over the same scene, a `set_window` + `load()` of a coarse window into memory followed by `GeoTensor` slicing is often dramatically faster than N small cloud reads.
+- **Files are opened on every read.** This is a feature (process-safety) but it costs ~ms per call.
+  For tight inner loops over the same file in one process, batching reads matters.
+- **Overviews don't always exist.** Plain GeoTIFFs without pyramids have empty `reader.overviews()`.
+  The reader doesn't *create* overviews on the fly; that's `gdaladdo` territory.
 
 ---
 
@@ -411,7 +453,8 @@ The [Reader reconciliation design](../plans/georeader/README.md) is about wideni
 
 Where `RasterioReader` shows up downstream:
 
-- **`georeader.read`** — every `read_from_*` function takes a `GeoData`, and a `RasterioReader` is the typical input. Reprojection ([Chapter 5](05_read.md)) is where lazy reading really pays off: you compute the source window from the destination grid first, then read only that window.
+- **`georeader.read`** — every `read_from_*` function takes a `GeoData`, and a `RasterioReader` is the typical input.
+  Reprojection ([Chapter 5](05_read.md)) is where lazy reading really pays off: you compute the source window from the destination grid first, then read only that window.
 - **`georeader.mosaic`** — combine multiple `RasterioReader`s into one composite, reading only the windows that cover the target.
 - **`georeader.save`** — `save_cog(reader, path)` streams a reader to disk without ever having the full array in memory.
 - **`georeader.readers.S2_SAFE_reader`** — the Sentinel-2 reader is a `RasterioReader` underneath, with band-group logic on top.

--- a/projects/geotoolz/georeader_tutorial/04_window_utils.md
+++ b/projects/geotoolz/georeader_tutorial/04_window_utils.md
@@ -15,8 +15,9 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, window
 ---
 
-> **Module:** `georeader/window_utils.py` (1471 LOC, the second-densest in diagrams)
-> **Role:** the math underneath everything else in the package. Windows, bounds, transforms, rounding, padding, polygon reprojection. Reading these utilities once is the cheapest way to understand why the higher-level `read.py` API is shaped the way it is.
+> **Module:** `georeader/window_utils.py` (1471 LOC, the second-densest in diagrams) **Role:** the math underneath everything else in the package.
+> Windows, bounds, transforms, rounding, padding, polygon reprojection.
+> Reading these utilities once is the cheapest way to understand why the higher-level `read.py` API is shaped the way it is.
 
 ---
 
@@ -28,13 +29,15 @@ Three responsibilities in one file:
 2. **Padding & rounding.** Grow / shrink / round windows so they align with pixel boundaries, fit a fixed CNN input size, or include all partial pixels intersected by a query.
 3. **Polygon ↔ pixel.** Reproject Shapely geometries between CRSs and convert their vertices to pixel-coordinate paths (used by `rasterize` and `vectorize` downstream).
 
-A single design decision sits underneath all of it: `PIXEL_PRECISION = 3` decimal places. Coordinate transforms drift through reprojection round-trips, so the module deliberately tolerates ≤ 0.001-pixel error before deciding "this is or isn't an integer offset."
+A single design decision sits underneath all of it: `PIXEL_PRECISION = 3` decimal places.
+Coordinate transforms drift through reprojection round-trips, so the module deliberately tolerates ≤ 0.001-pixel error before deciding "this is or isn't an integer offset."
 
 ---
 
 ## 2. Window anatomy
 
-A `rasterio.windows.Window` is a rectangle in *pixel* space — not geographic space. The constructor argument order is the source of most bugs that touch this module.
+A `rasterio.windows.Window` is a rectangle in *pixel* space — not geographic space.
+The constructor argument order is the source of most bugs that touch this module.
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -64,16 +67,21 @@ A `rasterio.windows.Window` is a rectangle in *pixel* space — not geographic s
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-> **NOTE:** Window constructor order is `(col_off, row_off)` but most geospatial
-> operations use `(row, col)` or `(y, x)` order. **Be careful!**
+> **NOTE:** Window constructor order is `(col_off, row_off)` but most geospatial operations use `(row, col)` or `(y, x)` order.
+> **Be careful!**
 
-That note is in the source verbatim and it earns its caps. Three places this trips people up:
+That note is in the source verbatim and it earns its caps.
+Three places this trips people up:
 
-- `np.zeros(shape)` is `(rows, cols)` = `(height, width)`. A `Window` is `(col_off, row_off, width, height)`. Mismatched axis order between the two has cost more than one afternoon.
-- `pad_window(window, pad_size)` takes `(pad_rows, pad_cols)` — numpy order, **not** Window order. The docstring warns about this.
+- `np.zeros(shape)` is `(rows, cols)` = `(height, width)`.
+  A `Window` is `(col_off, row_off, width, height)`.
+  Mismatched axis order between the two has cost more than one afternoon.
+- `pad_window(window, pad_size)` takes `(pad_rows, pad_cols)` — numpy order, **not** Window order.
+  The docstring warns about this.
 - `pad_window_to_size(window, size)` takes `(height, width)` — numpy order, **not** `(width, height)`.
 
-The module commits to numpy order for axis-tuple arguments because that's what users coming from `np.pad` expect. The Window constructor order is fixed by rasterio.
+The module commits to numpy order for axis-tuple arguments because that's what users coming from `np.pad` expect.
+The Window constructor order is fixed by rasterio.
 
 ---
 
@@ -105,8 +113,11 @@ The module commits to numpy order for axis-tuple arguments because that's what u
 
 Two named functions handle the round-trip:
 
-- **`window_bounds(window, transform) → (minx, miny, maxx, maxy)`** — apply `transform` to the four window corners, return their axis-aligned bounding box. Fast, deterministic, no CRS involved.
-- **`bounds_to_windows(data, bounds_dst, crs_dst) → list[Window]`** — the more interesting one. Reprojects `bounds_dst` from `crs_dst` into `data.crs`, then inverts the transform. Returns a **list** because a query that crosses the antimeridian splits into two windows in the source CRS. Most calls return a length-1 list; AOI bboxes that wrap longitude need length-2 handling.
+- **`window_bounds(window, transform) → (minx, miny, maxx, maxy)`** — apply `transform` to the four window corners, return their axis-aligned bounding box.
+  Fast, deterministic, no CRS involved.
+- **`bounds_to_windows(data, bounds_dst, crs_dst) → list[Window]`** — the more interesting one.
+  Reprojects `bounds_dst` from `crs_dst` into `data.crs`, then inverts the transform.
+  Returns a **list** because a query that crosses the antimeridian splits into two windows in the source CRS. Most calls return a length-1 list; AOI bboxes that wrap longitude need length-2 handling.
 
 The asymmetry — one direction is geometry math, the other is CRS-aware — is why this module is bigger than it might first seem.
 
@@ -114,7 +125,8 @@ The asymmetry — one direction is geometry math, the other is CRS-aware — is 
 
 ## 4. Rounding: outer vs inner
 
-Bounds rarely land on integer pixel boundaries. You have to choose which way to round.
+Bounds rarely land on integer pixel boundaries.
+You have to choose which way to round.
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -141,14 +153,16 @@ Bounds rarely land on integer pixel boundaries. You have to choose which way to 
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Default in georeader: **outer**. Reasons:
+Default in georeader: **outer**.
+Reasons:
 
 - For a read query, "give me everything that intersects this AOI" is what users mean 99% of the time.
 - Combined with `boundless=True` reads, outer rounding plus padding gives you a guaranteed-shape result with no missing data inside the AOI.
 
 `round_inner_window` shows up in two niche cases: when you're cropping to a strict mask (no partial-pixel contamination), and when you're computing the largest *fully covered* sub-window for tile-aligned reads.
 
-Both functions tolerate `PIXEL_PRECISION = 3` slop before rounding — the example in the docstring: `99.9997 → 100`, `100.5 → unchanged`. That tolerance is what lets reprojection round-trips not slowly drift the window by sub-pixel amounts each pass.
+Both functions tolerate `PIXEL_PRECISION = 3` slop before rounding — the example in the docstring: `99.9997 → 100`, `100.5 → unchanged`.
+That tolerance is what lets reprojection round-trips not slowly drift the window by sub-pixel amounts each pass.
 
 ---
 
@@ -158,7 +172,8 @@ Two related functions, both in the "make my tile a fixed size" job.
 
 ### `pad_window(window, pad_size=(pad_rows, pad_cols))`
 
-Symmetric expansion on all four sides. Used to add **context** around an inference tile.
+Symmetric expansion on all four sides.
+Used to add **context** around an inference tile.
 
 ```text
 Original window:              Padded window (pad_size=(2, 3)):
@@ -176,11 +191,13 @@ Output: width = 100 + 2×3 = 106
         row_off = original - 2
 ```
 
-The output window may have **negative offsets** — that's intentional, and you read it via `read_from_window(..., boundless=True)` to pad the off-edge region with `fill_value_default`. (Chapter 3 §6.)
+The output window may have **negative offsets** — that's intentional, and you read it via `read_from_window(..., boundless=True)` to pad the off-edge region with `fill_value_default`.
+(Chapter 3 §6.)
 
 ### `pad_window_to_size(window, size=(height, width))`
 
-Re-centre to a target size. Both expansion *and* contraction work — passing a size smaller than the window gives you a centre crop.
+Re-centre to a target size.
+Both expansion *and* contraction work — passing a size smaller than the window gives you a centre crop.
 
 ```text
 Expansion (size > window):          Contraction (size < window):
@@ -198,7 +215,8 @@ Expansion (size > window):          Contraction (size < window):
 Symmetric expansion             Symmetric contraction
 ```
 
-Odd differences favour the bottom/right edge (integer division). When you need exact symmetry, use `pad_window` with explicit `pad_size`.
+Odd differences favour the bottom/right edge (integer division).
+When you need exact symmetry, use `pad_window` with explicit `pad_size`.
 
 ---
 
@@ -234,7 +252,8 @@ This function is the seam between `read.read_from_bounds` (which calls it) and t
 
 ## 7. Polygon ↔ pixel — exterior coordinates
 
-`window_polygon` is the geometry-aware sibling of `window_bounds`. Returns a Shapely `Polygon` rather than a 4-tuple — important when the transform has rotation/shear (`b ≠ 0` or `d ≠ 0`), where the bounding box and the actual footprint differ.
+`window_polygon` is the geometry-aware sibling of `window_bounds`.
+Returns a Shapely `Polygon` rather than a 4-tuple — important when the transform has rotation/shear (`b ≠ 0` or `d ≠ 0`), where the bounding box and the actual footprint differ.
 
 ```text
 window_surrounding=False (default):     window_surrounding=True:
@@ -251,15 +270,22 @@ Polygon includes full pixels             Polygon passes through pixel centers
 
 The `window_surrounding` flag picks between two valid pixel-footprint conventions:
 
-- **`False` (default)** — the polygon traces the *outside* of the pixel grid. Pixels are areas with non-zero extent. Use when you're computing intersections with vector geometries that should agree with `window_bounds`.
-- **`True`** — the polygon vertices sit at *pixel centres*. Pixels are samples (points) on a regular grid. Use when you're matching against point clouds or building irregular-grid representations.
+- **`False` (default)** — the polygon traces the *outside* of the pixel grid.
+  Pixels are areas with non-zero extent.
+  Use when you're computing intersections with vector geometries that should agree with `window_bounds`.
+- **`True`** — the polygon vertices sit at *pixel centres*.
+  Pixels are samples (points) on a regular grid.
+  Use when you're matching against point clouds or building irregular-grid representations.
 
 The default matches GIS convention; the alternative is needed when interfacing with point-sampling tools (some scipy/skimage routines treat pixels as samples by default).
 
 Companion functions:
 
-- **`polygon_to_crs(polygon, crs_polygon, dst_crs)`** — reproject a Shapely geometry. Works on `Polygon` and `MultiPolygon`; preserves geometry type.
-- **`exterior_pixel_coords(transform, crs, polygon, crs_polygon=None)`** — reproject `polygon` into the raster's CRS, then convert each ring of vertices to pixel coordinates. Returns `List[List[(col, row)]]` (one inner list per polygon part). Used by `rasterize` ([Chapter 9](09_rasterize.md)) to draw filled regions.
+- **`polygon_to_crs(polygon, crs_polygon, dst_crs)`** — reproject a Shapely geometry.
+  Works on `Polygon` and `MultiPolygon`; preserves geometry type.
+- **`exterior_pixel_coords(transform, crs, polygon, crs_polygon=None)`** — reproject `polygon` into the raster's CRS, then convert each ring of vertices to pixel coordinates.
+  Returns `List[List[(col, row)]]` (one inner list per polygon part).
+  Used by `rasterize` ([Chapter 9](09_rasterize.md)) to draw filled regions.
 
 ---
 
@@ -277,7 +303,8 @@ Given two windows:
 - A `dict[str, slice]` to extract the part of `window_read` that **does** overlap `window_data`
 - A `dict[str, (pad_left, pad_right)]` to pad the result so it ends up the requested shape
 
-The reader then reads the slice from disk and applies `np.pad` (or its own `fill_value_default`-aware equivalent) to produce a full-size array. CNN inference at scene edges relies entirely on this — every chip comes back the requested shape, with off-edge regions filled with nodata.
+The reader then reads the slice from disk and applies `np.pad` (or its own `fill_value_default`-aware equivalent) to produce a full-size array.
+CNN inference at scene edges relies entirely on this — every chip comes back the requested shape, with off-edge regions filled with nodata.
 
 Source: [window_utils.py:599](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/window_utils.py#L599).
 
@@ -294,7 +321,8 @@ The companion to `pad_window` for inference pipelines: when you've read a tile *
 4. Stitch extracted regions together to form complete prediction
 ```
 
-The reference is Huang et al. (2018) — the standard tile-and-stitch recipe. Used by ml4floods and similar segmentation pipelines built on georeader.
+The reference is Huang et al. (2018) — the standard tile-and-stitch recipe.
+Used by ml4floods and similar segmentation pipelines built on georeader.
 
 Source: [window_utils.py:1256](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/window_utils.py#L1256).
 
@@ -302,7 +330,8 @@ Source: [window_utils.py:1256](https://github.com/spaceml-org/georeader/blob/f0d
 
 ## 10. Function reference
 
-Grouped by purpose. Every function takes / returns `rasterio.Affine`, `rasterio.windows.Window`, or shapely `Polygon`/`MultiPolygon` — no GeoTensor/Reader anywhere in this module.
+Grouped by purpose.
+Every function takes / returns `rasterio.Affine`, `rasterio.windows.Window`, or shapely `Polygon`/`MultiPolygon` — no GeoTensor/Reader anywhere in this module.
 
 **Padding & rounding**
 - `pad_window(window, pad_size=(rows, cols))` — symmetric expansion
@@ -341,12 +370,19 @@ Grouped by purpose. Every function takes / returns `rasterio.Affine`, `rasterio.
 
 ## 11. Sharp edges
 
-- **Window order vs numpy order.** `Window(col_off, row_off, width, height)` — `(x, y, w, h)` in screen-coordinate parlance. `pad_window(pad_size)` is `(rows, cols)` — `(y, x)` in numpy parlance. `pad_window_to_size(size)` is `(height, width)`. The module deliberately uses numpy order for axis-tuple args; the rasterio Window constructor is fixed.
-- **`PIXEL_PRECISION = 3` is module-global.** If you have a workflow with sub-millipixel meaningful precision (you don't, but if), you'd need to thread `precision=` through every call. In practice, 3 is right.
-- **Antimeridian-crossing AOIs return *two* windows.** `bounds_to_windows` returns a list. Code that does `windows[0]` will silently lose half the AOI when an Asia/Pacific bbox is queried.
-- **Rotated transforms break `window_bounds`.** When `b ≠ 0` or `d ≠ 0`, the four-corner bounding box overestimates the data footprint. Use `window_polygon` and intersect against actual geometry.
+- **Window order vs numpy order.** `Window(col_off, row_off, width, height)` — `(x, y, w, h)` in screen-coordinate parlance.
+  `pad_window(pad_size)` is `(rows, cols)` — `(y, x)` in numpy parlance.
+  `pad_window_to_size(size)` is `(height, width)`.
+  The module deliberately uses numpy order for axis-tuple args; the rasterio Window constructor is fixed.
+- **`PIXEL_PRECISION = 3` is module-global.** If you have a workflow with sub-millipixel meaningful precision (you don't, but if), you'd need to thread `precision=` through every call.
+  In practice, 3 is right.
+- **Antimeridian-crossing AOIs return *two* windows.** `bounds_to_windows` returns a list.
+  Code that does `windows[0]` will silently lose half the AOI when an Asia/Pacific bbox is queried.
+- **Rotated transforms break `window_bounds`.** When `b ≠ 0` or `d ≠ 0`, the four-corner bounding box overestimates the data footprint.
+  Use `window_polygon` and intersect against actual geometry.
 - **`figure_out_transform` errors are validation, not bugs.** "ERROR (need bounds)" rows in the table are deliberate — there's no sensible default.
-- **`exterior_pixel_coords` returns col-row, not row-col.** Matches Shapely (x, y) convention. Don't pass it directly to `np.zeros[...]`.
+- **`exterior_pixel_coords` returns col-row, not row-col.** Matches Shapely (x, y) convention.
+  Don't pass it directly to `np.zeros[...]`.
 
 ---
 
@@ -354,10 +390,14 @@ Grouped by purpose. Every function takes / returns `rasterio.Affine`, `rasterio.
 
 Three concrete things `geotoolz.sampling` and `geotoolz.inference` will lean on:
 
-1. **`pad_window` + `slice_save_for_pred`** is the entire ApplyToChips machinery. Read with context, predict, save the centre, stitch.
+1. **`pad_window` + `slice_save_for_pred`** is the entire ApplyToChips machinery.
+   Read with context, predict, save the centre, stitch.
 2. **`bounds_to_windows`** is what a `BoundingBoxSampler` (TorchGeo-style) calls under the hood when chips are specified in geographic coords rather than pixel coords.
-3. **`figure_out_transform`** is the "design my output grid" function. Every reprojection-aware operator (mosaicking, ensemble averaging across scenes) needs it.
+3. **`figure_out_transform`** is the "design my output grid" function.
+   Every reprojection-aware operator (mosaicking, ensemble averaging across scenes) needs it.
 
-You can build the whole `geotoolz.sampling` module without touching anything in `georeader` *except* this file plus `read.py`. That's a clean cut for the operator layer.
+You can build the whole `geotoolz.sampling` module without touching anything in `georeader` *except* this file plus `read.py`.
+That's a clean cut for the operator layer.
 
-Next chapter: [05_read.md](05_read.md) — the high-level reading API (`read_from_bounds`, `read_from_polygon`, `read_from_center_coords`, reprojection / resampling). The single densest module in the package by diagram count, and the one most users touch first.
+Next chapter: [05_read.md](05_read.md) — the high-level reading API (`read_from_bounds`, `read_from_polygon`, `read_from_center_coords`, reprojection / resampling).
+The single densest module in the package by diagram count, and the one most users touch first.

--- a/projects/geotoolz/georeader_tutorial/05_read.md
+++ b/projects/geotoolz/georeader_tutorial/05_read.md
@@ -15,8 +15,9 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, read, reproject
 ---
 
-> **Module:** `georeader/read.py` (1967 LOC, the densest module in the package — 123 box-drawing characters across the docstring)
-> **Role:** the public face of georeader. Most users start here. Six "specify the AOI in the form most natural to your problem" entry points, plus reprojection / resampling / grid-matching.
+> **Module:** `georeader/read.py` (1967 LOC, the densest module in the package — 123 box-drawing characters across the docstring) **Role:** the public face of georeader.
+> Most users start here.
+> Six "specify the AOI in the form most natural to your problem" entry points, plus reprojection / resampling / grid-matching.
 
 ---
 
@@ -108,10 +109,13 @@ Each `read_from_*` has a sibling `window_from_*` that returns just the `Window` 
 
 The split matters because:
 
-- **Windows are CRS-free.** Once you have a window in the source's pixel space, no further coordinate math is needed. `read_from_window` is the cheapest entry point.
-- **Bounds carry a CRS.** `read_from_bounds(data, bounds, crs_bounds)` *always* takes a separate `crs_bounds` arg — even if it's the same as the data — because there's no way to read the CRS off a tuple. Forgetting `crs_bounds` is a common bug.
+- **Windows are CRS-free.** Once you have a window in the source's pixel space, no further coordinate math is needed.
+  `read_from_window` is the cheapest entry point.
+- **Bounds carry a CRS.** `read_from_bounds(data, bounds, crs_bounds)` *always* takes a separate `crs_bounds` arg — even if it's the same as the data — because there's no way to read the CRS off a tuple.
+  Forgetting `crs_bounds` is a common bug.
 
-The `window_from_*` siblings are the bridge: they normalise any AOI specification into a pixel window in the source's CRS, with antimeridian handling and outer-rounding applied. The `read_from_*` functions then call `data.read_from_window(window, boundless=True).load()`.
+The `window_from_*` siblings are the bridge: they normalise any AOI specification into a pixel window in the source's CRS, with antimeridian handling and outer-rounding applied.
+The `read_from_*` functions then call `data.read_from_window(window, boundless=True).load()`.
 
 ---
 
@@ -153,10 +157,14 @@ The `window_from_*` siblings are the bridge: they normalise any AOI specificatio
 Three reprojection-flavoured entry points:
 
 - **`read_to_crs(data, dst_crs, resampling=...)`** — simplest case: same bounds, new CRS. Used for visualisation flips (UTM → Web Mercator).
-- **`read_reproject(data, dst_crs=None, bounds=None, resolution_dst_crs=None, dst_transform=None, ...)`** — the workhorse. Choose any combination of CRS / bounds / resolution / explicit transform; the function fills in the rest using `window_utils.figure_out_transform`.
-- **`read_reproject_like(data_in, data_like, ...)`** — match another raster's grid exactly. Reads `data_like.transform`, `data_like.crs`, `data_like.shape` and builds the matching read. Standard pattern for stacking heterogeneous sources onto a common grid.
+- **`read_reproject(data, dst_crs=None, bounds=None, resolution_dst_crs=None, dst_transform=None, ...)`** — the workhorse.
+  Choose any combination of CRS / bounds / resolution / explicit transform; the function fills in the rest using `window_utils.figure_out_transform`.
+- **`read_reproject_like(data_in, data_like, ...)`** — match another raster's grid exactly.
+  Reads `data_like.transform`, `data_like.crs`, `data_like.shape` and builds the matching read.
+  Standard pattern for stacking heterogeneous sources onto a common grid.
 
-The default resampling is `cubic_spline`. The advice in the table is good: **switch to `nearest` for masks and class labels**, otherwise you'll get fractional class IDs after resampling.
+The default resampling is `cubic_spline`.
+The advice in the table is good: **switch to `nearest` for masks and class labels**, otherwise you'll get fractional class IDs after resampling.
 
 The `resize` function is the resolution-only sibling — same CRS, same origin, new pixel size — with built-in anti-aliasing pre-blur for downsampling.
 
@@ -186,7 +194,8 @@ The `resize` function is the resolution-only sibling — same CRS, same origin, 
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-`boundless=True` is the default everywhere in `read.py`. This is deliberate: the moment you compose tiled inference with edge tiles, you *want* fixed-size outputs and don't want to special-case "this tile is at the edge."
+`boundless=True` is the default everywhere in `read.py`.
+This is deliberate: the moment you compose tiled inference with edge tiles, you *want* fixed-size outputs and don't want to special-case "this tile is at the edge."
 
 `boundless=False` is the right choice when you specifically want to detect off-edge requests — e.g., "did my AOI actually fall inside the scene?"
 
@@ -194,7 +203,8 @@ The `resize` function is the resolution-only sibling — same CRS, same origin, 
 
 ## 6. The eight-step `read_reproject` walkthrough
 
-The implementation of `read_reproject` ([read.py:1348](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/read.py#L1348)) is annotated with eight numbered banner-comments inside the function body. They're not a single ASCII diagram, but they're the clearest map of how reprojection actually works in this package — worth preserving.
+The implementation of `read_reproject` ([read.py:1348](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/read.py#L1348)) is annotated with eight numbered banner-comments inside the function body.
+They're not a single ASCII diagram, but they're the clearest map of how reprojection actually works in this package — worth preserving.
 
 ```text
 ─────────────────────────────────────────────────────────────────────────
@@ -282,11 +292,17 @@ This is where the actual coordinate transformation happens:
 
 Five things worth highlighting from this walkthrough:
 
-1. **Step 3 is the fast path.** Same CRS + same pixel size + grid-aligned origins → reprojection collapses to a window read. ~10–100× speedup. This is why operators that read coregistered data should reach for `read_from_bounds` (which dispatches via this path) instead of `read_reproject` blindly.
-2. **Step 6 short-circuits non-intersecting requests.** Asking for an AOI that doesn't overlap the scene returns a nodata-filled array, not an error. Composing tiled inference across catalogs of partially-overlapping scenes works without try/except.
-3. **Step 7 reads with a 3-pixel buffer.** That's the anti-aliasing-of-resampling-kernels reason. Bilinear / cubic kernels need neighbouring pixels at the destination boundary; without the buffer you get a thin nodata stripe along edges.
-4. **Step 4's bool dance.** Reprojecting a bool mask via `nearest` is correct semantically but loses smooth boundaries. The float32 → interpolate → threshold trick gives anti-aliased mask edges while preserving bool dtype on output.
-5. **Step 8 iterates by non-spatial dim.** A `(T, C, H, W)` GeoTensor reprojects band-by-band, time-by-time. The outer loop is in Python; the inner reprojection is in `rasterio.warp.reproject` (GDAL). For very large stacks this can be a bottleneck — one of the things a JAX-batched reprojection in `geotoolz` could improve later.
+1. **Step 3 is the fast path.** Same CRS + same pixel size + grid-aligned origins → reprojection collapses to a window read. ~10–100× speedup.
+   This is why operators that read coregistered data should reach for `read_from_bounds` (which dispatches via this path) instead of `read_reproject` blindly.
+2. **Step 6 short-circuits non-intersecting requests.** Asking for an AOI that doesn't overlap the scene returns a nodata-filled array, not an error.
+   Composing tiled inference across catalogs of partially-overlapping scenes works without try/except.
+3. **Step 7 reads with a 3-pixel buffer.** That's the anti-aliasing-of-resampling-kernels reason.
+   Bilinear / cubic kernels need neighbouring pixels at the destination boundary; without the buffer you get a thin nodata stripe along edges.
+4. **Step 4's bool dance.** Reprojecting a bool mask via `nearest` is correct semantically but loses smooth boundaries.
+   The float32 → interpolate → threshold trick gives anti-aliased mask edges while preserving bool dtype on output.
+5. **Step 8 iterates by non-spatial dim.** A `(T, C, H, W)` GeoTensor reprojects band-by-band, time-by-time.
+   The outer loop is in Python; the inner reprojection is in `rasterio.warp.reproject` (GDAL).
+   For very large stacks this can be a bottleneck — one of the things a JAX-batched reprojection in `geotoolz` could improve later.
 
 ---
 
@@ -321,7 +337,8 @@ Five things worth highlighting from this walkthrough:
 
 ## 8. The `pad_add` argument on `read_from_polygon`
 
-`read_from_polygon` accepts `pad_add=(rows, cols)` — a tuple of pixel padding to grow the read window beyond the polygon's bounding box. This isn't documented as a feature of the others, but it shows up in two contexts:
+`read_from_polygon` accepts `pad_add=(rows, cols)` — a tuple of pixel padding to grow the read window beyond the polygon's bounding box.
+This isn't documented as a feature of the others, but it shows up in two contexts:
 
 - **Reprojection edge handling.** Internal calls in `read_reproject` use `pad_add=(3, 3)` so that the resampling kernel has neighbours at the destination boundary (Step 7 above).
 - **CNN context windows.** For a segmentation model that needs context around the AOI, `pad_add=(32, 32)` reads a buffer; you pass through to inference, then crop the centre.
@@ -332,11 +349,16 @@ For other entry points, achieve the same effect by `pad_window`-ing the result o
 
 ## 9. Sharp edges
 
-- **`crs_bounds` / `crs_polygon` / `crs_center_coords` are required when they differ from the source.** If omitted, the function assumes the AOI is already in the source's CRS — which is silently wrong if it isn't. Pass the CRS explicitly always.
-- **Default resampling is `cubic_spline`.** Wrong for masks. Pass `resampling=Resampling.nearest` for class labels / cloud masks.
-- **`read_reproject` allocates the output upfront (Step 5).** A misconfigured huge output shape (e.g., units mismatch in `resolution_dst_crs`) tries to allocate a TB-scale array. If allocation seems suspicious, print the inferred output shape before reading.
-- **The fast path (Step 3) requires *exact* integer pixel offsets.** A fractional offset of 0.0003 still triggers the full reproject path. The `_is_exact_round` precision check matches `PIXEL_PRECISION = 3` from `window_utils`.
-- **`read_from_polygon` reads the polygon's *bounding box*, then masks.** It doesn't do per-pixel polygon membership at the read step — the read returns a rectangle. For pixel-level masking, follow with `rasterize` ([Chapter 9](09_rasterize.md)) or use `data.footprint().intersects(polygon)` checks.
+- **`crs_bounds` / `crs_polygon` / `crs_center_coords` are required when they differ from the source.** If omitted, the function assumes the AOI is already in the source's CRS — which is silently wrong if it isn't.
+  Pass the CRS explicitly always.
+- **Default resampling is `cubic_spline`.** Wrong for masks.
+  Pass `resampling=Resampling.nearest` for class labels / cloud masks.
+- **`read_reproject` allocates the output upfront (Step 5).** A misconfigured huge output shape (e.g., units mismatch in `resolution_dst_crs`) tries to allocate a TB-scale array.
+  If allocation seems suspicious, print the inferred output shape before reading.
+- **The fast path (Step 3) requires *exact* integer pixel offsets.** A fractional offset of 0.0003 still triggers the full reproject path.
+  The `_is_exact_round` precision check matches `PIXEL_PRECISION = 3` from `window_utils`.
+- **`read_from_polygon` reads the polygon's *bounding box*, then masks.** It doesn't do per-pixel polygon membership at the read step — the read returns a rectangle.
+  For pixel-level masking, follow with `rasterize` ([Chapter 9](09_rasterize.md)) or use `data.footprint().intersects(polygon)` checks.
 - **Antimeridian-crossing AOIs split into two reads.** Inherited from `bounds_to_windows` ([Chapter 4 §3](04_window_utils.md)); the splitting is automatic but it's two HTTP requests on cloud data.
 - **`read_from_tile` returns a Web Mercator tile.** If your source isn't in Web Mercator, this triggers a full reprojection per tile — fine for occasional rendering, expensive for a tile-loop.
 
@@ -350,6 +372,8 @@ Three functions from this module are essentially the entire `geotoolz.sampling.G
 - `read_from_window(boundless=True)` — fixed-shape chip retrieval.
 - `read_reproject_like` — when sampling from heterogeneous sources, match all chips to a common grid.
 
-A `GridSampler` is mostly a generator of `(x_min, y_min, x_max, y_max)` tuples in the source CRS; the `chip_op` calls `read_from_bounds` per tuple. Add `pad_add=(context, context)` for inference with context, then `slice_save_for_pred` ([Chapter 4 §9](04_window_utils.md)) to crop back when stitching. The whole loop is ~50 lines that wrap functions already in this module.
+A `GridSampler` is mostly a generator of `(x_min, y_min, x_max, y_max)` tuples in the source CRS; the `chip_op` calls `read_from_bounds` per tuple.
+Add `pad_add=(context, context)` for inference with context, then `slice_save_for_pred` ([Chapter 4 §9](04_window_utils.md)) to crop back when stitching.
+The whole loop is ~50 lines that wrap functions already in this module.
 
 Next chapter: [06_slices.md](06_slices.md) — tiling strategies (overlap, stride, chunked) for memory-efficient processing of datasets that don't fit in RAM.

--- a/projects/geotoolz/georeader_tutorial/06_slices.md
+++ b/projects/geotoolz/georeader_tutorial/06_slices.md
@@ -15,14 +15,16 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, slices, tiling
 ---
 
-> **Module:** `georeader/slices.py` (404 LOC)
-> **Role:** divide a raster into tiles. Three diagrams cover the *what* (overlap vs not), the *vocabulary* (Python `slice` vs `rasterio.windows.Window`), and the *what-do-I-do-at-the-edge* problem. Three public functions: `create_slices`, `create_windows`, plus the dict↔window converters.
+> **Module:** `georeader/slices.py` (404 LOC) **Role:** divide a raster into tiles.
+> Three diagrams cover the *what* (overlap vs not), the *vocabulary* (Python `slice` vs `rasterio.windows.Window`), and the *what-do-I-do-at-the-edge* problem.
+> Three public functions: `create_slices`, `create_windows`, plus the dict↔window converters.
 
 ---
 
 ## 1. The job
 
-When a raster doesn't fit in RAM (or a model has a fixed input size), you process it in tiles. The whole module exists to answer one question:
+When a raster doesn't fit in RAM (or a model has a fixed input size), you process it in tiles.
+The whole module exists to answer one question:
 
 **Given a raster shape, a tile size, and an overlap, give me the list of windows that cover it.**
 
@@ -55,10 +57,14 @@ Everything else — overlap semantics, edge handling, dict-vs-tuple ergonomics �
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Stride** = `tile_size - overlap`. That single equation drives the whole module:
+**Stride** = `tile_size - overlap`.
+That single equation drives the whole module:
 
-- `overlap=0` → stride = tile_size → tiles abut perfectly. Best for per-pixel work that has no spatial neighbourhood (mean per tile, classification heads applied independently).
-- `overlap>0` → stride < tile_size → tiles share rows/cols with neighbours. Necessary for any operation with a spatial kernel (convolutions, Lee-speckle filters, cubic resampling). The overlap should be at least the kernel half-width plus a margin — typical values 16/32/64 for U-Net-shaped models.
+- `overlap=0` → stride = tile_size → tiles abut perfectly.
+  Best for per-pixel work that has no spatial neighbourhood (mean per tile, classification heads applied independently).
+- `overlap>0` → stride < tile_size → tiles share rows/cols with neighbours.
+  Necessary for any operation with a spatial kernel (convolutions, Lee-speckle filters, cubic resampling).
+  The overlap should be at least the kernel half-width plus a margin — typical values 16/32/64 for U-Net-shaped models.
 
 The overlapped form composes with `slice_save_for_pred` ([Chapter 4 §9](04_window_utils.md)) for the standard "predict on padded chip, save the centre" tile-and-stitch recipe.
 
@@ -88,7 +94,8 @@ The overlapped form composes with `slice_save_for_pred` ([Chapter 4 §9](04_wind
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Two vocabularies for the same rectangle. Pick by audience:
+Two vocabularies for the same rectangle.
+Pick by audience:
 
 | Use slices when | Use windows when |
 |---|---|
@@ -96,9 +103,12 @@ Two vocabularies for the same rectangle. Pick by audience:
 | Composing with `xarray.isel` | Calling `read_from_window` |
 | Working in numpy `(rows, cols)` order | Working in rasterio `(col, row)` order |
 
-The conversion is purely arithmetic — there's no CRS or transform involved. The example: rows 100–355 inclusive (256 rows) and cols 200–455 inclusive (256 cols) is `Window(col_off=200, row_off=100, width=256, height=256)`. Note the order swap: numpy is rows-first, Window is col-first.
+The conversion is purely arithmetic — there's no CRS or transform involved.
+The example: rows 100–355 inclusive (256 rows) and cols 200–455 inclusive (256 cols) is `Window(col_off=200, row_off=100, width=256, height=256)`.
+Note the order swap: numpy is rows-first, Window is col-first.
 
-`create_slices` returns dicts (`{"y": slice(...), "x": slice(...)}`); `create_windows` returns `Window` objects. They're the same data wearing different hats.
+`create_slices` returns dicts (`{"y": slice(...), "x": slice(...)}`); `create_windows` returns `Window` objects.
+They're the same data wearing different hats.
 
 ---
 
@@ -128,15 +138,23 @@ The conversion is purely arithmetic — there's no CRS or transform involved. Th
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-500 isn't divisible by 128 — what to do with the remainder? Three flags settle it:
+500 isn't divisible by 128 — what to do with the remainder?
+Three flags settle it:
 
-- **`include_incomplete=True` (default).** Keep the partial last tile. Result has 5 tiles for our example, the last covering only 12 pixels. Use this for visualization / aggregation where every pixel must be covered.
-- **`include_incomplete=False`.** Drop the partial last tile. Result has 3 tiles covering 384 of the 500 pixels. Use this for ML training where a partial tile would have a different shape from the rest of the batch.
-- **`trim_incomplete=True` (default).** Last slice is `slice(384, 500)` — trimmed to the raster bound. The alternative (`trim_incomplete=False`) is `slice(384, 512)` — extending past the raster, requiring `boundless=True` reads to pad with `fill_value_default`. The trimmed version is what you want when reading; the un-trimmed is what you want when *writing back* into a fixed-size grid that already has padding allocated.
+- **`include_incomplete=True` (default).** Keep the partial last tile.
+  Result has 5 tiles for our example, the last covering only 12 pixels.
+  Use this for visualization / aggregation where every pixel must be covered.
+- **`include_incomplete=False`.** Drop the partial last tile.
+  Result has 3 tiles covering 384 of the 500 pixels.
+  Use this for ML training where a partial tile would have a different shape from the rest of the batch.
+- **`trim_incomplete=True` (default).** Last slice is `slice(384, 500)` — trimmed to the raster bound.
+  The alternative (`trim_incomplete=False`) is `slice(384, 512)` — extending past the raster, requiring `boundless=True` reads to pad with `fill_value_default`.
+  The trimmed version is what you want when reading; the un-trimmed is what you want when *writing back* into a fixed-size grid that already has padding allocated.
 
 There's also a fourth, narrower flag:
 
-- **`start_negative_if_padding=True`.** Shifts the first tile by `-overlap//2`, so overlap is symmetric across the *whole* raster (including the first/last edges) rather than just between interior tiles. Required when tile-and-stitch with a CNN that introduces edge artefacts even at the global boundary; usually paired with `boundless=True`.
+- **`start_negative_if_padding=True`.** Shifts the first tile by `-overlap//2`, so overlap is symmetric across the *whole* raster (including the first/last edges) rather than just between interior tiles.
+  Required when tile-and-stitch with a CNN that introduces edge artefacts even at the global boundary; usually paired with `boundless=True`.
 
 ---
 
@@ -144,13 +162,17 @@ There's also a fourth, narrower flag:
 
 ### `create_windows(geodata_shape, window_size, overlap=None, ...)`
 
-The primary entry point. `geodata_shape=(height, width)` (numpy order); `window_size=(height, width)`; `overlap=(row_overlap, col_overlap)`. Returns `list[rasterio.windows.Window]`.
+The primary entry point.
+`geodata_shape=(height, width)` (numpy order); `window_size=(height, width)`; `overlap=(row_overlap, col_overlap)`.
+Returns `list[rasterio.windows.Window]`.
 
 **Use this** for tiled reading from a raster.
 
 ### `create_slices(named_shape, dims, overlap=None, ...)`
 
-Generalised N-dimensional version. `named_shape={"y": H, "x": W, ...}`, `dims={"y": tile_h, "x": tile_w, ...}`. Returns `list[dict[str, slice]]` — one dict per tile, with one slice per named dimension.
+Generalised N-dimensional version.
+`named_shape={"y": H, "x": W, ...}`, `dims={"y": tile_h, "x": tile_w, ...}`.
+Returns `list[dict[str, slice]]` — one dict per tile, with one slice per named dimension.
 
 **Use this** for xarray-style indexing or for tiling along non-spatial dims (time chunks, band groups).
 
@@ -158,7 +180,8 @@ Internally, `create_windows` is a thin wrapper around `create_slices` with `dims
 
 ### `slices_to_windows((row_slice, col_slice))` / `window_to_slices(window)`
 
-Pair-wise converters. No tiling logic — just rectangle-shape translation.
+Pair-wise converters.
+No tiling logic — just rectangle-shape translation.
 
 There are also private helpers `_slices` (1D), `_slices_nd` (N-D tuple form), and `_slices_2d` (2D tuple form) — used internally and occasionally exposed in older code paths.
 
@@ -216,17 +239,26 @@ Pattern C is the one that lets you process a year of S2 in monthly time-chunks w
 
 ## 7. Sharp edges
 
-- **Numpy axis order vs Window order, again.** `geodata_shape=(H, W)`, `window_size=(H, W)`, `overlap=(row_overlap, col_overlap)` — all numpy `(y, x)`. The returned `Window` objects are `(col_off, row_off, width, height)` — rasterio `(x, y)`. The function does the swap; you have to pass numpy order in.
-- **`include_incomplete=False` *drops* coverage.** The 12-pixel remainder of the worked example is unread. If you don't want to drop and don't want a small tile, pad the raster first or use `start_negative_if_padding`.
-- **`trim_incomplete` interacts with `boundless`.** Trimmed tiles are smaller than `window_size` — chip batches won't stack. Untrimmed-and-boundless gives uniform shape but allocates padding. Pick consciously.
-- **No CRS / transform involvement.** This module is pure pixel arithmetic. If you want geographic-coordinate tiles (e.g., "tiles aligned to UTM grid lines"), you compute a `figure_out_transform` first and use `bounds_to_windows` ([Chapter 4 §3](04_window_utils.md)) per tile-bbox.
-- **`overlap` argument order matches the dims order.** In `create_windows` it's `(row_overlap, col_overlap)`. In `create_slices` it's `{"y": ..., "x": ...}` — the dict keys make this less ambiguous.
+- **Numpy axis order vs Window order, again.** `geodata_shape=(H, W)`, `window_size=(H, W)`, `overlap=(row_overlap, col_overlap)` — all numpy `(y, x)`.
+  The returned `Window` objects are `(col_off, row_off, width, height)` — rasterio `(x, y)`.
+  The function does the swap; you have to pass numpy order in.
+- **`include_incomplete=False` *drops* coverage.** The 12-pixel remainder of the worked example is unread.
+  If you don't want to drop and don't want a small tile, pad the raster first or use `start_negative_if_padding`.
+- **`trim_incomplete` interacts with `boundless`.** Trimmed tiles are smaller than `window_size` — chip batches won't stack.
+  Untrimmed-and-boundless gives uniform shape but allocates padding.
+  Pick consciously.
+- **No CRS / transform involvement.** This module is pure pixel arithmetic.
+  If you want geographic-coordinate tiles (e.g., "tiles aligned to UTM grid lines"), you compute a `figure_out_transform` first and use `bounds_to_windows` ([Chapter 4 §3](04_window_utils.md)) per tile-bbox.
+- **`overlap` argument order matches the dims order.** In `create_windows` it's `(row_overlap, col_overlap)`.
+  In `create_slices` it's `{"y": ..., "x": ...}` — the dict keys make this less ambiguous.
 
 ---
 
 ## 8. Why this module is small and stays small
 
-`slices.py` is one of the cleanest files in georeader. 404 lines, three public functions, no dependencies beyond `rasterio.windows`. The strategic minimalism is deliberate: tiling is a generator, not a pipeline. The pipeline (read → predict → stitch) is the user's responsibility, composed from this module + `read.py` + `window_utils.py`.
+`slices.py` is one of the cleanest files in georeader. 404 lines, three public functions, no dependencies beyond `rasterio.windows`.
+The strategic minimalism is deliberate: tiling is a generator, not a pipeline.
+The pipeline (read → predict → stitch) is the user's responsibility, composed from this module + `read.py` + `window_utils.py`.
 
 For `geotoolz.sampling`:
 
@@ -234,4 +266,5 @@ For `geotoolz.sampling`:
 - `geotoolz.sampling.RandomSampler` is **not** in this module — random sampling is just `np.random.randint` over the geographic bbox; no tiling structure to share.
 - `geotoolz.sampling.Stitch` lives in [Chapter 4 §9](04_window_utils.md) (`slice_save_for_pred`) — this module gives you the chips, that one tells you how to put predictions back.
 
-Next chapter: [07_griddata.md](07_griddata.md) — irregular-grid interpolation and the geolocation-lookup-table (GLT) pattern. Where the package grows past "rectilinear rasters" into swath sensors like MODIS / PRISMA.
+Next chapter: [07_griddata.md](07_griddata.md) — irregular-grid interpolation and the geolocation-lookup-table (GLT) pattern.
+Where the package grows past "rectilinear rasters" into swath sensors like MODIS / PRISMA.

--- a/projects/geotoolz/georeader_tutorial/07_griddata.md
+++ b/projects/geotoolz/georeader_tutorial/07_griddata.md
@@ -15,21 +15,26 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, griddata
 ---
 
-> **Module:** `georeader/griddata.py` (617 LOC)
-> **Role:** the onramp for **curvilinear sensors** — pushbroom imagers, swath scanners, and any sensor that gives you per-pixel `lons` and `lats` rather than a clean affine transform. Where `read.py` ends and EMIT / PRISMA / EnMAP / MODIS / VIIRS begin.
+> **Module:** `georeader/griddata.py` (617 LOC) **Role:** the onramp for **curvilinear sensors** — pushbroom imagers, swath scanners, and any sensor that gives you per-pixel `lons` and `lats` rather than a clean affine transform.
+> Where `read.py` ends and EMIT / PRISMA / EnMAP / MODIS / VIIRS begin.
 
 ---
 
 ## 1. Why this module exists
 
-Rectilinear rasters (S2, Landsat, Planet) come with an `Affine` transform — six numbers that map pixel `(col, row)` to geographic `(x, y)`. Every function in `read.py` assumes this transform exists.
+Rectilinear rasters (S2, Landsat, Planet) come with an `Affine` transform — six numbers that map pixel `(col, row)` to geographic `(x, y)`.
+Every function in `read.py` assumes this transform exists.
 
-But many sensors **don't ship that way**. EMIT, PRISMA, EnMAP, MODIS, VIIRS, AVHRR all give you:
+But many sensors **don't ship that way**.
+EMIT, PRISMA, EnMAP, MODIS, VIIRS, AVHRR all give you:
 
 - A 3D radiance/reflectance array `(H, W, bands)`.
 - Two 2D coordinate arrays `lons (H, W)` and `lats (H, W)`, **one per pixel**.
 
-There's no transform. Two adjacent pixels in the array don't necessarily map to adjacent points on Earth. Reading a polygon AOI requires either **interpolating** the irregular grid onto a regular one, or **looking up** which sensor pixel each output pixel came from. This module does both.
+There's no transform.
+Two adjacent pixels in the array don't necessarily map to adjacent points on Earth.
+Reading a polygon AOI requires either **interpolating** the irregular grid onto a regular one, or **looking up** which sensor pixel each output pixel came from.
+This module does both.
 
 ---
 
@@ -59,7 +64,9 @@ The job of `griddata.py` is to take the left and produce the right — a `GeoTen
 
 There are two strategies for doing this:
 
-1. **Interpolation** (`reproject`, `read_to_crs`, `read_reproject_like`) — sample the scattered points onto a regular grid via `scipy.interpolate.griddata`. Works for any sensor that gives you `(lons, lats)` arrays. Slow for large hyperspectral cubes; smooth output.
+1. **Interpolation** (`reproject`, `read_to_crs`, `read_reproject_like`) — sample the scattered points onto a regular grid via `scipy.interpolate.griddata`.
+   Works for any sensor that gives you `(lons, lats)` arrays.
+   Slow for large hyperspectral cubes; smooth output.
 2. **GLT lookup** (`georreference`) — apply a precomputed Geolocation Lookup Table that names "for each output pixel, which sensor pixel?" Fast, lossless (no interpolation artefacts), but requires the sensor's product to ship a GLT (NASA EMIT does; PRISMA doesn't).
 
 ---
@@ -82,7 +89,9 @@ There are two strategies for doing this:
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
-The default is `"cubic"` — Clough-Tocher interpolation on the Delaunay triangulation of the scattered points. C² smoothness matters for hyperspectral retrievals because matched filters and unmixing react badly to discontinuities. The cost: cubic on a ~10⁶-point hyperspectral scene is multi-minute; consider downsampling first if the geometry doesn't need full-res.
+The default is `"cubic"` — Clough-Tocher interpolation on the Delaunay triangulation of the scattered points.
+C² smoothness matters for hyperspectral retrievals because matched filters and unmixing react badly to discontinuities.
+The cost: cubic on a ~10⁶-point hyperspectral scene is multi-minute; consider downsampling first if the geometry doesn't need full-res.
 
 `"linear"` is the right default for "I just want to look at it"; `"nearest"` for categorical data (cloud masks, class labels).
 
@@ -110,9 +119,13 @@ The default is `"cubic"` — Clough-Tocher interpolation on the Delaunay triangu
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
-A GLT is a `(2, H_out, W_out)` integer array. Channel 0 holds the source column, channel 1 holds the source row, and each output pixel reads from `data[..., glt[1, i, j], glt[0, i, j]]` — a pure index gather. Invalid pixels (output cells with no source coverage) are marked with `fill_value_default` (typically `-1`).
+A GLT is a `(2, H_out, W_out)` integer array.
+Channel 0 holds the source column, channel 1 holds the source row, and each output pixel reads from `data[..., glt[1, i, j], glt[0, i, j]]` — a pure index gather.
+Invalid pixels (output cells with no source coverage) are marked with `fill_value_default` (typically `-1`).
 
-GLTs are produced **once** by the data provider's processing chain (using the full sensor model — orbital ephemeris, look angles, terrain DEM) and shipped alongside the radiance product. NASA EMIT does this; the EnMAP and PRISMA L1 products instead ship raw lons/lats and require interpolation at consumption time. The structural diagram repeats inside the `georreference` docstring:
+GLTs are produced **once** by the data provider's processing chain (using the full sensor model — orbital ephemeris, look angles, terrain DEM) and shipped alongside the radiance product.
+NASA EMIT does this; the EnMAP and PRISMA L1 products instead ship raw lons/lats and require interpolation at consumption time.
+The structural diagram repeats inside the `georreference` docstring:
 
 ```text
 ┌────────────────────────────────────────────────────────────────────┐
@@ -150,7 +163,8 @@ The output grid in the diagram has cells that pull from non-adjacent sensor pixe
 - Runs at memory-bandwidth speed — a single fancy-index over the band dim.
 - Handles arbitrary geometry (rotation, terrain warp, antimeridian) without special cases.
 
-The trade-off: fixed output grid. If you want a different resolution or CRS than the GLT was built for, you either re-ship the GLT or fall back to interpolation.
+The trade-off: fixed output grid.
+If you want a different resolution or CRS than the GLT was built for, you either re-ship the GLT or fall back to interpolation.
 
 ---
 
@@ -185,36 +199,49 @@ The internal walkthrough lives inside `reproject`'s docstring:
 
 A few details that bite:
 
-- **Step 1 expects `(H, W, C)`, not `(C, H, W)`.** `griddata` is the only entry point in the package that takes channels-last input. The output is transposed back to `(C, H, W)` in step 4. Don't pass a `GeoTensor` directly — strip to `data.values.transpose(1, 2, 0)` first if you have one.
-- **Step 2 inverts directions.** The `meshgrid` call uses `source_crs=dst_crs, dst_crs=crs` — the output grid coordinates need to be expressed in the **input's** CRS so they line up with the `(lons, lats)` arrays. This is why the function also accepts `crs="EPSG:4326"` as the input CRS by default.
-- **Step 3 is the slow one.** `scipy.interpolate.griddata` builds a Delaunay triangulation over `H × W` scattered points and then samples at `width × height` query locations. For a 1000×1000 EMIT scene at full res, that's ~10⁶ triangulation points and ~10⁶ queries. Cubic adds the Clough-Tocher per-triangle solve. Budget 1–10 minutes per scene per band group.
-- **Step 4's NaN handling.** Output pixels outside the convex hull of the input points come back as NaN. The function replaces them with `fill_value_default` (default `-1`). For `boundless`-style behaviour, that's correct; for downstream NaN-aware code, set `fill_value_default=np.nan` explicitly.
+- **Step 1 expects `(H, W, C)`, not `(C, H, W)`.** `griddata` is the only entry point in the package that takes channels-last input.
+  The output is transposed back to `(C, H, W)` in step 4. Don't pass a `GeoTensor` directly — strip to `data.values.transpose(1, 2, 0)` first if you have one.
+- **Step 2 inverts directions.** The `meshgrid` call uses `source_crs=dst_crs, dst_crs=crs` — the output grid coordinates need to be expressed in the **input's** CRS so they line up with the `(lons, lats)` arrays.
+  This is why the function also accepts `crs="EPSG:4326"` as the input CRS by default.
+- **Step 3 is the slow one.** `scipy.interpolate.griddata` builds a Delaunay triangulation over `H × W` scattered points and then samples at `width × height` query locations.
+  For a 1000×1000 EMIT scene at full res, that's ~10⁶ triangulation points and ~10⁶ queries.
+  Cubic adds the Clough-Tocher per-triangle solve.
+  Budget 1–10 minutes per scene per band group.
+- **Step 4's NaN handling.** Output pixels outside the convex hull of the input points come back as NaN. The function replaces them with `fill_value_default` (default `-1`).
+  For `boundless`-style behaviour, that's correct; for downstream NaN-aware code, set `fill_value_default=np.nan` explicitly.
 
 ---
 
 ## 6. The three high-level entry points
 
-All three return a `GeoTensor` with a real affine transform. Pick by what you have on hand:
+All three return a `GeoTensor` with a real affine transform.
+Pick by what you have on hand:
 
 ### `read_to_crs(data, lons, lats, resolution_dst, dst_crs=..., crs="EPSG:4326", method="cubic")`
 
-You have `(data, lons, lats)` and a target resolution. Auto-computes the output bounds (from `footprint(lons, lats)`), the output shape, and a `figure_out_transform`. Default `dst_crs` is the auto-detected UTM zone.
+You have `(data, lons, lats)` and a target resolution.
+Auto-computes the output bounds (from `footprint(lons, lats)`), the output shape, and a `figure_out_transform`.
+Default `dst_crs` is the auto-detected UTM zone.
 
 **Use this** for the first orthorectification of a scene with no preferred grid.
 
 ### `read_reproject_like(data, lons, lats, data_like, method="cubic", ...)`
 
-You have `(data, lons, lats)` and want the result on **another raster's grid** (e.g., to coregister an EMIT scene with a Sentinel-2 scene). Reads `data_like.transform`, `data_like.crs`, `data_like.shape` and dispatches to `reproject`.
+You have `(data, lons, lats)` and want the result on **another raster's grid** (e.g., to coregister an EMIT scene with a Sentinel-2 scene).
+Reads `data_like.transform`, `data_like.crs`, `data_like.shape` and dispatches to `reproject`.
 
 **Use this** when stacking heterogeneous sensors onto a common grid.
 
 ### `reproject(data, lons, lats, width, height, transform, dst_crs, crs="EPSG:4326", fill_value_default=-1, method="cubic")`
 
-The full-control entry point. You provide the output grid explicitly. Both wrappers above ultimately call this.
+The full-control entry point.
+You provide the output grid explicitly.
+Both wrappers above ultimately call this.
 
 **Use this** for production pipelines where the output grid is fixed by upstream config (e.g., a tile catalog).
 
-There's also `get_shape_transform_crs(lons, lats, resolution_dst, ...)` — the inverse-design helper that `read_to_crs` uses internally. Useful when you want to plan a grid before committing to the slow interpolation step.
+There's also `get_shape_transform_crs(lons, lats, resolution_dst, ...)` — the inverse-design helper that `read_to_crs` uses internally.
+Useful when you want to plan a grid before committing to the slow interpolation step.
 
 ---
 
@@ -226,13 +253,15 @@ georreference(glt: GeoTensor, data: NDArray,
               fill_value_default: Optional[Union[int, float]] = None) -> GeoTensor
 ```
 
-`glt` carries the transform and CRS (because it's a `GeoTensor`); `data` is the raw sensor array. The function:
+`glt` carries the transform and CRS (because it's a `GeoTensor`); `data` is the raw sensor array.
+The function:
 
 1. Checks the `valid_glt` mask (or computes it from `glt != fill_value_default`).
 2. Allocates the output array with shape inferred from `glt.shape[1:]` plus `data`'s leading dims.
 3. Issues `output[..., valid_glt] = data[..., glt[1, valid_glt], glt[0, valid_glt]]` — a single fancy-index gather.
 
-Speed scales with output pixel count and band count, not with input scene size. A 285-band EMIT scene orthorectifies in seconds vs minutes for `cubic` interpolation.
+Speed scales with output pixel count and band count, not with input scene size.
+A 285-band EMIT scene orthorectifies in seconds vs minutes for `cubic` interpolation.
 
 Source: [griddata.py:473](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/griddata.py#L473).
 
@@ -244,9 +273,12 @@ Source: [griddata.py:473](https://github.com/spaceml-org/georeader/blob/f0d92f0/
 footprint(lons: NDArray, lats: NDArray) -> Polygon
 ```
 
-Builds a Shapely polygon for an irregular grid. Picks the four extremum points (argmin/argmax of lon and lat in raveled form) and connects them. Approximate — not the actual hull — but fast and good enough for AOI-overlap checks.
+Builds a Shapely polygon for an irregular grid.
+Picks the four extremum points (argmin/argmax of lon and lat in raveled form) and connects them.
+Approximate — not the actual hull — but fast and good enough for AOI-overlap checks.
 
-For exact hulls use `shapely.MultiPoint(zip(lons.ravel(), lats.ravel())).convex_hull`. The fast version is used inside `read_to_crs` to derive output bounds.
+For exact hulls use `shapely.MultiPoint(zip(lons.ravel(), lats.ravel())).convex_hull`.
+The fast version is used inside `read_to_crs` to derive output bounds.
 
 ---
 
@@ -268,23 +300,35 @@ For exact hulls use `shapely.MultiPoint(zip(lons.ravel(), lats.ravel())).convex_
 
 ## 10. Sharp edges
 
-- **`(H, W, C)` channels-last for input data.** The package convention everywhere else is `(C, H, W)`. `griddata.reproject` is the exception. Transpose before, untranspose after — or rely on the EMIT/PRISMA readers in `georeader.readers` which handle this internally.
-- **`fill_value_default = -1` is unusual.** Most of the package uses `0`. The `-1` choice here is to make "outside convex hull" visually obvious. Override if you're feeding the result into something that interprets negative numbers as physical (e.g., reflectance models).
-- **The Delaunay triangulation is built per call.** If you're orthorectifying many bands of the same scene, *don't* call `reproject` per band. Pass the multi-band array; `griddata` builds the triangulation once and queries it for each band internally. This is a 100× speedup.
+- **`(H, W, C)` channels-last for input data.** The package convention everywhere else is `(C, H, W)`.
+  `griddata.reproject` is the exception.
+  Transpose before, untranspose after — or rely on the EMIT/PRISMA readers in `georeader.readers` which handle this internally.
+- **`fill_value_default = -1` is unusual.** Most of the package uses `0`.
+  The `-1` choice here is to make "outside convex hull" visually obvious.
+  Override if you're feeding the result into something that interprets negative numbers as physical (e.g., reflectance models).
+- **The Delaunay triangulation is built per call.** If you're orthorectifying many bands of the same scene, *don't* call `reproject` per band.
+  Pass the multi-band array; `griddata` builds the triangulation once and queries it for each band internally.
+  This is a 100× speedup.
 - **`lons` and `lats` must be 2D and same-shape as `data`'s spatial dims.** Some sensor products ship them as 1D `(H,)` and `(W,)` axes (rectilinear lat/lon grids that aren't projected); for those, build `lats[:, None] + 0*lons[None, :]` to broadcast to 2D first, or just use `read.read_reproject` which handles the rectilinear case.
-- **NaN inputs propagate through `griddata`.** Mask them out before calling — `griddata` has no `nan_policy`. The function's NaN handling at step 4 is for *out-of-hull* output pixels, not for NaN inputs.
-- **The function's name is `georreference` — note the double 'r'.** It's a typo that's now part of the public API (renaming is a breaking change). Don't fix it locally.
+- **NaN inputs propagate through `griddata`.** Mask them out before calling — `griddata` has no `nan_policy`.
+  The function's NaN handling at step 4 is for *out-of-hull* output pixels, not for NaN inputs.
+- **The function's name is `georreference` — note the double 'r'.** It's a typo that's now part of the public API (renaming is a breaking change).
+  Don't fix it locally.
 
 ---
 
 ## 11. How the curvilinear sensor readers use this module
 
-- **EMIT** (NASA, ISS) — ships a GLT in the L1B product. `georeader.readers.emit.load(...)` calls `georreference(glt, radiance)`. Fast.
-- **PRISMA** (ASI) — ships per-pixel `(lons, lats)` but no GLT. `georeader.readers.prisma.load(...)` calls `read_to_crs(...)`. Slow but unavoidable.
+- **EMIT** (NASA, ISS) — ships a GLT in the L1B product.
+  `georeader.readers.emit.load(...)` calls `georreference(glt, radiance)`.
+  Fast.
+- **PRISMA** (ASI) — ships per-pixel `(lons, lats)` but no GLT. `georeader.readers.prisma.load(...)` calls `read_to_crs(...)`.
+  Slow but unavoidable.
 - **EnMAP** (DLR) — same pattern as PRISMA. Per-pixel coords, interpolation on read.
 - **MODIS, VIIRS** (planned in [`modis.md`](../plans/readers/modis.md)) — same pattern as PRISMA, with extra wrinkles (bowtie pixel duplicates, antimeridian crossing for polar orbits).
 
-The `geotoolz` plan is to keep this division: GLT-equipped sensors get the fast path, everyone else gets cubic interpolation. The `griddata` module is the substrate; the readers are the per-sensor wrappers.
+The `geotoolz` plan is to keep this division: GLT-equipped sensors get the fast path, everyone else gets cubic interpolation.
+The `griddata` module is the substrate; the readers are the per-sensor wrappers.
 
 ---
 
@@ -292,8 +336,11 @@ The `geotoolz` plan is to keep this division: GLT-equipped sensors get the fast 
 
 Three concrete things downstream:
 
-1. **Hyperspectral operators (matched filter, ACE, RX, unmixing) consume orthorectified `GeoTensor`s.** The interpolation step happens at *read* time, inside the sensor reader. By the time `geotoolz.hyperspectral.MatchedFilter` runs, it's just a `GeoTensor` like any other — the curvilinear-ness is invisible.
-2. **The cost asymmetry shapes the pipeline.** Interpolating a 285-band EMIT scene cubically is minutes. Operators that re-read the scene (e.g., parameter sweeps) should `load()` once and reuse, not ortho-on-demand.
-3. **GLT support is sensor-specific.** A `geotoolz.presets.emit.EMIT_METHANE_MF` preset can rely on the fast GLT path; the equivalent EnMAP/PRISMA preset cannot. This shows up as different default behaviour in those presets — not a bug, a substrate constraint.
+1. **Hyperspectral operators (matched filter, ACE, RX, unmixing) consume orthorectified `GeoTensor`s.** The interpolation step happens at *read* time, inside the sensor reader.
+   By the time `geotoolz.hyperspectral.MatchedFilter` runs, it's just a `GeoTensor` like any other — the curvilinear-ness is invisible.
+2. **The cost asymmetry shapes the pipeline.** Interpolating a 285-band EMIT scene cubically is minutes.
+   Operators that re-read the scene (e.g., parameter sweeps) should `load()` once and reuse, not ortho-on-demand.
+3. **GLT support is sensor-specific.** A `geotoolz.presets.emit.EMIT_METHANE_MF` preset can rely on the fast GLT path; the equivalent EnMAP/PRISMA preset cannot.
+   This shows up as different default behaviour in those presets — not a bug, a substrate constraint.
 
 Next chapter: [08_mosaic.md](08_mosaic.md) — combining multiple rasters into seamless composites with reprojection and nodata fill.

--- a/projects/geotoolz/georeader_tutorial/08_mosaic.md
+++ b/projects/geotoolz/georeader_tutorial/08_mosaic.md
@@ -15,8 +15,8 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, mosaic
 ---
 
-> **Module:** `georeader/mosaic.py` (450 LOC)
-> **Role:** turn N partially-overlapping `GeoData` sources into a single seamless `GeoTensor`. Reprojects, resamples, and fills nodata gaps from later rasters in the list.
+> **Module:** `georeader/mosaic.py` (450 LOC) **Role:** turn N partially-overlapping `GeoData` sources into a single seamless `GeoTensor`.
+> Reprojects, resamples, and fills nodata gaps from later rasters in the list.
 
 ---
 
@@ -24,9 +24,13 @@ keywords: tutorial, georeader, mosaic
 
 You have a list of rasters and one of these problems:
 
-- **Adjacent scenes with gaps.** Two S2 tiles cover an AOI that straddles a swath edge. Each has a triangular nodata zone where the other has data. You want the union with no gaps.
-- **Cloudy time series.** Three S2 acquisitions of the same scene over a month, each with different clouds. You want a single cloud-free image — pixel by pixel, take the first valid observation.
-- **Heterogeneous mixed sources.** S2 + Landsat covering the same AOI at different resolutions. You want one grid, S2 where available, Landsat to fill gaps.
+- **Adjacent scenes with gaps.** Two S2 tiles cover an AOI that straddles a swath edge.
+  Each has a triangular nodata zone where the other has data.
+  You want the union with no gaps.
+- **Cloudy time series.** Three S2 acquisitions of the same scene over a month, each with different clouds.
+  You want a single cloud-free image — pixel by pixel, take the first valid observation.
+- **Heterogeneous mixed sources.** S2 + Landsat covering the same AOI at different resolutions.
+  You want one grid, S2 where available, Landsat to fill gaps.
 
 All three are the same operation underneath: **iterate the list, fill remaining nodata from each subsequent raster.** That's `spatial_mosaic`.
 
@@ -63,7 +67,8 @@ All three are the same operation underneath: **iterate the list, fill remaining 
 The two rules underneath:
 
 1. **Order = priority.** `[A, B, C]` means "use A wherever A is valid; use B where A is nodata but B is valid; use C only where both A and B are nodata."
-2. **Early termination.** If after raster B every pixel is valid, raster C is never read. A user-supplied list of cloud-free fallback scenes pays nothing for the unused tail when the AOI is mostly cloud-free.
+2. **Early termination.** If after raster B every pixel is valid, raster C is never read.
+   A user-supplied list of cloud-free fallback scenes pays nothing for the unused tail when the AOI is mostly cloud-free.
 
 This is the `rasterio.merge.merge` shape but with two extras `merge` doesn't have: per-raster validity masks (next section) and arbitrary masking functions (e.g., apply a cloud detector lazily before contributing to the mosaic).
 
@@ -98,15 +103,23 @@ This is the `rasterio.merge.merge` shape but with two extras `merge` doesn't hav
 
 Conceptually different from spatial mosaicking: **every** timestep contributes (subject to nodata), and a reduction (median, mean, max, ...) decides the per-pixel output value.
 
-The module docstring promises a `rasters_reduction(rasters, reducer=np.nanmedian, ...)` function for this. **It isn't implemented in the current module** — only `spatial_mosaic` is exported. See [§8 below](#8-the-implementation-vs-docstring-gap) for what's actually shipped vs documented.
+The module docstring promises a `rasters_reduction(rasters, reducer=np.nanmedian, ...)` function for this.
+**It isn't implemented in the current module** — only `spatial_mosaic` is exported.
+See [§8 below](#8-the-implementation-vs-docstring-gap) for what's actually shipped vs documented.
 
 The conceptual reduction recipes are still useful as a reference:
 
-- **`nanmedian`** — robust temporal composite. The standard cloud-free recipe: stack T scenes, mask clouds to NaN, take the per-pixel median across time. Outliers (residual clouds, shadows, snow) bias the mean but barely move the median.
+- **`nanmedian`** — robust temporal composite.
+  The standard cloud-free recipe: stack T scenes, mask clouds to NaN, take the per-pixel median across time.
+  Outliers (residual clouds, shadows, snow) bias the mean but barely move the median.
 - **`nanmean`** — when you actually want the average (e.g., monthly mean radiance for an energy-budget paper).
-- **`nanmax`** — max-NDVI compositing. For each pixel, pick the timestep where NDVI was highest. Standard greenness-of-the-year recipe.
-- **`nanmin`** — minimum compositing. Useful for water/wetland detection where the *darkest* observation rejects clouds.
-- **`nanstd`** — temporal variability map. Not a composite but a derived product (where does the scene change a lot?).
+- **`nanmax`** — max-NDVI compositing.
+  For each pixel, pick the timestep where NDVI was highest.
+  Standard greenness-of-the-year recipe.
+- **`nanmin`** — minimum compositing.
+  Useful for water/wetland detection where the *darkest* observation rejects clouds.
+- **`nanstd`** — temporal variability map.
+  Not a composite but a derived product (where does the scene change a lot?).
 
 ---
 
@@ -143,7 +156,8 @@ spatial_mosaic([reader1, reader2, reader3], ...)              # nodata-only
 spatial_mosaic([(reader1, mask1), (reader2, mask2), ...], ...) # explicit masks
 ```
 
-The mask convention: **`True` means invalid** (cloud, shadow, sensor flag set). Invalid pixels are treated like nodata — fall through to the next raster.
+The mask convention: **`True` means invalid** (cloud, shadow, sensor flag set).
+Invalid pixels are treated like nodata — fall through to the next raster.
 
 There's also a third form via `masking_function`:
 
@@ -151,7 +165,8 @@ There's also a third form via `masking_function`:
 spatial_mosaic([reader1, reader2, reader3], masking_function=detect_clouds, ...)
 ```
 
-`masking_function` is called with each `GeoData` and returns a `GeoData` of invalid pixels. The wrapper computes the mask lazily, which avoids materialising mask rasters when the spatial precedence rules out their parent (early termination above).
+`masking_function` is called with each `GeoData` and returns a `GeoData` of invalid pixels.
+The wrapper computes the mask lazily, which avoids materialising mask rasters when the spatial precedence rules out their parent (early termination above).
 
 The masking function is the seam where downstream packages plug in cloud detectors (CloudSEN12, s2cloudless, FMask) without the mosaic module taking a hard dep.
 
@@ -177,8 +192,10 @@ spatial_mosaic(
 
 A few non-obvious points:
 
-- **Output grid is configured via the same triplet as `read_reproject`.** Polygon / bounds + transform / dst_crs + resolution. Pass any consistent subset; `figure_out_transform` ([Chapter 4 §6](04_window_utils.md)) fills in the rest.
-- **`window_size=(h, w)` switches to tiled processing.** For large mosaics that don't fit in RAM, tile through the output grid; for each output tile, call `read_reproject(reader, bounds=tile_bounds)` per input raster. Memory cost is `O(tile_size × n_rasters)`, not `O(output_size)`.
+- **Output grid is configured via the same triplet as `read_reproject`.** Polygon / bounds + transform / dst_crs + resolution.
+  Pass any consistent subset; `figure_out_transform` ([Chapter 4 §6](04_window_utils.md)) fills in the rest.
+- **`window_size=(h, w)` switches to tiled processing.** For large mosaics that don't fit in RAM, tile through the output grid; for each output tile, call `read_reproject(reader, bounds=tile_bounds)` per input raster.
+  Memory cost is `O(tile_size × n_rasters)`, not `O(output_size)`.
 - **`resampling=cubic_spline` is the default.** Same caveat as `read.py` — flip to `Resampling.nearest` when mosaicking categorical data (cloud masks, class labels).
 - **The "first raster wins" defaults** (CRS, dtype, nodata) make the call short for "give me everything in raster1's coordinate system." Override only when you have a reason — passing inconsistent dtype across rasters can silently truncate values during the first reproject step.
 
@@ -207,7 +224,8 @@ composite = mosaic.spatial_mosaic(
 )
 ```
 
-Key idea: **rank before mosaicking.** The "first raster wins" rule means the order of `data_list` controls per-pixel preference. Ordering by global cloud cover (or by acquisition recency, or by snow score, etc.) makes the composite reflect a quality preference, not just a temporal order.
+Key idea: **rank before mosaicking.** The "first raster wins" rule means the order of `data_list` controls per-pixel preference.
+Ordering by global cloud cover (or by acquisition recency, or by snow score, etc.) makes the composite reflect a quality preference, not just a temporal order.
 
 For temporal reductions that *don't* prefer one timestep — true median compositing — you'd want `rasters_reduction`, which (see next section) isn't actually implemented yet.
 
@@ -230,9 +248,11 @@ The `window_size=(h, w)` argument on `spatial_mosaic` covers the chunked-process
 
 ## 8. The implementation-vs-docstring gap
 
-The module docstring promises four functions; the source defines one. This is worth flagging because:
+The module docstring promises four functions; the source defines one.
+This is worth flagging because:
 
-- If you read the docstring expecting a `rasters_reduction` for temporal compositing, **it doesn't exist**. You'd implement it yourself using `np.nanmedian` over a stacked-time `GeoTensor` (Chapter 1 §9 covers `GeoTensor.stack`).
+- If you read the docstring expecting a `rasters_reduction` for temporal compositing, **it doesn't exist**.
+  You'd implement it yourself using `np.nanmedian` over a stacked-time `GeoTensor` (Chapter 1 §9 covers `GeoTensor.stack`).
 - The `pad_add_rasters` helper would have been useful for aligning rasters of different shapes prior to stacking; the workaround is `read_reproject_like` per raster against a common reference.
 
 This is one of the loose ends downstream `geotoolz.compositing` fills in — `MeanComposite`, `MedianComposite`, `MaxNDVIComposite`, `CloudFreeComposite` (the [geotoolz.md plan §1.2](../plans/geotoolz/geotoolz.md)) are the operator-form versions of what the docstring here describes but doesn't implement.
@@ -246,25 +266,32 @@ median = np.nanmedian(stacked.values, axis=0)                             # (C, 
 out = GeoTensor(median, transform=stacked.transform, crs=stacked.crs)
 ```
 
-That's six lines you'd otherwise expect to be `mosaic.rasters_reduction(readers, reducer=np.nanmedian)`. Worth knowing it isn't there.
+That's six lines you'd otherwise expect to be `mosaic.rasters_reduction(readers, reducer=np.nanmedian)`.
+Worth knowing it isn't there.
 
 ---
 
 ## 9. Sharp edges
 
-- **First raster's metadata wins.** `dst_crs`, `dtype_dst`, `dst_nodata` all default to the first raster. Mixing dtypes silently truncates; mixing CRS triggers reprojection (correct, but the cost surprises people who didn't realise their list was heterogeneous).
+- **First raster's metadata wins.** `dst_crs`, `dtype_dst`, `dst_nodata` all default to the first raster.
+  Mixing dtypes silently truncates; mixing CRS triggers reprojection (correct, but the cost surprises people who didn't realise their list was heterogeneous).
 - **Mask convention is `True = invalid`.** It's the inverse of "valid mask." Easy to get backwards if you're coming from `masked_array` or sklearn.
 - **Default `cubic_spline` resampling.** Flip to `nearest` for categorical mosaics (cloud masks, class labels).
-- **Tile processing (`window_size`) is per-tile complete.** It doesn't stream — each output tile fully reads and reprojects each contributing input tile. Memory bound is per-tile; total compute is the same.
-- **`spatial_mosaic_chunked` / `rasters_reduction` / `pad_add_rasters` aren't implemented.** Don't trust the module docstring's "Module Functions Overview" list. Inspect the source.
-- **No deduplication.** Passing the same reader twice in `data_list` reads it twice. The module doesn't try to detect identity.
-- **Order matters and is silent.** Two cloud-free scenes in `[scene1, scene2]` vs `[scene2, scene1]` produce different mosaics in their overlap region. There's no "blend" mode in the current implementation.
+- **Tile processing (`window_size`) is per-tile complete.** It doesn't stream — each output tile fully reads and reprojects each contributing input tile.
+  Memory bound is per-tile; total compute is the same.
+- **`spatial_mosaic_chunked` / `rasters_reduction` / `pad_add_rasters` aren't implemented.** Don't trust the module docstring's "Module Functions Overview" list.
+  Inspect the source.
+- **No deduplication.** Passing the same reader twice in `data_list` reads it twice.
+  The module doesn't try to detect identity.
+- **Order matters and is silent.** Two cloud-free scenes in `[scene1, scene2]` vs `[scene2, scene1]` produce different mosaics in their overlap region.
+  There's no "blend" mode in the current implementation.
 
 ---
 
 ## 10. Connection to `geotoolz.compositing`
 
-The [geotoolz.md plan §1.2](../plans/geotoolz/geotoolz.md) lists `compositing` as one of the v0.2 modules with four operators: `MedianComposite`, `MaxNDVIComposite`, `CloudFreeComposite`, `MeanComposite`. Mapping to this module:
+The [geotoolz.md plan §1.2](../plans/geotoolz/geotoolz.md) lists `compositing` as one of the v0.2 modules with four operators: `MedianComposite`, `MaxNDVIComposite`, `CloudFreeComposite`, `MeanComposite`.
+Mapping to this module:
 
 | `geotoolz` operator | Maps to `mosaic.spatial_mosaic` how |
 |---|---|
@@ -273,6 +300,7 @@ The [geotoolz.md plan §1.2](../plans/geotoolz/geotoolz.md) lists `compositing` 
 | `MedianComposite` | not direct: needs `rasters_reduction(reducer=np.nanmedian)` |
 | `MeanComposite` | not direct: needs `rasters_reduction(reducer=np.nanmean)` |
 
-So `geotoolz.compositing` is *partly* a thin wrapper over `spatial_mosaic` and *partly* the missing `rasters_reduction` reimplemented at the operator layer. The implementation gap above means `geotoolz.compositing` will probably ship its own temporal-reduction core rather than depending on this module for it.
+So `geotoolz.compositing` is *partly* a thin wrapper over `spatial_mosaic` and *partly* the missing `rasters_reduction` reimplemented at the operator layer.
+The implementation gap above means `geotoolz.compositing` will probably ship its own temporal-reduction core rather than depending on this module for it.
 
 Next chapter: [09_rasterize.md](09_rasterize.md) — burning vector geometries into raster grids (the inverse of `vectorize`).

--- a/projects/geotoolz/georeader_tutorial/09_rasterize.md
+++ b/projects/geotoolz/georeader_tutorial/09_rasterize.md
@@ -15,8 +15,8 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, rasterize
 ---
 
-> **Module:** `georeader/rasterize.py` (438 LOC)
-> **Role:** burn vector geometries (polygons, lines, GeoDataFrames) into raster grids aligned to an existing `GeoData`. The standard tool for building masks, segmentation labels, and ROI maps from GIS-flavoured data.
+> **Module:** `georeader/rasterize.py` (438 LOC) **Role:** burn vector geometries (polygons, lines, GeoDataFrames) into raster grids aligned to an existing `GeoData`.
+> The standard tool for building masks, segmentation labels, and ROI maps from GIS-flavoured data.
 
 ---
 
@@ -58,7 +58,8 @@ This is what GIS calls "rasterization" or "burning vectors." The implementation 
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Two values control the output: `value` (the "burn" value, default `1`) and `fill` (the "outside" value, default `0`). The default produces a binary mask — pass non-binary `value` for class labels (e.g., `value=3` for "this polygon is class 3").
+Two values control the output: `value` (the "burn" value, default `1`) and `fill` (the "outside" value, default `0`).
+The default produces a binary mask — pass non-binary `value` for class labels (e.g., `value=3` for "this polygon is class 3").
 
 ---
 
@@ -91,10 +92,15 @@ Two values control the output: `value` (the "burn" value, default `1`) and `fill
 
 A pixel that's **half** inside the polygon: include it or not?
 
-- **`all_touched=False`** (default) — include only if the pixel **centre** is inside. Conservative; preserves area; matches GDAL's default. The right choice for area computations and for ML labels where you don't want bordering pixels labelled as belonging to a class their centre isn't in.
-- **`all_touched=True`** — include any pixel the polygon **touches**. Inclusive; over-estimates area; never gaps at boundaries. The right choice for masks where you want **no missing data inside the AOI** — e.g., reading a polygon AOI before doing per-pixel work, where missing edge pixels would bias statistics.
+- **`all_touched=False`** (default) — include only if the pixel **centre** is inside.
+  Conservative; preserves area; matches GDAL's default.
+  The right choice for area computations and for ML labels where you don't want bordering pixels labelled as belonging to a class their centre isn't in.
+- **`all_touched=True`** — include any pixel the polygon **touches**.
+  Inclusive; over-estimates area; never gaps at boundaries.
+  The right choice for masks where you want **no missing data inside the AOI** — e.g., reading a polygon AOI before doing per-pixel work, where missing edge pixels would bias statistics.
 
-The two modes can produce visibly different masks for thin geometries (lines, narrow polygons). For a `LineString`, `all_touched=False` produces an effectively empty raster (lines have zero area, so no pixel centre is "inside") — you almost always want `all_touched=True` for line rasterization.
+The two modes can produce visibly different masks for thin geometries (lines, narrow polygons).
+For a `LineString`, `all_touched=False` produces an effectively empty raster (lines have zero area, so no pixel centre is "inside") — you almost always want `all_touched=True` for line rasterization.
 
 ---
 
@@ -119,13 +125,15 @@ The two modes can produce visibly different masks for thin geometries (lines, na
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Each row contributes a different burn value, taken from the named attribute column. The standard pattern for building **segmentation labels** from GIS-curated training data:
+Each row contributes a different burn value, taken from the named attribute column.
+The standard pattern for building **segmentation labels** from GIS-curated training data:
 
 - Column = `class_id` integer per row.
 - `fill=0` so background is class 0.
 - Output dtype determined by the column's dtype (cast to `uint8` if you have ≤ 256 classes).
 
-For overlapping polygons, **last-row wins** — the rasterio default. If your classes have a meaningful precedence (water > vegetation > bare), sort the GeoDataFrame in priority order before passing.
+For overlapping polygons, **last-row wins** — the rasterio default.
+If your classes have a meaningful precedence (water > vegetation > bare), sort the GeoDataFrame in priority order before passing.
 
 ---
 
@@ -142,11 +150,15 @@ The module exports four entry points distinguished by **input** (single geometry
 
 Common kwargs across all four:
 
-- **`crs_geometry` / `crs_dataframe`** — CRS of the input geometry. If different from the raster's CRS, it's reprojected to match before rasterising. Required when crossing CRSs; the function doesn't guess.
+- **`crs_geometry` / `crs_dataframe`** — CRS of the input geometry.
+  If different from the raster's CRS, it's reprojected to match before rasterising.
+  Required when crossing CRSs; the function doesn't guess.
 - **`all_touched`** — section 3 above.
-- **`dtype`** — output dtype. Default `uint8` for the binary case; for class-label rasterization, defaults to the column's dtype.
+- **`dtype`** — output dtype.
+  Default `uint8` for the binary case; for class-label rasterization, defaults to the column's dtype.
 
-The "`_like`" forms wrap the explicit forms by reading `data_like.transform`, `data_like.crs`, `data_like.shape`, `data_like.dtype`. So in practice you'll use the `_like` forms 95% of the time.
+The "`_like`" forms wrap the explicit forms by reading `data_like.transform`, `data_like.crs`, `data_like.shape`, `data_like.dtype`.
+So in practice you'll use the `_like` forms 95% of the time.
 
 ---
 
@@ -191,7 +203,8 @@ This pairs with whatever `data_like` you read for X — `(s2_image, labels)` is 
 
 ## 7. The relationship to `window_utils.exterior_pixel_coords`
 
-`rasterize.py` could in principle be implemented purely on top of `window_utils.exterior_pixel_coords` (Chapter 4 §7) — convert polygon vertices to pixel coords, then fill via `cv2.fillPoly` or `skimage.draw.polygon`. The reason this module instead delegates to `rasterio.features.rasterize`:
+`rasterize.py` could in principle be implemented purely on top of `window_utils.exterior_pixel_coords` (Chapter 4 §7) — convert polygon vertices to pixel coords, then fill via `cv2.fillPoly` or `skimage.draw.polygon`.
+The reason this module instead delegates to `rasterio.features.rasterize`:
 
 1. **GDAL handles topology correctly.** Multipolygons with holes, self-intersecting rings, and degenerate edge cases all just work.
 2. **`all_touched` is built in.** Reimplementing the centre-vs-touched distinction correctly across edge cases is annoying; GDAL has done it.
@@ -203,13 +216,17 @@ The `exterior_pixel_coords` function still has its uses (custom drawing, vertex-
 
 ## 8. Sharp edges
 
-- **`all_touched=False` is the default.** For boolean masks where you want to read everything inside the AOI, you almost always want `all_touched=True`. The default is conservative because it matches GDAL.
+- **`all_touched=False` is the default.** For boolean masks where you want to read everything inside the AOI, you almost always want `all_touched=True`.
+  The default is conservative because it matches GDAL.
 - **Overlapping polygons: last-row wins.** Sort your GeoDataFrame in priority order if classes overlap.
-- **`crs_geometry` is required when CRSs differ.** No "auto-detect from rows" — pass it explicitly. A common bug: WGS84 polygons against a UTM raster, no `crs_geometry`, output is empty because the polygon coordinates are nonsensical in UTM space.
+- **`crs_geometry` is required when CRSs differ.** No "auto-detect from rows" — pass it explicitly.
+  A common bug: WGS84 polygons against a UTM raster, no `crs_geometry`, output is empty because the polygon coordinates are nonsensical in UTM space.
 - **Lines with `all_touched=False` are mostly empty.** Use `True` for `LineString` rasterization.
 - **Dtype matters.** Default `uint8` clips at 255; for segmentation tasks with > 256 classes, pass `dtype=np.uint16` or your column's dtype is silently truncated.
-- **Output is a `GeoTensor`, not a numpy array.** It comes with the reference raster's transform / CRS / fill_value. Ready for arithmetic with sibling `GeoTensor`s without coordinate fiddling.
-- **The shape matches the spatial dims of `data_like`.** If `data_like.shape` is `(C, H, W)`, the rasterised output is `(H, W)` (2D). Multiply with `data_like` and broadcasting handles the band axis.
+- **Output is a `GeoTensor`, not a numpy array.** It comes with the reference raster's transform / CRS / fill_value.
+  Ready for arithmetic with sibling `GeoTensor`s without coordinate fiddling.
+- **The shape matches the spatial dims of `data_like`.** If `data_like.shape` is `(C, H, W)`, the rasterised output is `(H, W)` (2D).
+  Multiply with `data_like` and broadcasting handles the band axis.
 
 ---
 
@@ -217,8 +234,10 @@ The `exterior_pixel_coords` function still has its uses (custom drawing, vertex-
 
 Two operators in [`geotoolz.md`](../plans/geotoolz/geotoolz.md) lean on this module:
 
-- **`cloud.ApplyMask(mask)`** — when the mask is geometry-shaped (e.g., AOI polygon), `ApplyMask` rasterises before applying. The user passes a `Polygon`, the operator handles the burn.
-- **`catalog_ops.WriteCOG(write_polygon=...)`** — clipping output to a polygon footprint at write time. Rasterise the polygon to a mask, multiply, write.
+- **`cloud.ApplyMask(mask)`** — when the mask is geometry-shaped (e.g., AOI polygon), `ApplyMask` rasterises before applying.
+  The user passes a `Polygon`, the operator handles the burn.
+- **`catalog_ops.WriteCOG(write_polygon=...)`** — clipping output to a polygon footprint at write time.
+  Rasterise the polygon to a mask, multiply, write.
 
 Beyond those, anywhere users pass a Shapely geometry and need a per-pixel decision, this module is the bridge.
 

--- a/projects/geotoolz/georeader_tutorial/10_vectorize.md
+++ b/projects/geotoolz/georeader_tutorial/10_vectorize.md
@@ -15,21 +15,24 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, vectorize
 ---
 
-> **Module:** `georeader/vectorize.py` (370 LOC)
-> **Role:** the inverse of [Chapter 9](09_rasterize.md). Extract polygon geometries from binary raster masks. Standard tool for converting segmentation outputs and classification rasters back to GIS-friendly vector formats.
+> **Module:** `georeader/vectorize.py` (370 LOC) **Role:** the inverse of [Chapter 9](09_rasterize.md).
+> Extract polygon geometries from binary raster masks.
+> Standard tool for converting segmentation outputs and classification rasters back to GIS-friendly vector formats.
 
 ---
 
 ## 1. The job
 
-You have a binary (or thresholded) raster — typically the output of a CNN segmentation, a cloud detector, or a classified scene. You want a list of Shapely `Polygon`s in CRS coordinates, suitable for:
+You have a binary (or thresholded) raster — typically the output of a CNN segmentation, a cloud detector, or a classified scene.
+You want a list of Shapely `Polygon`s in CRS coordinates, suitable for:
 
 - Writing to GeoJSON / Shapefile / GeoParquet for downstream GIS work.
 - Computing per-region statistics (area, perimeter, intersection with other vectors).
 - Counting / filtering objects (e.g., "how many flood polygons larger than 1 km²?").
 - Overlaying on a basemap with `lonboard` / Leaflet / QGIS.
 
-Underneath this is `rasterio.features.shapes` (which delegates to GDAL's polygonization). This module wraps it with three on-by-default ergonomics: small-polygon filtering, vertex simplification, and polygon buffering.
+Underneath this is `rasterio.features.shapes` (which delegates to GDAL's polygonization).
+This module wraps it with three on-by-default ergonomics: small-polygon filtering, vertex simplification, and polygon buffering.
 
 ---
 
@@ -58,9 +61,11 @@ Underneath this is `rasterio.features.shapes` (which delegates to GDAL's polygon
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Every connected component of `1`-valued pixels becomes one polygon. The polygon traces the **outside** edge of the foreground pixels — so a 3×3 patch of `1`s becomes a polygon enclosing 9 pixel squares (perimeter ≈ 12 pixels), not a single point.
+Every connected component of `1`-valued pixels becomes one polygon.
+The polygon traces the **outside** edge of the foreground pixels — so a 3×3 patch of `1`s becomes a polygon enclosing 9 pixel squares (perimeter ≈ 12 pixels), not a single point.
 
-For multi-class rasters, threshold or mask first: `vectorize` is fundamentally a binary operation. To extract per-class polygons from a label raster, loop:
+For multi-class rasters, threshold or mask first: `vectorize` is fundamentally a binary operation.
+To extract per-class polygons from a label raster, loop:
 
 ```python
 polygons_per_class = {
@@ -95,9 +100,12 @@ polygons_per_class = {
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Without simplification, a polygon traces every pixel boundary — a 100×100 region produces ~400 vertices forming a staircase pattern. That's both visually ugly and storage-expensive.
+Without simplification, a polygon traces every pixel boundary — a 100×100 region produces ~400 vertices forming a staircase pattern.
+That's both visually ugly and storage-expensive.
 
-`tolerance` is the Douglas-Peucker simplification distance, in **pixels**. Default `1.0` collapses single-pixel jaggies into smooth edges while preserving features ≥ 1 pixel. Larger values smooth more aggressively at the cost of accuracy:
+`tolerance` is the Douglas-Peucker simplification distance, in **pixels**.
+Default `1.0` collapses single-pixel jaggies into smooth edges while preserving features ≥ 1 pixel.
+Larger values smooth more aggressively at the cost of accuracy:
 
 | `tolerance` | What you get |
 |---|---|
@@ -106,7 +114,8 @@ Without simplification, a polygon traces every pixel boundary — a 100×100 reg
 | `2.0–5.0` | Aggressive smoothing for visualisation. Loses fine-grained shape detail. |
 | `> 10` | Bounding-box-like simplification. Suitable only for index/preview purposes. |
 
-The simplification happens after vectorization, in pixel coordinates, before applying the affine transform. So `tolerance=1` always means "1 pixel" regardless of CRS or resolution.
+The simplification happens after vectorization, in pixel coordinates, before applying the affine transform.
+So `tolerance=1` always means "1 pixel" regardless of CRS or resolution.
 
 ---
 
@@ -140,10 +149,16 @@ The simplification happens after vectorization, in pixel coordinates, before app
 
 Two filters layered onto the basic extraction:
 
-- **`min_area`** — drop any polygon whose area is below this threshold. Units are **pixels** (so `25.5` ≈ a 5×5 pixel square; the `.5` accounts for the typical pixel-centre adjustment). Crucial for noise removal: CNN segmentations often emit single-pixel false positives, and the default `25.5` filters them at very low cost. For large-scale work where every commission error matters, raise to 100 or 1000.
-- **`polygon_buffer`** — apply a shapely buffer in pixel units. Positive value expands each polygon (closes small gaps, merges nearby objects); negative value erodes (shrinks; can split a polygon into pieces or eliminate thin features). `polygon_buffer=-1` is the standard "shrink by one pixel to avoid edge inclusivity" trick.
+- **`min_area`** — drop any polygon whose area is below this threshold.
+  Units are **pixels** (so `25.5` ≈ a 5×5 pixel square; the `.5` accounts for the typical pixel-centre adjustment).
+  Crucial for noise removal: CNN segmentations often emit single-pixel false positives, and the default `25.5` filters them at very low cost.
+  For large-scale work where every commission error matters, raise to 100 or 1000.
+- **`polygon_buffer`** — apply a shapely buffer in pixel units.
+  Positive value expands each polygon (closes small gaps, merges nearby objects); negative value erodes (shrinks; can split a polygon into pieces or eliminate thin features).
+  `polygon_buffer=-1` is the standard "shrink by one pixel to avoid edge inclusivity" trick.
 
-Order of operations: vectorize → buffer → simplify → filter by min_area. So the area filter applies to the *final* simplified geometry, not the raw extraction.
+Order of operations: vectorize → buffer → simplify → filter by min_area.
+So the area filter applies to the *final* simplified geometry, not the raw extraction.
 
 ---
 
@@ -158,10 +173,13 @@ Order of operations: vectorize → buffer → simplify → filter by min_area. S
 
 Accepts either a numpy array or a `GeoData` (`GeoTensor` / `RasterioReader`).
 
-- **If `binary_mask` is a `GeoData`** — the function reads `.transform` and uses it to convert pixel-coordinate polygons to CRS-coordinate polygons. The output Polygons are georeferenced.
-- **If `binary_mask` is a plain ndarray** — output Polygons are in pixel coordinates, **unless** you pass `transform=` explicitly. In which case they're in CRS coords.
+- **If `binary_mask` is a `GeoData`** — the function reads `.transform` and uses it to convert pixel-coordinate polygons to CRS-coordinate polygons.
+  The output Polygons are georeferenced.
+- **If `binary_mask` is a plain ndarray** — output Polygons are in pixel coordinates, **unless** you pass `transform=` explicitly.
+  In which case they're in CRS coords.
 
-This duck-typing on input is the killer convenience: pipe a CNN's `(H, W)` numpy output and a transform together, get georeferenced polygons. No manual `polygon_to_crs` round-trip.
+This duck-typing on input is the killer convenience: pipe a CNN's `(H, W)` numpy output and a transform together, get georeferenced polygons.
+No manual `polygon_to_crs` round-trip.
 
 ### `transform_polygon(polygon, ...)`
 
@@ -201,30 +219,40 @@ gdf = gpd.GeoDataFrame(geometry=polygons, crs=s2_gt.crs)
 gdf.to_file("flood_polygons.geojson", driver="GeoJSON")
 ```
 
-Five lines for the whole "CNN prediction → georeferenced vector layer" pipeline. The `array_as_geotensor` step (Chapter 1 §10) is what makes the final polygons georeferenced — without it you'd be in pixel coords.
+Five lines for the whole "CNN prediction → georeferenced vector layer" pipeline.
+The `array_as_geotensor` step (Chapter 1 §10) is what makes the final polygons georeferenced — without it you'd be in pixel coords.
 
 ---
 
 ## 7. The rasterize ↔ vectorize round trip
 
-`rasterize` and `vectorize` are conceptually inverses, but **they are not exactly invertible**. Three sources of asymmetry:
+`rasterize` and `vectorize` are conceptually inverses, but **they are not exactly invertible**.
+Three sources of asymmetry:
 
-1. **Rasterization quantises** — every pixel either is or isn't in the polygon. After `rasterize → vectorize`, you get a polygon traced along pixel boundaries (a staircase) rather than the original smooth shape.
-2. **`tolerance > 0` smooths**. Round-tripping through `vectorize(tolerance=1)` then `rasterize` will not exactly match the original raster.
-3. **`min_area` drops content**. Small features below the threshold are gone for good after `vectorize → rasterize`.
+1. **Rasterization quantises** — every pixel either is or isn't in the polygon.
+   After `rasterize → vectorize`, you get a polygon traced along pixel boundaries (a staircase) rather than the original smooth shape.
+2. **`tolerance > 0` smooths**.
+   Round-tripping through `vectorize(tolerance=1)` then `rasterize` will not exactly match the original raster.
+3. **`min_area` drops content**.
+   Small features below the threshold are gone for good after `vectorize → rasterize`.
 
-For applications that need exact round-trips (e.g., test fixtures), pass `tolerance=0, min_area=0, polygon_buffer=0`. The output will have full vertex counts (large) and exact pixel boundaries.
+For applications that need exact round-trips (e.g., test fixtures), pass `tolerance=0, min_area=0, polygon_buffer=0`.
+The output will have full vertex counts (large) and exact pixel boundaries.
 
 ---
 
 ## 8. Sharp edges
 
-- **`min_area` units are pixels, not CRS area.** A `min_area=25` means 25 pixels regardless of resolution. If you want "1 km² minimum" on a 10m raster, that's `100*100 = 10000` pixels.
+- **`min_area` units are pixels, not CRS area.** A `min_area=25` means 25 pixels regardless of resolution.
+  If you want "1 km² minimum" on a 10m raster, that's `100*100 = 10000` pixels.
 - **`polygon_buffer` units are pixels too.** Same caveat.
-- **`tolerance=0` produces large polygons.** Every pixel boundary becomes a vertex. A flood-mapping output across a city can produce polygons with 100k+ vertices each; downstream tools (especially leaflet) will choke. Default `tolerance=1` is correct in nearly all cases.
+- **`tolerance=0` produces large polygons.** Every pixel boundary becomes a vertex.
+  A flood-mapping output across a city can produce polygons with 100k+ vertices each; downstream tools (especially leaflet) will choke.
+  Default `tolerance=1` is correct in nearly all cases.
 - **The function only vectorizes `True` pixels.** For multi-class rasters, threshold or split per-class first.
 - **A `MultiPolygon` is returned as multiple `Polygon`s.** `get_polygons` doesn't preserve multipolygon grouping — disconnected components are separate list entries even if the source mask had them as part of the same logical region.
-- **Plain ndarray + no `transform` → pixel-coordinate output.** Easy to forget; the polygons look "off-by-1000-orders-of-magnitude wrong" when you plot them on a map. Either pass `transform=` or wrap as a `GeoTensor` first.
+- **Plain ndarray + no `transform` → pixel-coordinate output.** Easy to forget; the polygons look "off-by-1000-orders-of-magnitude wrong" when you plot them on a map.
+  Either pass `transform=` or wrap as a `GeoTensor` first.
 - **GeoJSON expects WGS84 (`EPSG:4326`).** The polygons come out in the source raster's CRS. Use `transform_polygon(p, src_crs=..., dst_crs="EPSG:4326")` before exporting if your raster wasn't already WGS84.
 
 ---
@@ -233,8 +261,10 @@ For applications that need exact round-trips (e.g., test fixtures), pass `tolera
 
 Two operators in [`geotoolz.md`](../plans/geotoolz/geotoolz.md) wrap this module:
 
-- **`postprocess.PolygonsFromMask(min_area=..., tolerance=...)`** — a terminal operator that converts the final `(H, W)` boolean output of a `Sequential` to a list of polygons. Useful as the last step of a `[Sequential(model + threshold + PolygonsFromMask)]` pipeline.
-- **`catalog_ops.WriteGeoJSON(...)`** — write polygons (with optional attributes) to disk per-tile during catalog processing. Internal call: `get_polygons(...)` + `gpd.GeoDataFrame(...)` + `to_file(...)`.
+- **`postprocess.PolygonsFromMask(min_area=..., tolerance=...)`** — a terminal operator that converts the final `(H, W)` boolean output of a `Sequential` to a list of polygons.
+  Useful as the last step of a `[Sequential(model + threshold + PolygonsFromMask)]` pipeline.
+- **`catalog_ops.WriteGeoJSON(...)`** — write polygons (with optional attributes) to disk per-tile during catalog processing.
+  Internal call: `get_polygons(...)` + `gpd.GeoDataFrame(...)` + `to_file(...)`.
 
 These complete the "raster ML pipeline → GIS-ready output" loop without users touching rasterio or geopandas directly.
 

--- a/projects/geotoolz/georeader_tutorial/11_reflectance.md
+++ b/projects/geotoolz/georeader_tutorial/11_reflectance.md
@@ -15,8 +15,8 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, radiometry, srf
 ---
 
-> **Module:** `georeader/reflectance.py` (971 LOC, 97 box-drawing characters — third densest in the package)
-> **Role:** convert satellite imagery between physically meaningful radiometric quantities — radiance, top-of-atmosphere (ToA) reflectance, and band-integrated irradiance. Where the package crosses from "geospatial bookkeeping" into actual physics.
+> **Module:** `georeader/reflectance.py` (971 LOC, 97 box-drawing characters — third densest in the package) **Role:** convert satellite imagery between physically meaningful radiometric quantities — radiance, top-of-atmosphere (ToA) reflectance, and band-integrated irradiance.
+> Where the package crosses from "geospatial bookkeeping" into actual physics.
 
 ---
 
@@ -24,9 +24,12 @@ keywords: tutorial, georeader, radiometry, srf
 
 Satellite imagery is delivered in any of three radiometric units depending on the sensor / processing level:
 
-- **Digital numbers (DN)** — raw counts, sensor-specific, dimensionless. You almost never want to work with these.
-- **Radiance (L)** — `W / m² / sr / nm` — the actual photon flux hitting the sensor, per unit area, per unit solid angle, per wavelength. Physical, directly comparable across sensors *if* you know the geometry.
-- **Top-of-atmosphere reflectance (ρ)** — dimensionless, typically ∈ `[0, 1]` — the fraction of incoming solar radiation that the surface reflected back, **before** atmospheric correction. The starting point for most ML pipelines because it normalises out solar-illumination effects (sun angle, Earth-sun distance).
+- **Digital numbers (DN)** — raw counts, sensor-specific, dimensionless.
+  You almost never want to work with these.
+- **Radiance (L)** — `W / m² / sr / nm` — the actual photon flux hitting the sensor, per unit area, per unit solid angle, per wavelength.
+  Physical, directly comparable across sensors *if* you know the geometry.
+- **Top-of-atmosphere reflectance (ρ)** — dimensionless, typically ∈ `[0, 1]` — the fraction of incoming solar radiation that the surface reflected back, **before** atmospheric correction.
+  The starting point for most ML pipelines because it normalises out solar-illumination effects (sun angle, Earth-sun distance).
 
 This module provides:
 
@@ -61,7 +64,8 @@ This module provides:
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The DN→radiance step is **sensor-specific** (linear scale + offset from per-band calibration coefficients) and lives inside the per-sensor reader, not this module. Once you have radiance, this module handles the rest.
+The DN→radiance step is **sensor-specific** (linear scale + offset from per-band calibration coefficients) and lives inside the per-sensor reader, not this module.
+Once you have radiance, this module handles the rest.
 
 The three supported radiance unit systems all ship in real-world products:
 
@@ -90,8 +94,10 @@ where:
 Three corrections combined:
 
 - **`π`** — convert from solid-angle-aware radiance to a Lambertian-equivalent reflectance.
-- **`d²`** — Earth-sun distance correction. Earth's orbit is elliptical; in January (perihelion) we're closer to the Sun and get more incoming radiation than in July (aphelion).
-- **`cos(θ_z)`** — solar zenith correction. When the Sun is low in the sky, the same surface element intercepts less radiation per unit horizontal area.
+- **`d²`** — Earth-sun distance correction.
+  Earth's orbit is elliptical; in January (perihelion) we're closer to the Sun and get more incoming radiation than in July (aphelion).
+- **`cos(θ_z)`** — solar zenith correction.
+  When the Sun is low in the sky, the same surface element intercepts less radiation per unit horizontal area.
 
 The module factors them into `obfactor = π × d² / cos(θ_z)` — `observation_date_correction_factor` — so the reflectance line collapses to `ρ = L × obfactor / E_sun`.
 
@@ -148,9 +154,11 @@ The module factors them into `obfactor = π × d² / cos(θ_z)` — `observation
 └────────────────────────────────────────────────────────────────────┘
 ```
 
-The annual ≈ ±1.7% variation in distance becomes ≈ ±3.4% in `d²` and therefore ≈ 6.5% peak-to-peak in irradiance over the year. **Ignoring this correction biases reflectance time series**: you'd see a fake annual cycle of ~3% amplitude with peaks in the Northern winter (smaller `d`, more apparent radiance, higher uncorrected reflectance).
+The annual ≈ ±1.7% variation in distance becomes ≈ ±3.4% in `d²` and therefore ≈ 6.5% peak-to-peak in irradiance over the year.
+**Ignoring this correction biases reflectance time series**: you'd see a fake annual cycle of ~3% amplitude with peaks in the Northern winter (smaller `d`, more apparent radiance, higher uncorrected reflectance).
 
-The closed-form expression `d = 1 - 0.01673 × cos(0.0172 × (DOY − 4))` is what `earth_sun_distance_correction_factor(date_of_acquisition)` returns. It's accurate to ~0.001 AU — well below the precision needed for radiometric calibration.
+The closed-form expression `d = 1 - 0.01673 × cos(0.0172 × (DOY − 4))` is what `earth_sun_distance_correction_factor(date_of_acquisition)` returns.
+It's accurate to ~0.001 AU — well below the precision needed for radiometric calibration.
 
 ---
 
@@ -182,10 +190,13 @@ When you want to take a hyperspectral measurement (~285 narrow bands) and turn i
 
 Two functions own this:
 
-- **`srf(center_wavelengths, fwhm, wavelengths)`** — build a Gaussian SRF DataFrame from per-band centre/FWHM specs. Returns shape `(N_wavelengths, K_bands)` normalized so each column sums to 1.
+- **`srf(center_wavelengths, fwhm, wavelengths)`** — build a Gaussian SRF DataFrame from per-band centre/FWHM specs.
+  Returns shape `(N_wavelengths, K_bands)` normalized so each column sums to 1.
 - **`transform_to_srf(hyperspectral_data, srf, wavelengths)`** — apply the SRF: produce a `(K_bands, H, W)` multispectral cube from a `(N_wavelengths, H, W)` hyperspectral cube.
 
-Why Gaussian? Most published SRFs are well-approximated by Gaussians, and Gaussian SRFs are uniquely specified by `(centre, FWHM)`. The exact published SRFs (S2, Landsat, etc.) tend to have ~1% non-Gaussian deviations; for most ML applications the difference doesn't matter, but for radiative-transfer studies you'd want to use the exact published curves rather than a Gaussian approximation.
+Why Gaussian?
+Most published SRFs are well-approximated by Gaussians, and Gaussian SRFs are uniquely specified by `(centre, FWHM)`.
+The exact published SRFs (S2, Landsat, etc.) tend to have ~1% non-Gaussian deviations; for most ML applications the difference doesn't matter, but for radiative-transfer studies you'd want to use the exact published curves rather than a Gaussian approximation.
 
 The `2 × √(2 × ln(2)) ≈ 2.355` constant in the formula is the FWHM-to-σ ratio for a Gaussian — comes up again in any "spread parameter" discussion.
 
@@ -218,11 +229,14 @@ Reflectance computation needs `E_sun` **per band** — a single number that summ
 E_k = ∫ E_sun(λ) × R_k(λ) dλ  /  ∫ R_k(λ) dλ
 ```
 
-`integrated_irradiance(srf, solar_irradiance=None, epsilon_srf=1e-4)` computes the integral per band. If `solar_irradiance=None`, it loads the **Thuillier (2003) reference spectrum** bundled with the package as `SolarIrradiance_Thuillier.csv` (Solar Physics 214). The Thuillier spectrum covers 200–2400 nm at ~1 nm resolution — fine enough for any current orbital sensor.
+`integrated_irradiance(srf, solar_irradiance=None, epsilon_srf=1e-4)` computes the integral per band.
+If `solar_irradiance=None`, it loads the **Thuillier (2003) reference spectrum** bundled with the package as `SolarIrradiance_Thuillier.csv` (Solar Physics 214).
+The Thuillier spectrum covers 200–2400 nm at ~1 nm resolution — fine enough for any current orbital sensor.
 
 The `epsilon_srf` threshold zeroes out SRF values below a tiny floor — important because Gaussian SRFs technically extend forever, and the integration would otherwise pick up out-of-band noise in `E_sun(λ)`.
 
-`load_thuillier_irradiance()` returns the cached DataFrame with columns `["Nanometer", "Radiance(mW/m2/nm)"]`. The `THUILLIER_RADIANCE = None` module-level cache means it's loaded lazily on first use.
+`load_thuillier_irradiance()` returns the cached DataFrame with columns `["Nanometer", "Radiance(mW/m2/nm)"]`.
+The `THUILLIER_RADIANCE = None` module-level cache means it's loaded lazily on first use.
 
 ---
 
@@ -264,7 +278,8 @@ toa_refl = reflectance.radiance_to_reflectance(
 # toa_refl is a (B, H, W) GeoTensor in [0, 1]
 ```
 
-The `solar_irradiance` argument is what lets you specialise to *any* sensor — pass S2's per-band `E_sun` for S2, Landsat's for Landsat. The reader for each sensor typically ships these constants as a module-level array.
+The `solar_irradiance` argument is what lets you specialise to *any* sensor — pass S2's per-band `E_sun` for S2, Landsat's for Landsat.
+The reader for each sensor typically ships these constants as a module-level array.
 
 **B. Hyperspectral EMIT → S2-equivalent multispectral:**
 
@@ -289,19 +304,29 @@ This is the "spectral response binning" preset that the [`geotoolz.md` plan](../
 
 ## 9. Sharp edges
 
-- **`solar_irradiance` units must be `W/m²/nm`, not `mW/m²/nm`.** Even when the input radiance is in mW units. The function normalises radiance internally; it does not normalise the solar input. Mismatched scaling here is the most common bug, off by a factor of 1000.
-- **`center_coords` for solar zenith.** If `data` is a `GeoTensor`, the function can derive scene centre from `transform`. If it's a plain ndarray, you must pass `center_coords` explicitly. Forgetting this with a non-GeoTensor input gives a silent mis-correction.
-- **`crs_coords` defaults to EPSG:4326.** If your `center_coords` are in UTM, pass `crs_coords="EPSG:32630"` (or whichever zone). Otherwise the SZA computation places your scene at lon=500000, lat=4500000 — somewhere in deep space.
-- **`observation_date_corr_factor` shortcut.** Pass it pre-computed and the function skips date and centre coords. Useful for batched processing where you've calibrated `obfactor` once and want to apply it to N tiles cheaply.
-- **Thuillier is in `mW/m²/nm`, not `W/m²/nm`.** Read the column name. If you pass it directly as `solar_irradiance` to `radiance_to_reflectance`, you'll be off by 1000.
-- **`integrated_irradiance` returns same units as input solar spectrum.** Mixing Thuillier (`mW`) with a band-integrated value used as `W` argument is the dominant unit confusion. Convert explicitly.
+- **`solar_irradiance` units must be `W/m²/nm`, not `mW/m²/nm`.** Even when the input radiance is in mW units.
+  The function normalises radiance internally; it does not normalise the solar input.
+  Mismatched scaling here is the most common bug, off by a factor of 1000.
+- **`center_coords` for solar zenith.** If `data` is a `GeoTensor`, the function can derive scene centre from `transform`.
+  If it's a plain ndarray, you must pass `center_coords` explicitly.
+  Forgetting this with a non-GeoTensor input gives a silent mis-correction.
+- **`crs_coords` defaults to EPSG:4326.** If your `center_coords` are in UTM, pass `crs_coords="EPSG:32630"` (or whichever zone).
+  Otherwise the SZA computation places your scene at lon=500000, lat=4500000 — somewhere in deep space.
+- **`observation_date_corr_factor` shortcut.** Pass it pre-computed and the function skips date and centre coords.
+  Useful for batched processing where you've calibrated `obfactor` once and want to apply it to N tiles cheaply.
+- **Thuillier is in `mW/m²/nm`, not `W/m²/nm`.** Read the column name.
+  If you pass it directly as `solar_irradiance` to `radiance_to_reflectance`, you'll be off by 1000.
+- **`integrated_irradiance` returns same units as input solar spectrum.** Mixing Thuillier (`mW`) with a band-integrated value used as `W` argument is the dominant unit confusion.
+  Convert explicitly.
 - **`srf(center, fwhm, wavelengths)` doesn't normalise to unit area.** The `transform_to_srf` and `integrated_irradiance` functions do their own normalisation internally, but if you take the SRF DataFrame and use it elsewhere you may need to divide by `np.trapz(R, wavelengths)`.
 
 ---
 
 ## 10. Why this module is denser than its size
 
-971 LOC, 97 box-drawing characters — the third densest in the package because **physics requires illustration**. The Earth-sun distance plot, the SRF convolution diagram, and the integration visual are doing real explanatory work that prose alone wouldn't. If you only keep one chapter's diagrams from this whole tutorial, this is one of the candidates — they're the ones that explain the *why* not just the *what*.
+971 LOC, 97 box-drawing characters — the third densest in the package because **physics requires illustration**.
+The Earth-sun distance plot, the SRF convolution diagram, and the integration visual are doing real explanatory work that prose alone wouldn't.
+If you only keep one chapter's diagrams from this whole tutorial, this is one of the candidates — they're the ones that explain the *why* not just the *what*.
 
 ---
 
@@ -309,10 +334,13 @@ This is the "spectral response binning" preset that the [`geotoolz.md` plan](../
 
 Three concrete operator-shapes from [`geotoolz.md`](../plans/geotoolz/geotoolz.md) wrap functions in this module:
 
-- **`correction.TOAToBOA(sun_zenith=..., atmosphere=...)`** — wraps `radiance_to_reflectance` plus an atmospheric correction step. The radiance→ToA part is what this module already does.
-- **`radiometry.SRFBin(target_centres, target_fwhm)`** — wraps `srf` + `transform_to_srf` to take a hyperspectral cube and bin it to a target sensor's bands. The basis for the `EnMAP → S2` and `EMIT → S2` preset operators.
+- **`correction.TOAToBOA(sun_zenith=..., atmosphere=...)`** — wraps `radiance_to_reflectance` plus an atmospheric correction step.
+  The radiance→ToA part is what this module already does.
+- **`radiometry.SRFBin(target_centres, target_fwhm)`** — wraps `srf` + `transform_to_srf` to take a hyperspectral cube and bin it to a target sensor's bands.
+  The basis for the `EnMAP → S2` and `EMIT → S2` preset operators.
 - **`presets.s2.S2_L1C_TO_BOA_NDVI(...)`** — a `Sequential` that includes `radiance_to_reflectance` as one of its steps when starting from L1A radiance products.
 
-The module is also implicitly used inside `readers.emit`, `readers.prisma`, and `readers.enmap` — those readers do DN → radiance internally (per their per-sensor calibration coefficients) and expose the radiance-units result. The reflectance step is then a one-line call to this module.
+The module is also implicitly used inside `readers.emit`, `readers.prisma`, and `readers.enmap` — those readers do DN → radiance internally (per their per-sensor calibration coefficients) and expose the radiance-units result.
+The reflectance step is then a one-line call to this module.
 
 Next chapter: [12_save.md](12_save.md) — writing GeoTensors to disk; full Cloud-Optimized GeoTIFF (COG) anatomy.

--- a/projects/geotoolz/georeader_tutorial/12_save.md
+++ b/projects/geotoolz/georeader_tutorial/12_save.md
@@ -15,20 +15,27 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, cog, save
 ---
 
-> **Module:** `georeader/save.py` (586 LOC; the empty `save_cog.py` is a deprecated stub)
-> **Role:** the export side. Take a `GeoTensor` (or anything `GeoData`-shaped), write it to disk as a tiled GeoTIFF or a Cloud-Optimized GeoTIFF (COG). Handles cloud-storage destinations (`gs://`, `s3://`, `az://`) transparently.
+> **Module:** `georeader/save.py` (586 LOC; the empty `save_cog.py` is a deprecated stub) **Role:** the export side.
+> Take a `GeoTensor` (or anything `GeoData`-shaped), write it to disk as a tiled GeoTIFF or a Cloud-Optimized GeoTIFF (COG).
+> Handles cloud-storage destinations (`gs://`, `s3://`, `az://`) transparently.
 
 ---
 
 ## 1. Why COGs
 
-A traditional GeoTIFF stores data as a single big image, with the header at the *end* of the file. To read any part of it you need to first download enough bytes to find the header, then seek into the data. Over HTTP this is awful — you pay for the round-trip on every read.
+A traditional GeoTIFF stores data as a single big image, with the header at the *end* of the file.
+To read any part of it you need to first download enough bytes to find the header, then seek into the data.
+Over HTTP this is awful — you pay for the round-trip on every read.
 
 A Cloud Optimized GeoTIFF (COG) reorganises the same byte stream so:
 
-- The **header lives at the start**. A few KB of HTTP range-read tells you everything about the file.
-- Data is **tiled** (default 256×256 blocks). To read one tile you fetch one tile's bytes — not the whole file.
-- **Overviews** (decimated pyramid layers — 2×, 4×, 8× downsampled copies) are interleaved at the start. Want a thumbnail? Read overview 8 — a tiny number of bytes.
+- The **header lives at the start**.
+  A few KB of HTTP range-read tells you everything about the file.
+- Data is **tiled** (default 256×256 blocks).
+  To read one tile you fetch one tile's bytes — not the whole file.
+- **Overviews** (decimated pyramid layers — 2×, 4×, 8× downsampled copies) are interleaved at the start.
+  Want a thumbnail?
+  Read overview 8 — a tiny number of bytes.
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -60,7 +67,8 @@ A Cloud Optimized GeoTIFF (COG) reorganises the same byte stream so:
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The cost: COG files are slightly larger than minimal GeoTIFFs (overviews add ~33% on top of full resolution). The benefit: for any file you'll touch over HTTP, COG is transformative — `RasterioReader("https://...cog.tif")` becomes interactive.
+The cost: COG files are slightly larger than minimal GeoTIFFs (overviews add ~33% on top of full resolution).
+The benefit: for any file you'll touch over HTTP, COG is transformative — `RasterioReader("https://...cog.tif")` becomes interactive.
 
 The practical rule: **save everything as COG by default unless you have a reason not to**.
 
@@ -89,11 +97,17 @@ The practical rule: **save everything as COG by default unless you have a reason
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The package default is **`lzw`** — a sensible "fast and lossless" choice that's universally supported by GeoTIFF readers (going back decades). Three other choices show up often:
+The package default is **`lzw`** — a sensible "fast and lossless" choice that's universally supported by GeoTIFF readers (going back decades).
+Three other choices show up often:
 
-- **`zstd`** — modern, faster than lzw, smaller files. Recommended whenever your downstream readers support it (rasterio + GDAL ≥ 3.0 do; older proprietary tools may not). Probably the best default for new projects.
-- **`deflate` with `predictor=2`** — ideal for integer masks and class-label rasters. The predictor encodes pixel-to-pixel differences before deflate, giving 5–10× better ratios on data that varies smoothly.
-- **`jpeg` / `webp`** — *lossy*. Use only for visualisation outputs where you don't care about exact pixel values. Never for ML training data.
+- **`zstd`** — modern, faster than lzw, smaller files.
+  Recommended whenever your downstream readers support it (rasterio + GDAL ≥ 3.0 do; older proprietary tools may not).
+  Probably the best default for new projects.
+- **`deflate` with `predictor=2`** — ideal for integer masks and class-label rasters.
+  The predictor encodes pixel-to-pixel differences before deflate, giving 5–10× better ratios on data that varies smoothly.
+- **`jpeg` / `webp`** — *lossy*.
+  Use only for visualisation outputs where you don't care about exact pixel values.
+  Never for ML training data.
 
 Override via `profile_arg={"compress": "zstd"}`.
 
@@ -117,7 +131,9 @@ Override via `profile_arg={"compress": "zstd"}`.
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The `bool → Byte` conversion is the only sneaky one — booleans are written as `uint8` `{0, 1}` because GeoTIFF has no boolean type. Reading them back gives a `uint8` array, and you'd usually `> 0` to convert it back to bool. The `validmask`/`invalidmask` `GeoTensor` properties (Chapter 1) are aware of this.
+The `bool → Byte` conversion is the only sneaky one — booleans are written as `uint8` `{0, 1}` because GeoTIFF has no boolean type.
+Reading them back gives a `uint8` array, and you'd usually `> 0` to convert it back to bool.
+The `validmask`/`invalidmask` `GeoTensor` properties (Chapter 1) are aware of this.
 
 `profile_from_dtype(dtype)` gives you the rasterio profile dict for any of these — used internally by `save_cog`.
 
@@ -127,7 +143,8 @@ The `bool → Byte` conversion is the only sneaky one — booleans are written a
 
 ### `save_cog(data_save, path_tiff_save, descriptions=None, tags=None, profile_arg=None, ...)`
 
-The standard export. Steps:
+The standard export.
+Steps:
 
 1. Materialise `data_save` to an in-memory ndarray (calls `.load()` if it's a reader).
 2. Build a profile from the dtype + the COG defaults (LZW, 256×256 blocks, BIGTIFF if needed).
@@ -140,7 +157,9 @@ The two-pass approach (write, then reorganise) is what GDAL's COG driver does in
 
 ### `save_tiled_geotiff(data_save, path_tiff_save, ...)`
 
-The "no overviews" variant. Same profile, same compression, same tiling, but skips the overview-building and reorganisation steps. Cheaper to write; you can't preview at low res over HTTP. Use when:
+The "no overviews" variant.
+Same profile, same compression, same tiling, but skips the overview-building and reorganisation steps.
+Cheaper to write; you can't preview at low res over HTTP. Use when:
 
 - Output is already a tile of a larger product and the consumer never zooms.
 - You're producing intermediate files that get re-read locally.
@@ -152,16 +171,19 @@ Source: [save.py:163 (`save_tiled_geotiff`)](https://github.com/spaceml-org/geor
 
 ## 5. Cloud destinations
 
-`save_cog("gs://bucket/key.tif", ...)` works. The implementation:
+`save_cog("gs://bucket/key.tif", ...)` works.
+The implementation:
 
 - Detects the prefix (`gs://`, `s3://`, `az://`, `abfs://`, `oss://`, `http://`, `https://`).
 - Writes locally to a temp file.
 - Uploads via fsspec (or a user-supplied `fs` filesystem object) once writing is complete.
 - Cleans up the temp file.
 
-The constant `REMOTE_FILE_EXTENSIONS` at the top of the module is the prefix list. Extending support to a new cloud (`oss://` etc.) is mostly a one-line addition there + ensuring the right fsspec backend is installed.
+The constant `REMOTE_FILE_EXTENSIONS` at the top of the module is the prefix list.
+Extending support to a new cloud (`oss://` etc.) is mostly a one-line addition there + ensuring the right fsspec backend is installed.
 
-For HTTP destinations, the upload phase requires a destination that accepts PUTs (presigned S3 URLs work; static HTTP URLs do not). Most "I want to write to https://..." workflows mean "actually I want to write to s3://, then serve via https://" — pass the `s3://` URL.
+For HTTP destinations, the upload phase requires a destination that accepts PUTs (presigned S3 URLs work; static HTTP URLs do not).
+Most "I want to write to https://..." workflows mean "actually I want to write to s3://, then serve via https://" — pass the `s3://` URL.
 
 The `fs` parameter is the escape hatch for custom auth: pass `fs=gcsfs.GCSFileSystem(token=...)` to use a non-default credential.
 
@@ -183,10 +205,14 @@ save_cog(
 
 A few non-obvious points:
 
-- **`descriptions`** maps to `rasterio`'s per-band `descriptions` field — visible in `gdalinfo`, used by some viewers as the band-picker label. Highly recommended (`["Red", "Green", "Blue"]` etc.) for any file you ship.
-- **`tags`** is file-level GDAL metadata, written into the GeoTIFF's GDAL_METADATA tag. Use for provenance: `{"source": "Sentinel-2", "date": "2024-01-15", "processing": "ndvi"}`. Survives round-trip through `RasterioReader.tags()`.
+- **`descriptions`** maps to `rasterio`'s per-band `descriptions` field — visible in `gdalinfo`, used by some viewers as the band-picker label.
+  Highly recommended (`["Red", "Green", "Blue"]` etc.) for any file you ship.
+- **`tags`** is file-level GDAL metadata, written into the GeoTIFF's GDAL_METADATA tag.
+  Use for provenance: `{"source": "Sentinel-2", "date": "2024-01-15", "processing": "ndvi"}`.
+  Survives round-trip through `RasterioReader.tags()`.
 - **`profile_arg={"compress": "zstd", "predictor": 2}`** is the override hatch. The full list of COG-relevant profile keys: `compress`, `blockxsize`, `blockysize`, `predictor`, `BIGTIFF`, `TILED`, `COPY_SRC_OVERVIEWS`.
-- **`nodata=None`** means "use `data_save.fill_value_default`". Pass explicitly when your output should have a different nodata than the input (e.g., `nodata=255` for a uint8 mask).
+- **`nodata=None`** means "use `data_save.fill_value_default`".
+  Pass explicitly when your output should have a different nodata than the input (e.g., `nodata=255` for a uint8 mask).
 
 ---
 
@@ -213,28 +239,39 @@ save.save_cog(
 )
 ```
 
-`save_cog` calls `data_save.load()` internally (step 1 of section 4), so the full scene is materialised in memory before the file is written and uploaded. This is fine for scenes that fit in RAM; for genuinely huge scenes that don't, this function is the wrong tool — use a manual window-loop pattern instead, opening the destination dataset with `rasterio.open(path, "w", **profile)` and calling `dataset.write(arr, window=...)` per chunk so that no buffer ever holds the full output.
+`save_cog` calls `data_save.load()` internally (step 1 of section 4), so the full scene is materialised in memory before the file is written and uploaded.
+This is fine for scenes that fit in RAM; for genuinely huge scenes that don't, this function is the wrong tool — use a manual window-loop pattern instead, opening the destination dataset with `rasterio.open(path, "w", **profile)` and calling `dataset.write(arr, window=...)` per chunk so that no buffer ever holds the full output.
 
 ---
 
 ## 8. Internal helpers worth knowing
 
-- **`_add_overviews(rst_out, tile_size, verbose=False)`** — iterates over decimation factors (2, 4, 8, 16, ...) and stops once an overview would be ≤ `tile_size`. Public-internal: it's prefixed with `_` but stable.
-- **`_save_cog(out_np, path_tiff_save, profile, ...)`** — the actual write step. Takes a numpy array (already materialised) and a complete rasterio profile. Used by `save_cog` after step 1.
-- **`PROFILE_TILED_GEOTIFF_DEFAULT`** — module-level dict. The defaults: `lzw` compress, `BIGTIFF=IF_SAFER`, 256×256 blocks. Inspect or override via `profile_arg`.
-- **`BLOCKSIZE_DEFAULT = 256`** — module-level constant. Change at module level if your downstream tools want different blocking; pass via `profile_arg` per call otherwise.
+- **`_add_overviews(rst_out, tile_size, verbose=False)`** — iterates over decimation factors (2, 4, 8, 16, ...) and stops once an overview would be ≤ `tile_size`.
+  Public-internal: it's prefixed with `_` but stable.
+- **`_save_cog(out_np, path_tiff_save, profile, ...)`** — the actual write step.
+  Takes a numpy array (already materialised) and a complete rasterio profile.
+  Used by `save_cog` after step 1.
+- **`PROFILE_TILED_GEOTIFF_DEFAULT`** — module-level dict.
+  The defaults: `lzw` compress, `BIGTIFF=IF_SAFER`, 256×256 blocks.
+  Inspect or override via `profile_arg`.
+- **`BLOCKSIZE_DEFAULT = 256`** — module-level constant.
+  Change at module level if your downstream tools want different blocking; pass via `profile_arg` per call otherwise.
 
 ---
 
 ## 9. Sharp edges
 
-- **`save_cog` materialises in memory.** Don't use it for files that won't fit. Use `save_tiled_geotiff` with windowed writes via rasterio directly for stream-write scenarios.
-- **Nodata for floating-point.** Default nodata of 0 is wrong for float reflectance (0 is a valid dark pixel). Pass `nodata=np.nan` or use a per-band sentinel like `-9999`.
+- **`save_cog` materialises in memory.** Don't use it for files that won't fit.
+  Use `save_tiled_geotiff` with windowed writes via rasterio directly for stream-write scenarios.
+- **Nodata for floating-point.** Default nodata of 0 is wrong for float reflectance (0 is a valid dark pixel).
+  Pass `nodata=np.nan` or use a per-band sentinel like `-9999`.
 - **`bool` arrays write as `uint8`.** Round-trip gives uint8; cast with `.astype(bool)` after read if you need bool semantics.
-- **Big-endian and signed-byte exotica aren't supported.** The dtype mapping only covers what numpy + GeoTIFF agree on. If you have weird dtypes, cast first.
+- **Big-endian and signed-byte exotica aren't supported.** The dtype mapping only covers what numpy + GeoTIFF agree on.
+  If you have weird dtypes, cast first.
 - **`COPY_SRC_OVERVIEWS` doesn't apply here.** That GDAL flag is for *copying* an existing file's overviews; this module always builds them fresh.
 - **Cloud writes are atomic at the destination.** The temp-file-then-upload pattern means partial writes don't appear at the destination URL. But a crash mid-upload leaves the temp file orphaned in `/tmp`.
-- **The `save_cog.py` file in the package is empty.** It's a placeholder kept around for backwards-import-compatibility. The real code is in `save.py`.
+- **The `save_cog.py` file in the package is empty.** It's a placeholder kept around for backwards-import-compatibility.
+  The real code is in `save.py`.
 
 ---
 
@@ -242,9 +279,12 @@ save.save_cog(
 
 Two `geotoolz` operators wrap this module:
 
-- **`catalog_ops.WriteCOG(path_template="...")`** — a terminal Operator. Takes a `GeoTensor` from upstream, formats `path_template` with metadata from the catalog row, calls `save.save_cog(...)`. The `path_template="{tile_id}_{date}.tif"` form lets `Sequential` pipelines write per-tile outputs to deterministic filenames.
+- **`catalog_ops.WriteCOG(path_template="...")`** — a terminal Operator.
+  Takes a `GeoTensor` from upstream, formats `path_template` with metadata from the catalog row, calls `save.save_cog(...)`.
+  The `path_template="{tile_id}_{date}.tif"` form lets `Sequential` pipelines write per-tile outputs to deterministic filenames.
 - **`presets.s2.S2_L2A_NDVI(...)`** — implicitly uses `save_cog` if the user passes a `path` argument; otherwise returns an in-memory `GeoTensor`.
 
-The empty `save_cog.py` file alongside `save.py` is the back-compat stub from when `save_cog` lived in its own module. Don't import from it; use `from georeader.save import save_cog` (or the package-level re-export from `__init__.py`).
+The empty `save_cog.py` file alongside `save.py` is the back-compat stub from when `save_cog` lived in its own module.
+Don't import from it; use `from georeader.save import save_cog` (or the package-level re-export from `__init__.py`).
 
 Next chapter: [13_misc_io.md](13_misc_io.md) — the smaller utility modules (`io.py`, `dataarray.py`, `plot.py`).

--- a/projects/geotoolz/georeader_tutorial/13_misc_io.md
+++ b/projects/geotoolz/georeader_tutorial/13_misc_io.md
@@ -15,7 +15,13 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, io
 ---
 
-> **Modules:** - `georeader/io.py` (113 LOC) — NetCDF safe-open - `georeader/dataarray.py` (145 LOC) — xarray bridge - `georeader/plot.py` (336 LOC) — matplotlib helpers **Role:** the connective tissue.
+> **Modules:**
+>
+> - `georeader/io.py` (113 LOC) — NetCDF safe-open
+> - `georeader/dataarray.py` (145 LOC) — xarray bridge
+> - `georeader/plot.py` (336 LOC) — matplotlib helpers
+>
+> **Role:** the connective tissue.
 > Each module is small, focused, and invisible until you need it.
 > **Diagrams:** none.
 > These files don't have ASCII art — they're pure utility code.

--- a/projects/geotoolz/georeader_tutorial/13_misc_io.md
+++ b/projects/geotoolz/georeader_tutorial/13_misc_io.md
@@ -15,12 +15,10 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, io
 ---
 
-> **Modules:**
-> - `georeader/io.py` (113 LOC) — NetCDF safe-open
-> - `georeader/dataarray.py` (145 LOC) — xarray bridge
-> - `georeader/plot.py` (336 LOC) — matplotlib helpers
-> **Role:** the connective tissue. Each module is small, focused, and invisible until you need it.
-> **Diagrams:** none. These files don't have ASCII art — they're pure utility code.
+> **Modules:** - `georeader/io.py` (113 LOC) — NetCDF safe-open - `georeader/dataarray.py` (145 LOC) — xarray bridge - `georeader/plot.py` (336 LOC) — matplotlib helpers **Role:** the connective tissue.
+> Each module is small, focused, and invisible until you need it.
+> **Diagrams:** none.
+> These files don't have ASCII art — they're pure utility code.
 
 ---
 
@@ -28,12 +26,14 @@ keywords: tutorial, georeader, io
 
 The whole module is one helper plus one URL-detector:
 
-- **`is_url(path) → bool`** — `True` for paths starting with `http://`, `https://`, `ftp://`. Used elsewhere in the package to decide between local and VSI access.
+- **`is_url(path) → bool`** — `True` for paths starting with `http://`, `https://`, `ftp://`.
+  Used elsewhere in the package to decide between local and VSI access.
 - **`safe_open_netcdf(file_path_or_object, cache=False, load=True, group=None, **kwargs) → xr.Dataset`** — open a NetCDF file by trying multiple xarray engines until one succeeds.
 
 ### Why "safe" open exists
 
-NetCDF has three on-disk formats (NetCDF3, NetCDF4/HDF5, NetCDF-Java) and xarray has three backends (`scipy`, `h5netcdf`, `netcdf4`) with overlapping but not identical support. Different sensor providers ship different formats, and a backend that handles one will fail on another with cryptic errors.
+NetCDF has three on-disk formats (NetCDF3, NetCDF4/HDF5, NetCDF-Java) and xarray has three backends (`scipy`, `h5netcdf`, `netcdf4`) with overlapping but not identical support.
+Different sensor providers ship different formats, and a backend that handles one will fail on another with cryptic errors.
 
 `safe_open_netcdf` cycles through engines in a sensible order until one works:
 
@@ -46,10 +46,14 @@ NetCDF has three on-disk formats (NetCDF3, NetCDF4/HDF5, NetCDF-Java) and xarray
 
 ### Sharp edges
 
-- **`load=True` by default**, meaning the entire dataset is read into memory. For multi-GB EMIT NetCDFs you almost always want `load=False` and lazy slicing via xarray.
-- **The function eats errors per-engine** and only raises `IOError` if all engines fail. Debug with `logging.getLogger("georeader.io").setLevel(logging.DEBUG)`.
-- **File-like objects need `.seek(0)`** support — the function tries to rewind between engines, but some streams (e.g., raw HTTP responses) can't be rewound. Pass a `BytesIO` wrapper if you have to retry.
-- **`group=` is honoured** — for hierarchical NetCDFs (EMIT, EnMAP) where the data lives in a sub-group like `"location"` or `"sensor_band_parameters"`. Most readers in `georeader.readers.emit` etc. already pass the right group internally.
+- **`load=True` by default**, meaning the entire dataset is read into memory.
+  For multi-GB EMIT NetCDFs you almost always want `load=False` and lazy slicing via xarray.
+- **The function eats errors per-engine** and only raises `IOError` if all engines fail.
+  Debug with `logging.getLogger("georeader.io").setLevel(logging.DEBUG)`.
+- **File-like objects need `.seek(0)`** support — the function tries to rewind between engines, but some streams (e.g., raw HTTP responses) can't be rewound.
+  Pass a `BytesIO` wrapper if you have to retry.
+- **`group=` is honoured** — for hierarchical NetCDFs (EMIT, EnMAP) where the data lives in a sub-group like `"location"` or `"sensor_band_parameters"`.
+  Most readers in `georeader.readers.emit` etc. already pass the right group internally.
 
 This is the function that makes the EMIT / PRISMA / EnMAP readers work cleanly across providers without users worrying about which library wraps which format.
 
@@ -57,18 +61,26 @@ This is the function that makes the EMIT / PRISMA / EnMAP readers work cleanly a
 
 ## 2. `dataarray.py` — the xarray bridge
 
-Four functions that translate between `GeoTensor` and `xr.DataArray`. This is the substrate seam between georeader and `xr_toolz` (the climate-side sibling library — see [`geotoolz.md` §10](../plans/geotoolz/geotoolz.md)).
+Four functions that translate between `GeoTensor` and `xr.DataArray`.
+This is the substrate seam between georeader and `xr_toolz` (the climate-side sibling library — see [`geotoolz.md` §10](../plans/geotoolz/geotoolz.md)).
 
 ### The four functions
 
-- **`coords_to_transform(coords, x_axis_name="x", y_axis_name="y") → rasterio.Affine`** — given an xarray coordinates object with `x` and `y` axes, infer the affine transform. Inverse of `xr.open_rasterio`'s coord computation. Useful when reading a NetCDF or Zarr that has lon/lat coords but no transform metadata.
-- **`getcoords_from_transform_shape(transform, shape, x_axis_name="x", y_axis_name="y") → dict`** — the forward direction. Given a transform and a `(H, W)` shape, build coordinate arrays placed at pixel centres (`+ 0.5` offset). Asserts `transform.is_rectilinear` because rotated transforms can't be expressed as simple 1D coord arrays.
-- **`toDataArray(x: GeoTensor, x_axis_name="x", y_axis_name="y", extra_coords=None) → xr.DataArray`** — `GeoTensor` → `xr.DataArray`. Builds coords from the transform, attaches `attrs={"crs": ..., "fill_value_default": ...}`, optionally adds `extra_coords` for non-spatial dims (e.g., `{"time": dates_array}`).
-- **`fromDataArray(x: xr.DataArray, crs=None, ...) → GeoTensor`** — the inverse. Reads the `crs` from the DataArray's attrs (or from `crs=` argument as override), computes transform from `coords`, returns a `GeoTensor`.
+- **`coords_to_transform(coords, x_axis_name="x", y_axis_name="y") → rasterio.Affine`** — given an xarray coordinates object with `x` and `y` axes, infer the affine transform.
+  Inverse of `xr.open_rasterio`'s coord computation.
+  Useful when reading a NetCDF or Zarr that has lon/lat coords but no transform metadata.
+- **`getcoords_from_transform_shape(transform, shape, x_axis_name="x", y_axis_name="y") → dict`** — the forward direction.
+  Given a transform and a `(H, W)` shape, build coordinate arrays placed at pixel centres (`+ 0.5` offset).
+  Asserts `transform.is_rectilinear` because rotated transforms can't be expressed as simple 1D coord arrays.
+- **`toDataArray(x: GeoTensor, x_axis_name="x", y_axis_name="y", extra_coords=None) → xr.DataArray`** — `GeoTensor` → `xr.DataArray`.
+  Builds coords from the transform, attaches `attrs={"crs": ..., "fill_value_default": ...}`, optionally adds `extra_coords` for non-spatial dims (e.g., `{"time": dates_array}`).
+- **`fromDataArray(x: xr.DataArray, crs=None, ...) → GeoTensor`** — the inverse.
+  Reads the `crs` from the DataArray's attrs (or from `crs=` argument as override), computes transform from `coords`, returns a `GeoTensor`.
 
 ### Why this matters
 
-The whole point of having both `geotoolz` (RS substrate) and `xr_toolz` (climate substrate) as separate libraries is that **`georeader` is the bridge**. A workflow that reads with georeader, runs a climate analysis in xr_toolz, and writes back via georeader looks like:
+The whole point of having both `geotoolz` (RS substrate) and `xr_toolz` (climate substrate) as separate libraries is that **`georeader` is the bridge**.
+A workflow that reads with georeader, runs a climate analysis in xr_toolz, and writes back via georeader looks like:
 
 ```python
 gt = georeader.read_from_bounds(reader, bounds=AOI)
@@ -78,15 +90,22 @@ result_gt = georeader.dataarray.fromDataArray(result_da)  # back to GeoTensor
 georeader.save_cog(result_gt, "/out/result.tif")
 ```
 
-Five lines, no metadata loss. The conversion is cheap (it's just rebuilding coord arrays, no data copy if you're careful with `.values`).
+Five lines, no metadata loss.
+The conversion is cheap (it's just rebuilding coord arrays, no data copy if you're careful with `.values`).
 
 ### Sharp edges
 
-- **`is_rectilinear` is required.** Rotated transforms can't be expressed as 1D x and y coordinate arrays. For rotated rasters you'd have to convert to a regular grid first (Chapter 7, `griddata`).
-- **xarray's coord convention is pixel-centre.** The `+ 0.5` in `getcoords_from_transform_shape` is the pixel-centre vs pixel-edge convention. Forgetting this in custom code drifts the coord by half a pixel.
-- **CRS round-trip via `attrs`.** xarray doesn't have a first-class CRS concept; `toDataArray` stuffs it in `da.attrs["crs"]`. Other libraries (rioxarray, cf-xarray) use different conventions. If a downstream consumer expects rioxarray's `da.rio.crs`, an extra translation step is needed.
-- **`fromDataArray` defaults to `crs=None`.** It pulls from `attrs["crs"]` if present; otherwise raises. Pass `crs=` explicitly when reading from sources that don't carry CRS metadata.
-- **xarray is an optional dep.** This module fails to import if xarray isn't installed. Users without an xarray pipeline never need to touch this module.
+- **`is_rectilinear` is required.** Rotated transforms can't be expressed as 1D x and y coordinate arrays.
+  For rotated rasters you'd have to convert to a regular grid first (Chapter 7, `griddata`).
+- **xarray's coord convention is pixel-centre.** The `+ 0.5` in `getcoords_from_transform_shape` is the pixel-centre vs pixel-edge convention.
+  Forgetting this in custom code drifts the coord by half a pixel.
+- **CRS round-trip via `attrs`.** xarray doesn't have a first-class CRS concept; `toDataArray` stuffs it in `da.attrs["crs"]`.
+  Other libraries (rioxarray, cf-xarray) use different conventions.
+  If a downstream consumer expects rioxarray's `da.rio.crs`, an extra translation step is needed.
+- **`fromDataArray` defaults to `crs=None`.** It pulls from `attrs["crs"]` if present; otherwise raises.
+  Pass `crs=` explicitly when reading from sources that don't carry CRS metadata.
+- **xarray is an optional dep.** This module fails to import if xarray isn't installed.
+  Users without an xarray pipeline never need to touch this module.
 
 ---
 
@@ -103,7 +122,8 @@ Four functions for visualising geospatial data with matplotlib:
 
 ### `show(data, ...)`
 
-The workhorse. Reads the GeoData's transform and bounds, calls `ax.imshow(data.values.transpose(1, 2, 0))` for RGB or `ax.imshow(data.values)` for single-band, sets the extent so axis ticks display in geographic coordinates, optionally adds a colorbar via `colorbar_next_to`.
+The workhorse.
+Reads the GeoData's transform and bounds, calls `ax.imshow(data.values.transpose(1, 2, 0))` for RGB or `ax.imshow(data.values)` for single-band, sets the extent so axis ticks display in geographic coordinates, optionally adds a colorbar via `colorbar_next_to`.
 
 Used in the README quickstart:
 
@@ -111,15 +131,20 @@ Used in the README quickstart:
 plot.show((gt_rgb / 3500).clip(0, 1))
 ```
 
-The `/3500` and `.clip(0, 1)` are because S2 reflectance values are stored as int16 with a scale factor of 10000, and a viewable RGB needs floats in `[0, 1]`. Note this still uses `GeoTensor` arithmetic — the clipped result has the same transform/CRS, so the axis ticks are correct geo coords.
+The `/3500` and `.clip(0, 1)` are because S2 reflectance values are stored as int16 with a scale factor of 10000, and a viewable RGB needs floats in `[0, 1]`.
+Note this still uses `GeoTensor` arithmetic — the clipped result has the same transform/CRS, so the axis ticks are correct geo coords.
 
 ### `add_shape_to_plot(shape, ax=None, ...)`
 
-Accept `Polygon`, `MultiPolygon`, list of geometries, or `GeoDataFrame`. Draws on the supplied axis or `plt.gca()`. Reprojects the geometry to the axis's CRS if needed (via the `crs_geometry=` arg). The standard "draw the AOI on top of the imagery" pattern.
+Accept `Polygon`, `MultiPolygon`, list of geometries, or `GeoDataFrame`.
+Draws on the supplied axis or `plt.gca()`.
+Reprojects the geometry to the axis's CRS if needed (via the `crs_geometry=` arg).
+The standard "draw the AOI on top of the imagery" pattern.
 
 ### `plot_segmentation_mask(mask, color_array=None, ...)`
 
-Class-label rasters need a categorical colormap and a legend, not a continuous colorbar. This function:
+Class-label rasters need a categorical colormap and a legend, not a continuous colorbar.
+This function:
 
 1. Converts the integer label raster to RGB using `color_array` (or a sensible default palette).
 2. Adds a legend with one entry per class.
@@ -129,21 +154,27 @@ Useful for showing CNN segmentation outputs in notebooks.
 
 ### `colorbar_next_to(im, ax, fig=None, ...)`
 
-The "don't squeeze the main axis" colorbar. Uses `mpl_toolkits.axes_grid1.make_axes_locatable` to allocate a thin axis to the right of the main one, sized in the same proportion as the figure. Standard matplotlib idiom that never quite works on the first try; this packages it.
+The "don't squeeze the main axis" colorbar.
+Uses `mpl_toolkits.axes_grid1.make_axes_locatable` to allocate a thin axis to the right of the main one, sized in the same proportion as the figure.
+Standard matplotlib idiom that never quite works on the first try; this packages it.
 
 ### Sharp edges
 
-- **`show` reads the entire data into memory.** Calls `data.load()` if it's a reader. For large rasters, downsample first via `read.resize` or read from an overview level (Chapter 3 §8).
+- **`show` reads the entire data into memory.** Calls `data.load()` if it's a reader.
+  For large rasters, downsample first via `read.resize` or read from an overview level (Chapter 3 §8).
 - **RGB ordering is `(C, H, W)` → matplotlib's `(H, W, C)`.** The function does the transpose; user code that bypasses `show` and does `ax.imshow(gt.values)` directly will get the wrong shape.
 - **Tick labels are in the source CRS.** If you want lat/lon ticks on a UTM-projected raster, reproject first (Chapter 5 §4).
-- **No interactive zoom optimisation.** This is a static-figure module. For interactive maps use `lonboard` / `leafmap` against the COG-on-disk ([Chapter 12](12_save.md)).
-- **Matplotlib is a hard import.** Unlike xarray, no `try/except`. Importing `georeader.plot` requires matplotlib to be installed.
+- **No interactive zoom optimisation.** This is a static-figure module.
+  For interactive maps use `lonboard` / `leafmap` against the COG-on-disk ([Chapter 12](12_save.md)).
+- **Matplotlib is a hard import.** Unlike xarray, no `try/except`.
+  Importing `georeader.plot` requires matplotlib to be installed.
 
 ---
 
 ## 4. Why these three are grouped here
 
-None of `io`, `dataarray`, `plot` carry the architectural weight of the modules in Parts I–IV. They're small, single-purpose, and you reach for them when you need them rather than designing pipelines around them. Grouping into one chapter avoids three thin chapters with little to say.
+None of `io`, `dataarray`, `plot` carry the architectural weight of the modules in Parts I–IV. They're small, single-purpose, and you reach for them when you need them rather than designing pipelines around them.
+Grouping into one chapter avoids three thin chapters with little to say.
 
 The pattern they share: **delegate to a well-maintained external library, paper over the sharp edges that come up in real RS workflows.** `safe_open_netcdf` papers over the engine-format mismatch; `to/fromDataArray` papers over the xarray-vs-rasterio metadata convention gap; `show` papers over the matplotlib boilerplate for georeferenced display.
 
@@ -153,8 +184,10 @@ The pattern they share: **delegate to a well-maintained external library, paper 
 
 These three modules don't have direct `geotoolz` operators wrapping them, but each shows up indirectly:
 
-- **`io.safe_open_netcdf`** — used inside the curvilinear-sensor readers (EMIT, PRISMA, EnMAP). When `geotoolz.presets.emit.EMIT_METHANE_MF` runs `georeader.readers.emit.load(scene_path)`, it's `safe_open_netcdf` underneath.
-- **`dataarray.toDataArray` / `fromDataArray`** — the `geotoolz`/`xr_toolz` substrate-bridge example in [`geotoolz.md` §10.4](../plans/geotoolz/geotoolz.md) is literally these two functions. They keep the libraries decoupled while still letting users compose pipelines across substrates.
+- **`io.safe_open_netcdf`** — used inside the curvilinear-sensor readers (EMIT, PRISMA, EnMAP).
+  When `geotoolz.presets.emit.EMIT_METHANE_MF` runs `georeader.readers.emit.load(scene_path)`, it's `safe_open_netcdf` underneath.
+- **`dataarray.toDataArray` / `fromDataArray`** — the `geotoolz`/`xr_toolz` substrate-bridge example in [`geotoolz.md` §10.4](../plans/geotoolz/geotoolz.md) is literally these two functions.
+  They keep the libraries decoupled while still letting users compose pipelines across substrates.
 - **`plot.show`** — `geotoolz.radiometry` viz operators (`PercentileClip → Gamma → MinMax → S2_L2A_RGB`) produce visualisation-shaped `GeoTensor`s; the natural last step is `plot.show(...)` for inline display in notebooks.
 
 Next chapter: [14_sentinel2.md](14_sentinel2.md) — the Sentinel-2 SAFE reader (1845 LOC, the largest single file in the package).

--- a/projects/geotoolz/georeader_tutorial/14_sentinel2.md
+++ b/projects/geotoolz/georeader_tutorial/14_sentinel2.md
@@ -15,14 +15,15 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, sentinel2
 ---
 
-> **Module:** `georeader/readers/S2_SAFE_reader.py` (1845 LOC — the largest file in the package)
-> **Role:** read Sentinel-2 imagery in the official SAFE product format. Both Level-1C (top-of-atmosphere reflectance) and Level-2A (atmospherically-corrected surface reflectance) are supported, from local folders or Google Cloud's free public bucket.
+> **Module:** `georeader/readers/S2_SAFE_reader.py` (1845 LOC — the largest file in the package) **Role:** read Sentinel-2 imagery in the official SAFE product format.
+> Both Level-1C (top-of-atmosphere reflectance) and Level-2A (atmospherically-corrected surface reflectance) are supported, from local folders or Google Cloud's free public bucket.
 
 ---
 
 ## 1. Why this module is so large
 
-A Sentinel-2 SAFE product is **not one file**. It's a folder hierarchy with:
+A Sentinel-2 SAFE product is **not one file**.
+It's a folder hierarchy with:
 
 - 13 separate JPEG2000 (`.jp2`) files — one per spectral band — at three different native resolutions (10 m, 20 m, 60 m).
 - Two XML metadata files — product-level (`MTD_MSIL1C.xml`) and tile-level (`MTD_TL.xml`) — describing acquisition geometry, calibration coefficients, sun/viewing angles, cloud masks, and processing baseline.
@@ -31,7 +32,8 @@ A Sentinel-2 SAFE product is **not one file**. It's a folder hierarchy with:
 
 The module's job is to hide all of that behind a single class that behaves like a `GeoData` (Chapter 2) — `s2.shape`, `s2.transform`, `s2.read_from_bounds(...)`, `s2.load()` all work as if S2 were one file.
 
-The 1845 LOC accommodates: SAFE-folder discovery, XML parsing, granule resolution, per-band JP2 stacking via `RasterioReader`, DN→radiance conversion, SRF extraction, multi-resolution band alignment, and Google Cloud Storage path translation. All of that is invisible from the public API surface, which is essentially three classes (`S2Image`, `S2ImageL1C`, `S2ImageL2A`) and one factory (`s2loader`).
+The 1845 LOC accommodates: SAFE-folder discovery, XML parsing, granule resolution, per-band JP2 stacking via `RasterioReader`, DN→radiance conversion, SRF extraction, multi-resolution band alignment, and Google Cloud Storage path translation.
+All of that is invisible from the public API surface, which is essentially three classes (`S2Image`, `S2ImageL1C`, `S2ImageL2A`) and one factory (`s2loader`).
 
 ---
 
@@ -74,10 +76,14 @@ The 1845 LOC accommodates: SAFE-folder discovery, XML parsing, granule resolutio
 
 The key technical differences:
 
-- **L1C** — values are *top-of-atmosphere* reflectance scaled to int16 with a factor of `1 / 10000`. To convert to radiance, the module's `DN_to_radiance` applies per-band physical calibration constants from the metadata.
-- **L2A** — values are *bottom-of-atmosphere* reflectance from ESA's Sen2Cor processor (or equivalent). Includes the SCL band — a per-pixel classification (cloud / snow / water / vegetation / bare ground / etc.). **B10 (cirrus, 1375 nm) is dropped** because Sen2Cor uses it in the correction process and doesn't produce a corrected surface value.
+- **L1C** — values are *top-of-atmosphere* reflectance scaled to int16 with a factor of `1 / 10000`.
+  To convert to radiance, the module's `DN_to_radiance` applies per-band physical calibration constants from the metadata.
+- **L2A** — values are *bottom-of-atmosphere* reflectance from ESA's Sen2Cor processor (or equivalent).
+  Includes the SCL band — a per-pixel classification (cloud / snow / water / vegetation / bare ground / etc.).
+  **B10 (cirrus, 1375 nm) is dropped** because Sen2Cor uses it in the correction process and doesn't produce a corrected surface value.
 
-For ML pipelines you almost always want **L2A** — the atmospheric correction is consistent across scenes and removes much of the haze/illumination variability that confuses CNN training. For radiative-transfer studies that need to handle their own correction, you want L1C.
+For ML pipelines you almost always want **L2A** — the atmospheric correction is consistent across scenes and removes much of the haze/illumination variability that confuses CNN training.
+For radiative-transfer studies that need to handle their own correction, you want L1C.
 
 ---
 
@@ -101,11 +107,16 @@ B11  │  1610 nm  │   90 nm   │    20m     │  ✓  │  ✓  │ SWIR 1
 B12  │  2190 nm  │  180 nm   │    20m     │  ✓  │  ✓  │ SWIR 2
 ```
 
-This table is **the** reference you'll come back to. Three things worth highlighting:
+This table is **the** reference you'll come back to.
+Three things worth highlighting:
 
-- **Three native resolutions: 10 m / 20 m / 60 m.** When you set `out_res=10`, the 20 m and 60 m bands are *upsampled* on read. When you set `out_res=20`, the 10 m bands are *downsampled* and the 60 m bands are *upsampled*. The `out_res=20` option is the practical sweet-spot when you don't strictly need 10 m resolution — you keep more bands at native resolution.
+- **Three native resolutions: 10 m / 20 m / 60 m.** When you set `out_res=10`, the 20 m and 60 m bands are *upsampled* on read.
+  When you set `out_res=20`, the 10 m bands are *downsampled* and the 60 m bands are *upsampled*.
+  The `out_res=20` option is the practical sweet-spot when you don't strictly need 10 m resolution — you keep more bands at native resolution.
 - **B08 is the broad NIR (842 nm), B8A is the narrow NIR (865 nm).** These look interchangeable but aren't — atmospheric scientists prefer B8A (narrower bandpass = cleaner SWIR-NIR spectroscopy); ML practitioners often use B08 (10 m native + matches Landsat-8 NIR more closely).
-- **Bands 10/11/12 wavelength ordering looks weird.** B11 (1610 nm) is *between* B09 (945 nm) and B12 (2190 nm); B10 (1375 nm) is also between them. The naming follows ESA's historical band-ID scheme, not wavelength order. When constructing band lists for SRF binning or visualisation, use `BANDS_S2 = ["B01", "B02", ..., "B12"]` (the module-level constant) — that's the canonical order matching the array's band axis.
+- **Bands 10/11/12 wavelength ordering looks weird.** B11 (1610 nm) is *between* B09 (945 nm) and B12 (2190 nm); B10 (1375 nm) is also between them.
+  The naming follows ESA's historical band-ID scheme, not wavelength order.
+  When constructing band lists for SRF binning or visualisation, use `BANDS_S2 = ["B01", "B02", ..., "B12"]` (the module-level constant) — that's the canonical order matching the array's band axis.
 
 The module exports the canonical lists as `BANDS_S2` (full 13 for L1C), `BANDS_S2_L1C` (alias), and `BANDS_S2_L2A` (12 bands; no B10).
 
@@ -119,7 +130,8 @@ S2Image                    # base class — do not instantiate directly
 └── S2ImageL2A             # L2A-specific: SCL band, no B10
 ```
 
-`S2Image` lives at [S2_SAFE_reader.py:295](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L295). It implements the `GeoData` protocol (Chapter 2 §3) plus S2-specific machinery:
+`S2Image` lives at [S2_SAFE_reader.py:295](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L295).
+It implements the `GeoData` protocol (Chapter 2 §3) plus S2-specific machinery:
 
 - Granule discovery: walking the SAFE folder to find per-band JP2 paths.
 - Multi-resolution band alignment: each band has its native resolution; `out_res=` selects the output grid and bands at other native resolutions get resampled internally.
@@ -133,7 +145,8 @@ S2Image                    # base class — do not instantiate directly
 
 `S2ImageL2A` ([S2_SAFE_reader.py:918](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L918)) adds:
 
-- The Scene Classification Layer (SCL) — a 20 m raster of integer class codes (0=NoData, 1=Saturated, 2=DarkArea, 3=CloudShadow, 4=Vegetation, 5=BareSoil, 6=Water, 7=Unclassified, 8=CloudMediumProb, 9=CloudHighProb, 10=ThinCirrus, 11=Snow). Useful for masking without running a separate cloud detector.
+- The Scene Classification Layer (SCL) — a 20 m raster of integer class codes (0=NoData, 1=Saturated, 2=DarkArea, 3=CloudShadow, 4=Vegetation, 5=BareSoil, 6=Water, 7=Unclassified, 8=CloudMediumProb, 9=CloudHighProb, 10=ThinCirrus, 11=Snow).
+  Useful for masking without running a separate cloud detector.
 
 ---
 
@@ -153,11 +166,15 @@ S2ImageL2A(
 
 A few non-obvious points:
 
-- **`s2folder`** can be a `gs://` path. The module recognises `gs://gcp-public-data-sentinel-2/...` URIs and uses `fsspec` to walk the folder structure.
-- **`polygon` is in `EPSG:4326`.** Almost always — most catalog queries return WGS84 polygons. The module reprojects internally to the tile's UTM zone.
+- **`s2folder`** can be a `gs://` path.
+  The module recognises `gs://gcp-public-data-sentinel-2/...` URIs and uses `fsspec` to walk the folder structure.
+- **`polygon` is in `EPSG:4326`.** Almost always — most catalog queries return WGS84 polygons.
+  The module reprojects internally to the tile's UTM zone.
 - **`out_res=20` is often the best choice** for ML — keeps red-edge and SWIR at native resolution, avoids upsampling.
-- **`bands=` lets you load a subset.** Memory-efficient for "just RGB" or "just NDVI" use cases. The default is all bands at the chosen `out_res`.
-- **`window_focus`** — same semantics as `RasterioReader.set_window` (Chapter 3 §4). Restricts subsequent reads to a sub-region.
+- **`bands=` lets you load a subset.** Memory-efficient for "just RGB" or "just NDVI" use cases.
+  The default is all bands at the chosen `out_res`.
+- **`window_focus`** — same semantics as `RasterioReader.set_window` (Chapter 3 §4).
+  Restricts subsequent reads to a sub-region.
 
 ---
 
@@ -174,7 +191,8 @@ def s2loader(
 )
 ```
 
-Located at [S2_SAFE_reader.py:1603](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1603). The factory you should use 95% of the time:
+Located at [S2_SAFE_reader.py:1603](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1603).
+The factory you should use 95% of the time:
 
 - Detects whether the folder is L1C or L2A from the SAFE name (the second path segment encodes `MSIL1C` vs `MSIL2A`).
 - Returns the appropriate subclass.
@@ -190,7 +208,8 @@ Both wrap `s2loader` after extracting the SAFE path from the feature's assets.
 
 ## 7. The Google Cloud public bucket
 
-`gs://gcp-public-data-sentinel-2/` (constant: `FULL_PATH_PUBLIC_BUCKET_SENTINEL_2`) is a free, no-auth-required mirror of the entire Sentinel-2 archive. The `s2_public_bucket_path(...)` function ([S2_SAFE_reader.py:1739](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1739)) constructs paths from `(tile_number_field, datetime, processing_baseline)` — useful when you have a SAFE name from a catalog query and need to turn it into a `gs://` URL.
+`gs://gcp-public-data-sentinel-2/` (constant: `FULL_PATH_PUBLIC_BUCKET_SENTINEL_2`) is a free, no-auth-required mirror of the entire Sentinel-2 archive.
+The `s2_public_bucket_path(...)` function ([S2_SAFE_reader.py:1739](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1739)) constructs paths from `(tile_number_field, datetime, processing_baseline)` — useful when you have a SAFE name from a catalog query and need to turn it into a `gs://` URL.
 
 The standard "load any S2 scene from anywhere" recipe:
 
@@ -210,7 +229,8 @@ The lazy access pattern matches what you'd get with a single-file `RasterioReade
 
 ## 8. SRF reading
 
-`read_srf(s2obj=None, mission=None, ...)` ([S2_SAFE_reader.py:1411](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1411)) returns a `pd.DataFrame` with the **published S2 SRFs** — wavelength index, one column per band — exactly as ESA distributes them. Use this for the spectral-binning recipe in [Chapter 11 §8](11_reflectance.md):
+`read_srf(s2obj=None, mission=None, ...)` ([S2_SAFE_reader.py:1411](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/S2_SAFE_reader.py#L1411)) returns a `pd.DataFrame` with the **published S2 SRFs** — wavelength index, one column per band — exactly as ESA distributes them.
+Use this for the spectral-binning recipe in [Chapter 11 §8](11_reflectance.md):
 
 ```python
 srf_df = read_srf(mission="S2A")            # or pass s2obj
@@ -261,13 +281,20 @@ The DataFrame uses the canonical band naming (`B01`, `B02`, ..., `B12`) so it li
 
 ## 10. Sharp edges
 
-- **`out_res=10` upsamples 8 of 13 bands.** B01, B05–B07, B8A, B09, B10, B11, B12 are not natively at 10 m. Setting `out_res=10` makes them all `(10980, 10980)` via `Resampling.cubic_spline`; you don't get more information, just bigger files.
+- **`out_res=10` upsamples 8 of 13 bands.** B01, B05–B07, B8A, B09, B10, B11, B12 are not natively at 10 m.
+  Setting `out_res=10` makes them all `(10980, 10980)` via `Resampling.cubic_spline`; you don't get more information, just bigger files.
 - **L2A drops B10.** Code that hardcodes `bands=BANDS_S2_L1C` will fail on L2A. Use `BANDS_S2_L2A` or filter dynamically based on `s2.bands`.
-- **Old vs new SAFE names.** Pre-2017 products use a different naming convention (`s2_old_format_name_split`). The `s2loader` factory handles both; custom path parsing won't.
-- **Processing-baseline drift.** ESA reprocesses the archive every few years. `S2A_*_N0500_*` (baseline 5.00) and `S2A_*_N0510_*` (5.10) have subtly different radiometric calibration. Match baselines in time-series analyses or you'll see fake change signals.
-- **B10 in L1C is *only* useful for cloud detection.** It's centred on a strong water-vapour absorption — surface reflectance there is essentially zero, so any signal is from cirrus clouds in the upper atmosphere. Don't include B10 as a "regular" spectral feature.
+- **Old vs new SAFE names.** Pre-2017 products use a different naming convention (`s2_old_format_name_split`).
+  The `s2loader` factory handles both; custom path parsing won't.
+- **Processing-baseline drift.** ESA reprocesses the archive every few years.
+  `S2A_*_N0500_*` (baseline 5.00) and `S2A_*_N0510_*` (5.10) have subtly different radiometric calibration.
+  Match baselines in time-series analyses or you'll see fake change signals.
+- **B10 in L1C is *only* useful for cloud detection.** It's centred on a strong water-vapour absorption — surface reflectance there is essentially zero, so any signal is from cirrus clouds in the upper atmosphere.
+  Don't include B10 as a "regular" spectral feature.
 - **SCL is at 20 m.** When using L2A's SCL band as a cloud mask at `out_res=10`, the mask is upsampled — single-pixel cloud features can become 4-pixel features at 10 m.
-- **Requester-pays buckets.** The Microsoft / AWS S3 mirrors are requester-pays. Pass `requester_pays=True` to authenticate the read. The Google public bucket is free.
+- **Requester-pays buckets.** The Microsoft / AWS S3 mirrors are requester-pays.
+  Pass `requester_pays=True` to authenticate the read.
+  The Google public bucket is free.
 - **JP2 reads are not parallel-safe in the SAFE-reader sense.** Each band is a separate `RasterioReader`, so each is independently parallel-safe (Chapter 3), but reading multiple bands of one S2 scene from multiple processes is fine.
 
 ---
@@ -276,9 +303,12 @@ The DataFrame uses the canonical band naming (`B01`, `B02`, ..., `B12`) so it li
 
 The whole `presets.s2` block in [`geotoolz.md` §1.2](../plans/geotoolz/geotoolz.md) sits on top of this module:
 
-- **`presets.s2.S2_L2A_RGB(brightness=...)`** — `Sequential([s2.isel(["B04","B03","B02"]), ToFloat32, PercentileClip, Gamma])`. Loads via `s2loader`, picks RGB bands, normalises.
-- **`presets.s2.S2_L2A_NDVI(...)`** — `Sequential([s2.load(), MaskClouds(scl_band), NDVI(red_idx=2, nir_idx=3)])`. Uses the SCL band for cloud masking — a free pass thanks to L2A.
-- **`presets.s2.S2_L1C_TO_BOA_NDVI(...)`** — the harder pipeline: `Sequential([DN_to_radiance, TOAToBOA, MaskClouds, NDVI])`. Hits `DN_to_radiance` from this module before the radiometric work in [Chapter 11](11_reflectance.md).
+- **`presets.s2.S2_L2A_RGB(brightness=...)`** — `Sequential([s2.isel(["B04","B03","B02"]), ToFloat32, PercentileClip, Gamma])`.
+  Loads via `s2loader`, picks RGB bands, normalises.
+- **`presets.s2.S2_L2A_NDVI(...)`** — `Sequential([s2.load(), MaskClouds(scl_band), NDVI(red_idx=2, nir_idx=3)])`.
+  Uses the SCL band for cloud masking — a free pass thanks to L2A.
+- **`presets.s2.S2_L1C_TO_BOA_NDVI(...)`** — the harder pipeline: `Sequential([DN_to_radiance, TOAToBOA, MaskClouds, NDVI])`.
+  Hits `DN_to_radiance` from this module before the radiometric work in [Chapter 11](11_reflectance.md).
 - **`presets.s2.S2_QA60_CLOUD_MASK(...)`** — bit-flag extraction from the QA60 band on L1C.
 
 Sentinel-2 is the most-used sensor in the package's ecosystem, and this module's design (single class subclassing `GeoData`, lazy granule access, multi-resolution alignment) is the template the other big sensor readers (`emit`, `prisma`, `enmap`) follow.

--- a/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
+++ b/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
@@ -15,7 +15,13 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, emit, prisma, enmap
 ---
 
-> **Modules:** - `georeader/readers/emit.py` (1102 LOC) - `georeader/readers/prisma.py` (571 LOC) - `georeader/readers/enmap.py` (865 LOC) **Role:** read three hyperspectral satellite sensors — EMIT (NASA, ISS, 285 bands), PRISMA (ASI, 239 bands), EnMAP (DLR, 224 bands).
+> **Modules:**
+>
+> - `georeader/readers/emit.py` (1102 LOC)
+> - `georeader/readers/prisma.py` (571 LOC)
+> - `georeader/readers/enmap.py` (865 LOC)
+>
+> **Role:** read three hyperspectral satellite sensors — EMIT (NASA, ISS, 285 bands), PRISMA (ASI, 239 bands), EnMAP (DLR, 224 bands).
 > All cover ~400–2500 nm with ~10 nm spectral sampling.
 > The three readers share a design pattern but diverge on georeferencing — that's the interesting part.
 

--- a/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
+++ b/projects/geotoolz/georeader_tutorial/15_hyperspectral.md
@@ -15,11 +15,9 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, emit, prisma, enmap
 ---
 
-> **Modules:**
-> - `georeader/readers/emit.py` (1102 LOC)
-> - `georeader/readers/prisma.py` (571 LOC)
-> - `georeader/readers/enmap.py` (865 LOC)
-> **Role:** read three hyperspectral satellite sensors — EMIT (NASA, ISS, 285 bands), PRISMA (ASI, 239 bands), EnMAP (DLR, 224 bands). All cover ~400–2500 nm with ~10 nm spectral sampling. The three readers share a design pattern but diverge on georeferencing — that's the interesting part.
+> **Modules:** - `georeader/readers/emit.py` (1102 LOC) - `georeader/readers/prisma.py` (571 LOC) - `georeader/readers/enmap.py` (865 LOC) **Role:** read three hyperspectral satellite sensors — EMIT (NASA, ISS, 285 bands), PRISMA (ASI, 239 bands), EnMAP (DLR, 224 bands).
+> All cover ~400–2500 nm with ~10 nm spectral sampling.
+> The three readers share a design pattern but diverge on georeferencing — that's the interesting part.
 
 ---
 
@@ -31,7 +29,8 @@ keywords: tutorial, georeader, emit, prisma, enmap
 | **PRISMA** | ASI | 2019 | 239 | 400–2500 nm | 30 m | **per-pixel lat/lon** (interpolation) |
 | **EnMAP** | DLR | 2022 | 224 | 420–2450 nm | 30 m | **map-projected + RPCs** |
 
-The trio matters because they're the workhorses of the spaceborne hyperspectral era. They map onto three distinct georeferencing strategies — the structural axis along which the readers differ.
+The trio matters because they're the workhorses of the spaceborne hyperspectral era.
+They map onto three distinct georeferencing strategies — the structural axis along which the readers differ.
 
 ---
 
@@ -51,7 +50,8 @@ Raw Data Structure (NetCDF file):
 └─────────────────────────────────────┘
 ```
 
-EMIT ships data in **sensor coordinates** (raw pushbroom scan lines, not orthorectified), plus a Geographic Lookup Table that names — for each pixel of the *output* (orthorectified) grid — which sensor pixel to read from. This is the [`griddata.georreference` fast path from Chapter 7](07_griddata.md).
+EMIT ships data in **sensor coordinates** (raw pushbroom scan lines, not orthorectified), plus a Geographic Lookup Table that names — for each pixel of the *output* (orthorectified) grid — which sensor pixel to read from.
+This is the [`griddata.georreference` fast path from Chapter 7](07_griddata.md).
 
 ### GLT orthorectification (top-of-module diagram)
 
@@ -112,7 +112,9 @@ For geographic pixel (row, col):
 
 ### Interface
 
-`EMITImage(path, ...)` — main class. Methods include `load_radiance()`, `load_reflectance(...)`, `load_wavelengths([w1, w2, ...])`. Helpers `download_product()`, `get_radiance_link()` use NASA Earthdata credentials from `~/.georeader/auth_emit.json`.
+`EMITImage(path, ...)` — main class.
+Methods include `load_radiance()`, `load_reflectance(...)`, `load_wavelengths([w1, w2, ...])`.
+Helpers `download_product()`, `get_radiance_link()` use NASA Earthdata credentials from `~/.georeader/auth_emit.json`.
 
 ---
 
@@ -140,7 +142,9 @@ PRISMA HDF5 File Structure:
 └─────────────────────────────────────────────────────────┘
 ```
 
-Unlike EMIT, **PRISMA L1 data is NOT orthorectified**. Instead, it ships per-pixel `Latitude_*` / `Longitude_*` arrays. Producing a regular grid from this requires **interpolation** — the slow path in [Chapter 7](07_griddata.md), using `read_to_crs(data, lons, lats, ...)` under the hood.
+Unlike EMIT, **PRISMA L1 data is NOT orthorectified**.
+Instead, it ships per-pixel `Latitude_*` / `Longitude_*` arrays.
+Producing a regular grid from this requires **interpolation** — the slow path in [Chapter 7](07_griddata.md), using `read_to_crs(data, lons, lats, ...)` under the hood.
 
 ### Sensor grid → geographic grid
 
@@ -157,7 +161,8 @@ Sensor Grid (raw)                  Geographic Grid (output)
 └─────────────────────┘            └─────────────────────┘
 ```
 
-The `raw=True` / `raw=False` flag on PRISMA's load methods is the eject button: `raw=True` returns sensor coordinates (no interpolation, fast), `raw=False` runs `griddata` (slow, but produces a `GeoTensor` ready for downstream operators). For most ML workflows you want `raw=False`; for matched-filter retrievals that need exact radiometry, `raw=True` and handle gridding yourself if needed.
+The `raw=True` / `raw=False` flag on PRISMA's load methods is the eject button: `raw=True` returns sensor coordinates (no interpolation, fast), `raw=False` runs `griddata` (slow, but produces a `GeoTensor` ready for downstream operators).
+For most ML workflows you want `raw=False`; for matched-filter retrievals that need exact radiometry, `raw=True` and handle gridding yourself if needed.
 
 ### Dual-sensor configuration
 
@@ -175,7 +180,8 @@ VNIR Sensor                          SWIR Sensor
                      920-1010 nm
 ```
 
-PRISMA uses two separate sensors. The reader takes care of selecting the right one when you ask for a wavelength — `prisma.load_wavelengths([850, 1600])` gives you 850 nm from VNIR and 1600 nm from SWIR. The 920–1010 nm overlap is mostly used for cross-calibration; for analysis pick one source per wavelength.
+PRISMA uses two separate sensors.
+The reader takes care of selecting the right one when you ask for a wavelength — `prisma.load_wavelengths([850, 1600])` gives you 850 nm from VNIR and 1600 nm from SWIR. The 920–1010 nm overlap is mostly used for cross-calibration; for analysis pick one source per wavelength.
 
 ### Wavelength range diagram
 
@@ -196,7 +202,9 @@ Wavelength Range:
 
 ### Interface
 
-`PRISMA(path)` — main class. Methods `load_wavelengths([w1, w2, ...], as_reflectance=False, raw=False)`, `load_rgb(as_reflectance=False, raw=False)`. The wavelength-list interface handles VNIR/SWIR routing transparently.
+`PRISMA(path)` — main class.
+Methods `load_wavelengths([w1, w2, ...], as_reflectance=False, raw=False)`, `load_rgb(as_reflectance=False, raw=False)`.
+The wavelength-list interface handles VNIR/SWIR routing transparently.
 
 ---
 
@@ -219,7 +227,9 @@ EnMAP Product Structure:
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-EnMAP differs from both: ships as **separate GeoTIFF files** with an XML metadata manifest. Importantly, **EnMAP L1B is already orthorectified** (map-projected) — no GLT, no per-pixel coords. Plus a set of RPCs (Rational Polynomial Coefficients) for refined geolocation if you need it.
+EnMAP differs from both: ships as **separate GeoTIFF files** with an XML metadata manifest.
+Importantly, **EnMAP L1B is already orthorectified** (map-projected) — no GLT, no per-pixel coords.
+Plus a set of RPCs (Rational Polynomial Coefficients) for refined geolocation if you need it.
 
 ### Class diagram
 
@@ -236,7 +246,8 @@ File Structure:
 └────────────────────────────────────────────────────┘
 ```
 
-The XML metadata file is the **input** — pass that path to the reader. The reader walks the sibling files for the actual band data and quality masks.
+The XML metadata file is the **input** — pass that path to the reader.
+The reader walks the sibling files for the actual band data and quality masks.
 
 ### Dual-sensor + radiometric calibration
 
@@ -261,7 +272,8 @@ Wavelength: 420nm ──── 1000nm ──── 2450nm
                       900-1000nm
 ```
 
-VNIR has *finer* spectral sampling (6.5 nm vs 10 nm) than the other two sensors — useful for narrow-feature spectroscopy. The DN-to-radiance formula is the most peculiar:
+VNIR has *finer* spectral sampling (6.5 nm vs 10 nm) than the other two sensors — useful for narrow-feature spectroscopy.
+The DN-to-radiance formula is the most peculiar:
 
 ```
 L_λ = (GAIN × DN + OFFSET) × 1000   [mW/(m²·sr·nm)]
@@ -269,7 +281,8 @@ L_λ = (GAIN × DN + OFFSET) × 1000   [mW/(m²·sr·nm)]
 Note: DLR gains are multiplicative (not divisive as in some sensors)
 ```
 
-The `× 1000` at the end is because DLR's spec gives the result in `W/(m²·sr·nm)` and the reader converts to `mW` units to match PRISMA / Thuillier conventions. **Don't double-multiply** — let the reader handle calibration.
+The `× 1000` at the end is because DLR's spec gives the result in `W/(m²·sr·nm)` and the reader converts to `mW` units to match PRISMA / Thuillier conventions.
+**Don't double-multiply** — let the reader handle calibration.
 
 ### RPCs
 
@@ -282,11 +295,13 @@ RPCs model:
 - Terrain elevation effects (when height_off is set appropriately)
 ```
 
-EnMAP includes Rational Polynomial Coefficients in metadata for fine geolocation. The reader can apply RPCs during loading for refined geolocation; default uses the simple affine transform from the GeoTIFF (which is already pretty good — RPCs add ~1 pixel of refinement).
+EnMAP includes Rational Polynomial Coefficients in metadata for fine geolocation.
+The reader can apply RPCs during loading for refined geolocation; default uses the simple affine transform from the GeoTIFF (which is already pretty good — RPCs add ~1 pixel of refinement).
 
 ### Interface
 
-`EnMAPImage(metadata_xml_path, ...)` — the main class, takes the XML manifest path. Plus quality-mask accessors that pair with the per-pixel masks shipped alongside.
+`EnMAPImage(metadata_xml_path, ...)` — the main class, takes the XML manifest path.
+Plus quality-mask accessors that pair with the per-pixel masks shipped alongside.
 
 ---
 
@@ -335,7 +350,8 @@ prisma_rgb = prisma.load_rgb(as_reflectance=True, raw=False)
 enmap_rgb = enmap.load_rgb(as_reflectance=True)
 ```
 
-All three return a 3-band `GeoTensor` ready for `plot.show`. The interfaces deliberately converge despite the substrates diverging.
+All three return a 3-band `GeoTensor` ready for `plot.show`.
+The interfaces deliberately converge despite the substrates diverging.
 
 ### C — Spectral binning to S2 bands
 
@@ -357,22 +373,30 @@ This recipe works identically for PRISMA and EMIT — the readers expose `wavele
 ## 7. Sharp edges
 
 ### EMIT
-- **`μW/(cm²·sr·nm)` is unusual.** Convert by ÷100 to SI base or use `units="uW/cm^2/SR/nm"` to `radiance_to_reflectance` ([Chapter 11 §3](11_reflectance.md)). Wrong units silently produce wrong reflectance.
-- **GLT requires the file's `location` group.** Some legacy EMIT products on third-party mirrors strip it. Check `glt_x` / `glt_y` exist before using `load_radiance()`.
-- **NASA Earthdata auth.** Required for `download_product`. Stored in `~/.georeader/auth_emit.json` — make sure it's not world-readable (it's plaintext credentials).
+- **`μW/(cm²·sr·nm)` is unusual.** Convert by ÷100 to SI base or use `units="uW/cm^2/SR/nm"` to `radiance_to_reflectance` ([Chapter 11 §3](11_reflectance.md)).
+  Wrong units silently produce wrong reflectance.
+- **GLT requires the file's `location` group.** Some legacy EMIT products on third-party mirrors strip it.
+  Check `glt_x` / `glt_y` exist before using `load_radiance()`.
+- **NASA Earthdata auth.** Required for `download_product`.
+  Stored in `~/.georeader/auth_emit.json` — make sure it's not world-readable (it's plaintext credentials).
 
 ### PRISMA
-- **Cubic interpolation is the cost.** A full scene takes minutes. Use `raw=True` for radiometric work; only orthorectify when you need a regular grid for a downstream operator.
-- **VNIR/SWIR overlap (920–1010 nm).** The reader doesn't deduplicate; you can ask for 950 nm and get a different value depending on which sensor. Be explicit about which you want when documenting analyses.
+- **Cubic interpolation is the cost.** A full scene takes minutes.
+  Use `raw=True` for radiometric work; only orthorectify when you need a regular grid for a downstream operator.
+- **VNIR/SWIR overlap (920–1010 nm).** The reader doesn't deduplicate; you can ask for 950 nm and get a different value depending on which sensor.
+  Be explicit about which you want when documenting analyses.
 - **HDF5 path must end `.he5`.** Some catalog systems serve PRISMA as `.h5` — rename or symlink.
 
 ### EnMAP
 - **Pass the `*-METADATA.XML` path, not the imagery path.** Easy to confuse since the SAFE-style folder contains many files.
-- **`× 1000` in the radiance formula.** Don't apply it twice. The reader handles this; if you re-implement, factor it correctly.
-- **RPCs are off by default.** Pass the appropriate flag to enable. Most analyses don't need them — the GeoTIFF affine is already accurate to ~10 m.
+- **`× 1000` in the radiance formula.** Don't apply it twice.
+  The reader handles this; if you re-implement, factor it correctly.
+- **RPCs are off by default.** Pass the appropriate flag to enable.
+  Most analyses don't need them — the GeoTIFF affine is already accurate to ~10 m.
 
 ### Cross-sensor
-- **Spectral sampling differs.** EMIT (~7–10 nm), PRISMA (~10 nm), EnMAP VNIR (6.5 nm) / SWIR (10 nm). Inter-sensor compatibility requires SRF binning (Chapter 11) — don't pixel-match across sensors directly.
+- **Spectral sampling differs.** EMIT (~7–10 nm), PRISMA (~10 nm), EnMAP VNIR (6.5 nm) / SWIR (10 nm).
+  Inter-sensor compatibility requires SRF binning (Chapter 11) — don't pixel-match across sensors directly.
 - **Reflectance conversion needs solar geometry.** All three readers have helpers for sun angle / Earth-sun distance from acquisition timestamps; double-check this is set when calling `as_reflectance=True`.
 
 ---
@@ -381,11 +405,13 @@ This recipe works identically for PRISMA and EMIT — the readers expose `wavele
 
 The hyperspectral operators in [`geotoolz.md`](../plans/geotoolz/geotoolz.md) consume `GeoTensor`s produced by these readers:
 
-- **`hyperspectral.MatchedFilter(target_spectrum, axis=0)`** — works on any of the three (post-orthorectification). Standard Reed-Yu detector.
+- **`hyperspectral.MatchedFilter(target_spectrum, axis=0)`** — works on any of the three (post-orthorectification).
+  Standard Reed-Yu detector.
 - **`hyperspectral.ACEDetector` / `RXDetector` / `LinearUnmixing`** — same.
 - **`presets.emit.EMIT_METHANE_MF`** — relies on EMIT's GLT speed: read once, MF many times.
 - **`presets.enmap.ENMAP_TO_S2_BANDS`** — uses the SRF binning recipe (§6C above) for cross-sensor compatibility.
 
-The split-object pattern in `geotoolz` ([Ch §4 of geotoolz.md](../plans/geotoolz/geotoolz.md)) is especially relevant here: compute the scene mean / covariance / endmember spectrum once (slow), then apply per-band detectors fast. The hyperspectral cube is the canonical case where state-as-artifact pays off.
+The split-object pattern in `geotoolz` ([Ch §4 of geotoolz.md](../plans/geotoolz/geotoolz.md)) is especially relevant here: compute the scene mean / covariance / endmember spectrum once (slow), then apply per-band detectors fast.
+The hyperspectral cube is the canonical case where state-as-artifact pays off.
 
 Next chapter: [16_earth_engine.md](16_earth_engine.md) — Google Earth Engine integration (export tile splitting and parallel download).

--- a/projects/geotoolz/georeader_tutorial/16_earth_engine.md
+++ b/projects/geotoolz/georeader_tutorial/16_earth_engine.md
@@ -15,17 +15,14 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, gee
 ---
 
-> **Modules:**
-> - `georeader/readers/ee_image.py` (539 LOC)
-> - `georeader/readers/ee_query.py` (589 LOC)
-> - `georeader/readers/ee_utils.py` (58 LOC)
-> **Role:** export raster data from Google Earth Engine into `GeoTensor`s, handling GEE's request-size limits through recursive tile splitting and parallel downloads.
+> **Modules:** - `georeader/readers/ee_image.py` (539 LOC) - `georeader/readers/ee_query.py` (589 LOC) - `georeader/readers/ee_utils.py` (58 LOC) **Role:** export raster data from Google Earth Engine into `GeoTensor`s, handling GEE's request-size limits through recursive tile splitting and parallel downloads.
 
 ---
 
 ## 1. Why this module exists
 
-Google Earth Engine is the standard cloud platform for petabyte-scale remote-sensing analytics — it hosts every major archive (Landsat, Sentinel, MODIS, dozens more) and provides a JavaScript / Python API for server-side computation. But: **GEE export is constrained**.
+Google Earth Engine is the standard cloud platform for petabyte-scale remote-sensing analytics — it hosts every major archive (Landsat, Sentinel, MODIS, dozens more) and provides a JavaScript / Python API for server-side computation.
+But: **GEE export is constrained**.
 
 - `ee.data.computePixels()` and `ee.data.getPixels()` cap requests at ~32 MB per call.
 - A modest AOI at 10 m resolution easily exceeds this.
@@ -103,7 +100,8 @@ This pattern handles arbitrary AOI sizes — the only practical limit is memory 
 | `export_image_getpixels(asset_id, ...)` | direct-asset export via `ee.data.getPixels` (when you have the asset ID, not a computed image) |
 | `export_cube(query, geometry, ...)` | time-series export — returns `(T, C, H, W)` `GeoTensor` |
 
-`export_image` is the one you'll use 95% of the time. Source: [ee_image.py:223](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L223).
+`export_image` is the one you'll use 95% of the time.
+Source: [ee_image.py:223](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L223).
 
 `export_cube` ([ee_image.py:392](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L392)) is built on top — accepts a GeoDataFrame of (acquisition_date, asset_id) rows, exports each row as a 3D image, and stacks them along a new time axis.
 
@@ -122,23 +120,28 @@ This pattern handles arbitrary AOI sizes — the only practical limit is memory 
    Q3: (minx, miny, midx, midy)   Q4: (midx, miny, maxx, midy)
 ```
 
-Always 4-way split (not adaptive based on aspect ratio). Adequate for the typical "moderately large AOI" case; can be inefficient for very long thin AOIs (a 10000:1 aspect ratio strip would need many splits before each chunk fits — but the typical RS AOI is roughly square).
+Always 4-way split (not adaptive based on aspect ratio).
+Adequate for the typical "moderately large AOI" case; can be inefficient for very long thin AOIs (a 10000:1 aspect ratio strip would need many splits before each chunk fits — but the typical RS AOI is roughly square).
 
 ---
 
 ## 5. The Sentinel-2 special case: `interpolate_20mbands_s2ee`
 
-When you download S2 from GEE asking for 10 m resolution, GEE upsamples the 20 m and 60 m bands using **nearest neighbour**. That produces ugly blocky bands at 10 m — not what you want.
+When you download S2 from GEE asking for 10 m resolution, GEE upsamples the 20 m and 60 m bands using **nearest neighbour**.
+That produces ugly blocky bands at 10 m — not what you want.
 
-`interpolate_20mbands_s2ee(geotensor, ...)` ([ee_image.py:476](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L476)) post-processes the result by re-resampling the affected bands with **bicubic** interpolation. The result looks like a real 10 m image rather than blocky pixels.
+`interpolate_20mbands_s2ee(geotensor, ...)` ([ee_image.py:476](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/ee_image.py#L476)) post-processes the result by re-resampling the affected bands with **bicubic** interpolation.
+The result looks like a real 10 m image rather than blocky pixels.
 
-This isn't a bug in this module — it's a quirk of GEE's S2 ingestion. The workaround is the kind of detail that takes you an afternoon to find on the GEE forum; having it as a one-line call makes the module pay for itself.
+This isn't a bug in this module — it's a quirk of GEE's S2 ingestion.
+The workaround is the kind of detail that takes you an afternoon to find on the GEE forum; having it as a one-line call makes the module pay for itself.
 
 ---
 
 ## 6. The query side — `ee_query.py`
 
-`ee_query.py` (589 LOC) handles the **discovery** side: given a polygon and a date range, return a GeoDataFrame of available scenes. Functions like `query_collection(collection_name, polygon, start_date, end_date)` for each major collection (Sentinel-2, Landsat, MODIS, etc.).
+`ee_query.py` (589 LOC) handles the **discovery** side: given a polygon and a date range, return a GeoDataFrame of available scenes.
+Functions like `query_collection(collection_name, polygon, start_date, end_date)` for each major collection (Sentinel-2, Landsat, MODIS, etc.).
 
 The output GeoDataFrame is the input shape that `export_cube` consumes — so the pattern is:
 
@@ -163,7 +166,9 @@ That's the whole "find S2 scenes over Madagascar in 2024 with < 20% cloud cover,
 
 ## 7. Authentication
 
-GEE requires authentication. The package uses `ee.Authenticate()` and `ee.Initialize()` from the official `earthengine-api`. Standard setup:
+GEE requires authentication.
+The package uses `ee.Authenticate()` and `ee.Initialize()` from the official `earthengine-api`.
+Standard setup:
 
 ```python
 import ee
@@ -171,7 +176,9 @@ ee.Authenticate()  # browser flow first time, cached afterwards
 ee.Initialize(project="my-gcp-project")
 ```
 
-Install `georeader-spaceml` with the `[ee]` extra to pull in `earthengine-api`. Without it, importing `readers.ee_image` raises `ImportError`. In this repo the relevant install commands are `pixi add georeader-spaceml[ee]` or `uv add 'georeader-spaceml[ee]'` per the project's [CONTRIBUTING.md](../../../CONTRIBUTING.md) tooling conventions.
+Install `georeader-spaceml` with the `[ee]` extra to pull in `earthengine-api`.
+Without it, importing `readers.ee_image` raises `ImportError`.
+In this repo the relevant install commands are `pixi add georeader-spaceml[ee]` or `uv add 'georeader-spaceml[ee]'` per the project's [CONTRIBUTING.md](../../../CONTRIBUTING.md) tooling conventions.
 
 The credentials live in `~/.config/earthengine/credentials` (managed by `ee.Authenticate()`); the module doesn't add its own credential file like EMIT does.
 
@@ -201,13 +208,20 @@ The credentials live in `~/.config/earthengine/credentials` (managed by `ee.Auth
 
 ## 9. Sharp edges
 
-- **GEE rate limits per project.** Recursive splitting can issue many concurrent requests; on a small AOI this is fine, on a continental one you might hit `quota_exceeded` errors. Tune via fewer parallel threads (`max_workers=2`) or stagger requests.
-- **`ee.Initialize(project=...)` is required.** GEE migrated to project-scoped quotas in 2024; old code that just called `ee.Initialize()` without a project ID will fail. Use a GCP project you have access to.
-- **Authenticated S3-style mirrors are different.** GEE's mirrors of Sentinel-2 are *not* the same as the AWS / GCS public buckets. The `gs://gcp-public-data-sentinel-2` URL works without GEE auth (Chapter 14). GEE access to S2 needs `ee.Initialize` + project quota.
+- **GEE rate limits per project.** Recursive splitting can issue many concurrent requests; on a small AOI this is fine, on a continental one you might hit `quota_exceeded` errors.
+  Tune via fewer parallel threads (`max_workers=2`) or stagger requests.
+- **`ee.Initialize(project=...)` is required.** GEE migrated to project-scoped quotas in 2024; old code that just called `ee.Initialize()` without a project ID will fail.
+  Use a GCP project you have access to.
+- **Authenticated S3-style mirrors are different.** GEE's mirrors of Sentinel-2 are *not* the same as the AWS / GCS public buckets.
+  The `gs://gcp-public-data-sentinel-2` URL works without GEE auth (Chapter 14).
+  GEE access to S2 needs `ee.Initialize` + project quota.
 - **Nearest-neighbour upsampling for S2 20m bands.** Always run `interpolate_20mbands_s2ee` after exporting S2 at 10 m or your bands look terrible.
-- **`export_cube` aligns to the first scene's grid.** Heterogeneous resolutions across times need a `scale=` arg to be explicit. Mix-and-match Landsat-8 (30 m) + Sentinel-2 (10 m) without `scale=` will silently coerce to whatever the first scene was.
-- **Recursive splitting can OOM at the join.** The final `spatial_mosaic` call materialises all quadrants in memory. For petabyte-scale exports, `export_cube` with windowed writes to disk is more appropriate than `export_image` to a single `GeoTensor`.
-- **The `ee` import is hard.** `from georeader.readers import ee_image` requires `earthengine-api` to be installed. The package's `[ee]` extra makes this explicit; the import won't be silently skipped.
+- **`export_cube` aligns to the first scene's grid.** Heterogeneous resolutions across times need a `scale=` arg to be explicit.
+  Mix-and-match Landsat-8 (30 m) + Sentinel-2 (10 m) without `scale=` will silently coerce to whatever the first scene was.
+- **Recursive splitting can OOM at the join.** The final `spatial_mosaic` call materialises all quadrants in memory.
+  For petabyte-scale exports, `export_cube` with windowed writes to disk is more appropriate than `export_image` to a single `GeoTensor`.
+- **The `ee` import is hard.** `from georeader.readers import ee_image` requires `earthengine-api` to be installed.
+  The package's `[ee]` extra makes this explicit; the import won't be silently skipped.
 
 ---
 
@@ -215,8 +229,11 @@ The credentials live in `~/.config/earthengine/credentials` (managed by `ee.Auth
 
 GEE doesn't have a dedicated wrapper in [`geotoolz.md`](../plans/geotoolz/geotoolz.md), but it shows up as a substrate alternative:
 
-- **Catalog discovery via `ee_query`** is a sibling to `geotoolz.catalog_ops.CatalogPipeline(catalog, op).run()` from the geotoolz plan. The two could converge: `ee_query.query_*` produces a GeoDataFrame; `CatalogPipeline` consumes a `GeoCatalog`. A small adapter would let `geotoolz.catalog_ops` operate on GEE-discovered scenes directly.
-- **`export_cube` is the GEE analogue of `RasterioReader([paths], stack=True)`** — both produce `(T, C, H, W)`. Operators that consume time-stacks (e.g., `geotoolz.compositing.MedianComposite`) work on either substrate without modification.
+- **Catalog discovery via `ee_query`** is a sibling to `geotoolz.catalog_ops.CatalogPipeline(catalog, op).run()` from the geotoolz plan.
+  The two could converge: `ee_query.query_*` produces a GeoDataFrame; `CatalogPipeline` consumes a `GeoCatalog`.
+  A small adapter would let `geotoolz.catalog_ops` operate on GEE-discovered scenes directly.
+- **`export_cube` is the GEE analogue of `RasterioReader([paths], stack=True)`** — both produce `(T, C, H, W)`.
+  Operators that consume time-stacks (e.g., `geotoolz.compositing.MedianComposite`) work on either substrate without modification.
 
 For users who already live on GEE, this module is the bridge that lets them move pipelines into the georeader / geotoolz operator world without abandoning the GEE archive.
 

--- a/projects/geotoolz/georeader_tutorial/16_earth_engine.md
+++ b/projects/geotoolz/georeader_tutorial/16_earth_engine.md
@@ -15,7 +15,13 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, gee
 ---
 
-> **Modules:** - `georeader/readers/ee_image.py` (539 LOC) - `georeader/readers/ee_query.py` (589 LOC) - `georeader/readers/ee_utils.py` (58 LOC) **Role:** export raster data from Google Earth Engine into `GeoTensor`s, handling GEE's request-size limits through recursive tile splitting and parallel downloads.
+> **Modules:**
+>
+> - `georeader/readers/ee_image.py` (539 LOC)
+> - `georeader/readers/ee_query.py` (589 LOC)
+> - `georeader/readers/ee_utils.py` (58 LOC)
+>
+> **Role:** export raster data from Google Earth Engine into `GeoTensor`s, handling GEE's request-size limits through recursive tile splitting and parallel downloads.
 
 ---
 

--- a/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
+++ b/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
@@ -15,7 +15,12 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, spot, probav
 ---
 
-> **Modules:** - `georeader/readers/spotvgt_image_operational.py` (389 LOC) - `georeader/readers/probav_image_operational.py` (701 LOC) **Role:** read SPOT VGT and Proba-V — two coarse-resolution operational vegetation-monitoring sensors that pre-date the Sentinel-2 era.
+> **Modules:**
+>
+> - `georeader/readers/spotvgt_image_operational.py` (389 LOC)
+> - `georeader/readers/probav_image_operational.py` (701 LOC)
+>
+> **Role:** read SPOT VGT and Proba-V — two coarse-resolution operational vegetation-monitoring sensors that pre-date the Sentinel-2 era.
 > **No ASCII diagrams in either file.** They're operational readers built before the docstring-illustration push.
 
 ---

--- a/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
+++ b/projects/geotoolz/georeader_tutorial/17_legacy_sensors.md
@@ -15,10 +15,8 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, spot, probav
 ---
 
-> **Modules:**
-> - `georeader/readers/spotvgt_image_operational.py` (389 LOC)
-> - `georeader/readers/probav_image_operational.py` (701 LOC)
-> **Role:** read SPOT VGT and Proba-V — two coarse-resolution operational vegetation-monitoring sensors that pre-date the Sentinel-2 era. **No ASCII diagrams in either file.** They're operational readers built before the docstring-illustration push.
+> **Modules:** - `georeader/readers/spotvgt_image_operational.py` (389 LOC) - `georeader/readers/probav_image_operational.py` (701 LOC) **Role:** read SPOT VGT and Proba-V — two coarse-resolution operational vegetation-monitoring sensors that pre-date the Sentinel-2 era.
+> **No ASCII diagrams in either file.** They're operational readers built before the docstring-illustration push.
 
 ---
 
@@ -31,13 +29,17 @@ SPOT VGT and Proba-V are vegetation-monitoring missions built around **daily glo
 | **SPOT VGT** | CNES + VITO | 1998–2014 | 1 km | Blue, Red, NIR, SWIR | Daily global |
 | **Proba-V** | ESA + VITO | 2013–2020 | 100 m / 300 m / 1 km | Blue, Red, NIR, SWIR | Near-daily global |
 
-Both are 1 km–100 m sensors with 4 bands (Blue, Red, NIR, SWIR) — **vastly less rich** than the Sentinel-2-era spectrometers. So why include them?
+Both are 1 km–100 m sensors with 4 bands (Blue, Red, NIR, SWIR) — **vastly less rich** than the Sentinel-2-era spectrometers.
+So why include them?
 
 1. **Historical baseline.** Pre-2015 vegetation studies almost all use VGT. To build a multi-decadal time series you need to read VGT data the same way you read S2 data.
-2. **Continuity.** Proba-V was the explicit gap-filler between VGT (2014 end-of-life) and Sentinel-3 (operational 2018). Some climate datasets stitch all three.
-3. **Operational simplicity.** These products are tiled in WGS84 with simple GeoTIFFs — no SAFE complexity, no GLT, no per-pixel coords. They're useful as a "minimal sensor reader" reference.
+2. **Continuity.** Proba-V was the explicit gap-filler between VGT (2014 end-of-life) and Sentinel-3 (operational 2018).
+   Some climate datasets stitch all three.
+3. **Operational simplicity.** These products are tiled in WGS84 with simple GeoTIFFs — no SAFE complexity, no GLT, no per-pixel coords.
+   They're useful as a "minimal sensor reader" reference.
 
-The headers explicitly call out that these are **unofficial readers** — built by the package authors against published user manuals, not certified by the agencies. Behaviour matches the manual but isn't guaranteed against future product-format changes.
+The headers explicitly call out that these are **unofficial readers** — built by the package authors against published user manuals, not certified by the agencies.
+Behaviour matches the manual but isn't guaranteed against future product-format changes.
 
 ---
 
@@ -57,7 +59,8 @@ Each class implements:
 - **`load(boundless=True)`** — return a `GeoTensor`.
 - **`read_from_window(window, boundless=True)`** — window-restricted read.
 
-So you can drop a `SpotVGT` or `ProbaV` instance into any `read.read_from_polygon(reader, ...)` call. The `GeoData` protocol is the abstraction that makes this just work.
+So you can drop a `SpotVGT` or `ProbaV` instance into any `read.read_from_polygon(reader, ...)` call.
+The `GeoData` protocol is the abstraction that makes this just work.
 
 ---
 
@@ -75,7 +78,8 @@ Used internally by both readers — saves repeating the calibration boilerplate 
 
 ## 4. SPOT VGT: `SpotVGT`
 
-The single class is at [spotvgt_image_operational.py:65](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/spotvgt_image_operational.py#L65). Standard layout:
+The single class is at [spotvgt_image_operational.py:65](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/spotvgt_image_operational.py#L65).
+Standard layout:
 
 - Detects band files in the SPOT VGT product folder via filename regex.
 - Parses acquisition date / sensor / processing version from the filename.
@@ -85,7 +89,8 @@ The single class is at [spotvgt_image_operational.py:65](https://github.com/spac
 
 ### SM bit decoding
 
-The SPOT VGT Status Map encodes 8 flags in one byte. The functions decode bits like:
+The SPOT VGT Status Map encodes 8 flags in one byte.
+The functions decode bits like:
 
 | Bit | Meaning |
 |---|---|
@@ -110,9 +115,11 @@ The Proba-V hierarchy is more elaborate ([probav_image_operational.py](https://g
 - **`ProbaVRadiometry`** ([line 507](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/probav_image_operational.py#L507)) — subclass that loads ToA reflectance directly (handles per-band gain/offset internally).
 - **`ProbaVSM`** ([line 590](https://github.com/spaceml-org/georeader/blob/f0d92f0/georeader/readers/probav_image_operational.py#L590)) — subclass that exposes the Status Map for cloud / shadow / quality.
 
-The Status Map decoder functions `sm_cloud_mask` and `mask_only_sm` are duplicated between the two modules — same names, same logic, different bit conventions. Proba-V's SM is a different format than VGT's despite both coming from VITO; the readers can't share decoder code.
+The Status Map decoder functions `sm_cloud_mask` and `mask_only_sm` are duplicated between the two modules — same names, same logic, different bit conventions.
+Proba-V's SM is a different format than VGT's despite both coming from VITO; the readers can't share decoder code.
 
-The Proba-V file also has compression-availability checks (`is_compression_available`, `assert_compression_available`) — Proba-V uses LZW or DEFLATE per acquisition, and pre-2017 readers without recent libtiff would silently fail to decode some files. The check raises a clear error before reading.
+The Proba-V file also has compression-availability checks (`is_compression_available`, `assert_compression_available`) — Proba-V uses LZW or DEFLATE per acquisition, and pre-2017 readers without recent libtiff would silently fail to decode some files.
+The check raises a clear error before reading.
 
 ---
 
@@ -121,7 +128,8 @@ The Proba-V file also has compression-availability checks (`is_compression_avail
 A code-deduplication argument would say "extract a shared `LegacyVITOReader` base." The package doesn't, for two pragmatic reasons:
 
 1. **The user manuals describe them as separate products.** A user navigating from the VGT manual to the code wants a `SpotVGT` class, not a `LegacyVITOReader.create(sensor="vgt")`.
-2. **Bit-flag conventions differ.** Even though both Status Maps look superficially similar (8 bits per pixel, one bit per quality flag), the bit→meaning mapping is different. Sharing a decoder would require a configuration map that obscures more than it saves.
+2. **Bit-flag conventions differ.** Even though both Status Maps look superficially similar (8 bits per pixel, one bit per quality flag), the bit→meaning mapping is different.
+   Sharing a decoder would require a configuration map that obscures more than it saves.
 
 This is a recurring pattern in sensor readers: the surface area looks like it should generalise, but the per-sensor calibration / bit / metadata details bake in enough divergence that the de-duplication isn't worth the indirection.
 
@@ -149,11 +157,16 @@ This is a recurring pattern in sensor readers: the surface area looks like it sh
 
 ## 8. Sharp edges
 
-- **Filename-encoded metadata.** Both readers parse acquisition date / processing version from filenames via regex. Renamed files (or files served through path-rewriting CDNs) break the parser. Keep filenames intact.
+- **Filename-encoded metadata.** Both readers parse acquisition date / processing version from filenames via regex.
+  Renamed files (or files served through path-rewriting CDNs) break the parser.
+  Keep filenames intact.
 - **WGS84-tiled.** Output is in geographic coordinates (degrees), not projected UTM. For pixel-area work you need to convert or accept that 1 km at the equator is not 1 km at high latitudes.
-- **Small bands × big tiles.** The 1 km native resolution × global daily coverage means individual product files are large arrays of mostly-zeros (over oceans, deserts at night, etc.). Read with `boundless=False` if you want to detect coverage gaps.
-- **Two `sm_cloud_mask` functions exist.** They have the same name in the two modules. Be explicit: `from georeader.readers.spotvgt_image_operational import sm_cloud_mask as vgt_cloud_mask` to avoid confusion.
-- **Proba-V's compression check is silent until enabled.** If your libtiff is old, some files load partially zeros. Always call `assert_compression_available(dataset)` early in production code.
+- **Small bands × big tiles.** The 1 km native resolution × global daily coverage means individual product files are large arrays of mostly-zeros (over oceans, deserts at night, etc.).
+  Read with `boundless=False` if you want to detect coverage gaps.
+- **Two `sm_cloud_mask` functions exist.** They have the same name in the two modules.
+  Be explicit: `from georeader.readers.spotvgt_image_operational import sm_cloud_mask as vgt_cloud_mask` to avoid confusion.
+- **Proba-V's compression check is silent until enabled.** If your libtiff is old, some files load partially zeros.
+  Always call `assert_compression_available(dataset)` early in production code.
 - **Status Map bit-flag conventions are sensor-specific.** Don't port code from VGT to Proba-V (or vice versa) by copy-paste — the bit meanings differ.
 - **No GLT, no RPCs, no per-pixel coords.** These readers don't need [Chapter 7](07_griddata.md) — the products are already orthorectified to WGS84.
 
@@ -161,7 +174,8 @@ This is a recurring pattern in sensor readers: the surface area looks like it sh
 
 ## 9. Why no diagrams
 
-The two modules predate the documentation push that added ASCII diagrams to the rest of the package. They're stable, used by a handful of climate-baseline pipelines, and the maintainers haven't added illustrations because there's not much to illustrate — these are simple band-stack readers without the structural complexity of EMIT (GLT) or PRISMA (curvilinear) or S2 SAFE (multi-resolution + JP2 stacking).
+The two modules predate the documentation push that added ASCII diagrams to the rest of the package.
+They're stable, used by a handful of climate-baseline pipelines, and the maintainers haven't added illustrations because there's not much to illustrate — these are simple band-stack readers without the structural complexity of EMIT (GLT) or PRISMA (curvilinear) or S2 SAFE (multi-resolution + JP2 stacking).
 
 Including them in this tutorial preserves the catalog completeness, but you can probably skip these if you're not specifically working with VGT or Proba-V. The readers are stable, well-named, and self-documenting in their docstrings.
 
@@ -169,8 +183,12 @@ Including them in this tutorial preserves the catalog completeness, but you can 
 
 ## 10. Connection to `geotoolz`
 
-Neither sensor has a dedicated preset in [`geotoolz.md`](../plans/geotoolz/geotoolz.md). Proba-V and SPOT VGT are unlikely to grow new operators because they're discontinued. They'd live in `geotoolz.presets.legacy` if ever — a `presets.legacy.PROBAV_NDVI` operator would be `Sequential([ProbaVRadiometry.load(), MaskClouds(via SM), NDVI(red_idx=1, nir_idx=2)])`. Trivial to implement, but rare enough that no-one's asked.
+Neither sensor has a dedicated preset in [`geotoolz.md`](../plans/geotoolz/geotoolz.md).
+Proba-V and SPOT VGT are unlikely to grow new operators because they're discontinued.
+They'd live in `geotoolz.presets.legacy` if ever — a `presets.legacy.PROBAV_NDVI` operator would be `Sequential([ProbaVRadiometry.load(), MaskClouds(via SM), NDVI(red_idx=1, nir_idx=2)])`.
+Trivial to implement, but rare enough that no-one's asked.
 
-The general lesson: **operators are sensor-agnostic; readers are sensor-specific**. As long as a sensor's reader returns a `GeoData` with band semantics that match a downstream operator's `red_idx=` / `nir_idx=` arguments, the operator works without any sensor-specific code.
+The general lesson: **operators are sensor-agnostic; readers are sensor-specific**.
+As long as a sensor's reader returns a `GeoData` with band semantics that match a downstream operator's `red_idx=` / `nir_idx=` arguments, the operator works without any sensor-specific code.
 
 Next chapter: [18_query_and_download.md](18_query_and_download.md) — query / catalog / download helpers (`scihubcopernicus_query`, `download_pv_product`, `query_utils`, `tileserver`, `download_utils`).

--- a/projects/geotoolz/georeader_tutorial/18_query_and_download.md
+++ b/projects/geotoolz/georeader_tutorial/18_query_and_download.md
@@ -15,20 +15,16 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, query, download
 ---
 
-> **Modules** (all small):
-> - `query_utils.py` (80 LOC) — generic spatial-overlap helpers
-> - `scihubcopernicus_query.py` (111 LOC) — Copernicus SciHub query (Sentinel-1/2/3)
-> - `download_utils.py` (61 LOC) — generic HTTP-with-auth download
-> - `download_pv_product.py` (328 LOC) — Proba-V product download from VITO
-> - `tileserver.py` (68 LOC) — XYZ tileserver consumer
->
-> **Role:** the **discovery and acquisition** plumbing. Find scenes by AOI + time, download them, or read from a web tile server. **No ASCII diagrams in any of these.** They're all small utility modules.
+> **Modules** (all small): - `query_utils.py` (80 LOC) — generic spatial-overlap helpers - `scihubcopernicus_query.py` (111 LOC) — Copernicus SciHub query (Sentinel-1/2/3) - `download_utils.py` (61 LOC) — generic HTTP-with-auth download - `download_pv_product.py` (328 LOC) — Proba-V product download from VITO - `tileserver.py` (68 LOC) — XYZ tileserver consumer  **Role:** the **discovery and acquisition** plumbing.
+> Find scenes by AOI + time, download them, or read from a web tile server.
+> **No ASCII diagrams in any of these.** They're all small utility modules.
 
 ---
 
 ## 1. The shape of the discovery layer
 
-Most users don't have raw paths to satellite scenes — they have an AOI and a date range. The work flow is:
+Most users don't have raw paths to satellite scenes — they have an AOI and a date range.
+The work flow is:
 
 1. **Query a catalog** ("what scenes overlap my AOI in this date range?") → list of product metadata.
 2. **Filter** ("only ones with < 20% cloud cover") → narrower list.
@@ -41,7 +37,8 @@ The five small modules in this chapter cover steps 1–3. Step 4 is the rest of 
 
 ## 2. `query_utils.py` — generic spatial helpers
 
-Three functions, all collection-agnostic. The shared infrastructure that the per-collection query modules build on.
+Three functions, all collection-agnostic.
+The shared infrastructure that the per-collection query modules build on.
 
 | Function | What it does |
 |---|---|
@@ -60,14 +57,18 @@ get_api(api_url='https://scihub.copernicus.eu/dhus/') -> SentinelAPI
 query(area, date_start, date_end, ...) -> gpd.GeoDataFrame
 ```
 
-Wraps the [`sentinelsat`](https://sentinelsat.readthedocs.io/) library to issue spatial-temporal queries against the official Copernicus SciHub catalog. Returns a GeoDataFrame with one row per matched product, columns including `geometry`, `beginposition`, `cloudcoverpercentage`, `producttype`, `relativeorbitnumber`.
+Wraps the [`sentinelsat`](https://sentinelsat.readthedocs.io/) library to issue spatial-temporal queries against the official Copernicus SciHub catalog.
+Returns a GeoDataFrame with one row per matched product, columns including `geometry`, `beginposition`, `cloudcoverpercentage`, `producttype`, `relativeorbitnumber`.
 
-This is the **legacy** way to query Sentinel scenes. The Copernicus Data Space (`https://catalogue.dataspace.copernicus.eu/`) replaced SciHub in 2023; for new workflows, prefer:
+This is the **legacy** way to query Sentinel scenes.
+The Copernicus Data Space (`https://catalogue.dataspace.copernicus.eu/`) replaced SciHub in 2023; for new workflows, prefer:
 
 - **GEE** ([Chapter 16](16_earth_engine.md)) — wider catalog, no auth complications.
-- **STAC catalogs** — Element84, Microsoft Planetary Computer (Chapter 14 mentions both). The corresponding `s2_load_from_feature_*` adapters in `S2_SAFE_reader.py` consume STAC features directly.
+- **STAC catalogs** — Element84, Microsoft Planetary Computer (Chapter 14 mentions both).
+  The corresponding `s2_load_from_feature_*` adapters in `S2_SAFE_reader.py` consume STAC features directly.
 
-The SciHub module remains for users with workflows that pre-date the 2023 transition. Authentication uses Copernicus credentials via `sentinelsat.SentinelAPI(user, password, api_url)`.
+The SciHub module remains for users with workflows that pre-date the 2023 transition.
+Authentication uses Copernicus credentials via `sentinelsat.SentinelAPI(user, password, api_url)`.
 
 ---
 
@@ -79,15 +80,19 @@ Single function:
 download_product(link_down, filename=None, auth=None, ...) -> str
 ```
 
-Stream-downloads a URL to disk with optional HTTP basic auth. The base building block for all the per-source downloaders. Uses `requests` (which is a hard dep of this module — `import` raises `ImportError` if not installed).
+Stream-downloads a URL to disk with optional HTTP basic auth.
+The base building block for all the per-source downloaders.
+Uses `requests` (which is a hard dep of this module — `import` raises `ImportError` if not installed).
 
-Notable: the `auth` argument is just `requests`-style — pass a `(user, password)` tuple or a `requests.auth.AuthBase` subclass. No package-specific auth abstraction.
+Notable: the `auth` argument is just `requests`-style — pass a `(user, password)` tuple or a `requests.auth.AuthBase` subclass.
+No package-specific auth abstraction.
 
 ---
 
 ## 5. `download_pv_product.py` — Proba-V VITO downloads
 
-Proba-V data lives on [VITO's product distribution portal](https://www.vito-eodata.be/PDF/datapool/). Authentication uses VITO credentials stored in `~/.georeader/auth_vito.json`.
+Proba-V data lives on [VITO's product distribution portal](https://www.vito-eodata.be/PDF/datapool/).
+Authentication uses VITO credentials stored in `~/.georeader/auth_vito.json`.
 
 The module exposes a download workflow:
 
@@ -107,7 +112,8 @@ The module exposes a download workflow:
 
 The granularity is high because Proba-V's distribution is more rigid than modern STAC catalogs — there are specific URL patterns for `(year, month, day, camera, resolution)` tuples that the module encodes.
 
-This pairs with [`probav_image_operational.py`](17_legacy_sensors.md) — the download module fetches the files, the operational reader reads them. Together they cover the full Proba-V pipeline.
+This pairs with [`probav_image_operational.py`](17_legacy_sensors.md) — the download module fetches the files, the operational reader reads them.
+Together they cover the full Proba-V pipeline.
 
 ---
 
@@ -117,7 +123,8 @@ This pairs with [`probav_image_operational.py`](17_legacy_sensors.md) — the do
 read_from_tileserver(tile_server, geometry, ...) -> GeoTensor
 ```
 
-Reads from a slippy-map XYZ tile server (Mapbox, Google Maps, OSM-style basemaps). Given a polygon AOI:
+Reads from a slippy-map XYZ tile server (Mapbox, Google Maps, OSM-style basemaps).
+Given a polygon AOI:
 
 1. Compute which `(x, y, z)` tiles cover the AOI via [`mercantile`](https://github.com/mapbox/mercantile).
 2. HTTP-GET each tile from the tileserver URL pattern (e.g., `https://tile.openstreetmap.org/{z}/{x}/{y}.png`).
@@ -129,7 +136,8 @@ Useful for:
 - **Basemaps as raster context.** Drop OSM tiles under a derived layer for visualisation.
 - **Quick previews.** When you have an AOI but no archive access, a tileserver gives you something to work with.
 
-The output is in **Web Mercator**, not the native CRS of the satellite imagery you're typically processing. If you need it in another CRS, follow with `read.read_to_crs` ([Chapter 5 §4](05_read.md)).
+The output is in **Web Mercator**, not the native CRS of the satellite imagery you're typically processing.
+If you need it in another CRS, follow with `read.read_to_crs` ([Chapter 5 §4](05_read.md)).
 
 ---
 
@@ -147,10 +155,14 @@ The output is in **Web Mercator**, not the native CRS of the satellite imagery y
 
 ## 8. Sharp edges
 
-- **SciHub is deprecated.** Don't build new code against `scihubcopernicus_query`. Use Microsoft Planetary Computer or Element84 STAC catalogs instead.
-- **Credential files are plaintext JSON.** `~/.georeader/auth_emit.json`, `~/.georeader/auth_vito.json`. Make sure they're not in dotfile sync. The package doesn't encrypt them.
+- **SciHub is deprecated.** Don't build new code against `scihubcopernicus_query`.
+  Use Microsoft Planetary Computer or Element84 STAC catalogs instead.
+- **Credential files are plaintext JSON.** `~/.georeader/auth_emit.json`, `~/.georeader/auth_vito.json`.
+  Make sure they're not in dotfile sync.
+  The package doesn't encrypt them.
 - **Tileserver outputs are in EPSG:3857.** Web Mercator is *not* the same as UTM zones — don't `same_extent` against an S2 scene without reprojecting first.
-- **Tileserver licensing.** Pulling many tiles from OSM violates their tile-usage policy (rate limit, attribution). For production / research you'd want a self-hosted tileserver or a paid Mapbox account.
+- **Tileserver licensing.** Pulling many tiles from OSM violates their tile-usage policy (rate limit, attribution).
+  For production / research you'd want a self-hosted tileserver or a paid Mapbox account.
 - **Proba-V download URLs encode many fields.** A typo in the camera ID or resolution silently returns 404. The `exists_product_name` helper exists for the same reason.
 - **`requests` is a hard import for `download_utils`.** Other modules import lazily; this one fails on module load if `requests` isn't installed.
 
@@ -160,7 +172,8 @@ The output is in **Web Mercator**, not the native CRS of the satellite imagery y
 
 The discovery layer is **explicitly out of scope** for `geotoolz` per [`geotoolz.md` §1.3](../plans/geotoolz/geotoolz.md):
 
-> **Not `georeader`.** No I/O, no CRS plumbing, no reader classes, no catalog construction. Those are `georeader`'s job.
+> **Not `georeader`.** No I/O, no CRS plumbing, no reader classes, no catalog construction.
+> Those are `georeader`'s job.
 
 But there's a clean handoff: `geotoolz.catalog_ops.CatalogPipeline(catalog, op).run()` (from [§1.2 of the plan](../plans/geotoolz/geotoolz.md)) consumes a `georeader.catalog.GeoCatalog` — which (per the [Geodatabase design](../plans/geodatabase/README.md)) is a planned addition to georeader that would unify all the per-collection query modules in this chapter.
 
@@ -170,13 +183,15 @@ The future state, per the plans:
 - A `GeoCatalog` wraps any GeoDataFrame as a queryable, persistable spatial index.
 - `geotoolz.catalog_ops.CatalogPipeline` takes a `GeoCatalog`, applies a `Sequential` of operators per row, writes outputs.
 
-Today, you build that pipeline by hand — query, filter, loop, read, process, write. The chapters 14–18 give you the building blocks; the orchestration is your code.
+Today, you build that pipeline by hand — query, filter, loop, read, process, write.
+The chapters 14–18 give you the building blocks; the orchestration is your code.
 
 ---
 
 ## 10. Closing the tutorial
 
-This is the final chapter. The full coverage:
+This is the final chapter.
+The full coverage:
 
 - **Part I (Ch. 1–3):** core data model — `GeoTensor`, abstract reader protocols, `RasterioReader`.
 - **Part II (Ch. 4–6):** reading & windowing — `window_utils`, `read.py`, `slices`.
@@ -184,6 +199,9 @@ This is the final chapter. The full coverage:
 - **Part IV (Ch. 11–13):** radiometry & I/O — `reflectance`, `save`, miscellaneous utilities.
 - **Part V (Ch. 14–18):** sensor readers — Sentinel-2, hyperspectral trio, Earth Engine, legacy sensors, query/download.
 
-Total preserved: **all ASCII diagrams across 17 modules** that had them, plus the implementation walkthroughs (the 8-step `read_reproject` annotation in [Chapter 5](05_read.md)) that were also at risk of being cleaned up. The tutorial mirrors the package structure so a reader can navigate from "I want to do X" → which module → which chapter → the diagrams + prose explaining it.
+Total preserved: **all ASCII diagrams across 17 modules** that had them, plus the implementation walkthroughs (the 8-step `read_reproject` annotation in [Chapter 5](05_read.md)) that were also at risk of being cleaned up.
+The tutorial mirrors the package structure so a reader can navigate from "I want to do X" → which module → which chapter → the diagrams + prose explaining it.
 
-The closing observation: **georeader is a coherent stack, not a kitchen sink.** Every module builds on the layer below it. `GeoTensor` (Chapter 1) carries metadata; `window_utils` (Chapter 4) does pixel-geo math; `read.py` (Chapter 5) composes the two; `mosaic` / `rasterize` / `vectorize` (Chapters 8–10) build on `read.py`; the sensor readers (Chapters 14–17) plug into the `GeoData` protocol so all of the above just works on real-world products. That layering is what makes a `geotoolz` operator-composition library viable — it has a clean substrate to sit on.
+The closing observation: **georeader is a coherent stack, not a kitchen sink.** Every module builds on the layer below it.
+`GeoTensor` (Chapter 1) carries metadata; `window_utils` (Chapter 4) does pixel-geo math; `read.py` (Chapter 5) composes the two; `mosaic` / `rasterize` / `vectorize` (Chapters 8–10) build on `read.py`; the sensor readers (Chapters 14–17) plug into the `GeoData` protocol so all of the above just works on real-world products.
+That layering is what makes a `geotoolz` operator-composition library viable — it has a clean substrate to sit on.

--- a/projects/geotoolz/georeader_tutorial/18_query_and_download.md
+++ b/projects/geotoolz/georeader_tutorial/18_query_and_download.md
@@ -15,7 +15,15 @@ license: CC-BY-4.0
 keywords: tutorial, georeader, query, download
 ---
 
-> **Modules** (all small): - `query_utils.py` (80 LOC) — generic spatial-overlap helpers - `scihubcopernicus_query.py` (111 LOC) — Copernicus SciHub query (Sentinel-1/2/3) - `download_utils.py` (61 LOC) — generic HTTP-with-auth download - `download_pv_product.py` (328 LOC) — Proba-V product download from VITO - `tileserver.py` (68 LOC) — XYZ tileserver consumer  **Role:** the **discovery and acquisition** plumbing.
+> **Modules** (all small):
+>
+> - `query_utils.py` (80 LOC) — generic spatial-overlap helpers
+> - `scihubcopernicus_query.py` (111 LOC) — Copernicus SciHub query (Sentinel-1/2/3)
+> - `download_utils.py` (61 LOC) — generic HTTP-with-auth download
+> - `download_pv_product.py` (328 LOC) — Proba-V product download from VITO
+> - `tileserver.py` (68 LOC) — XYZ tileserver consumer
+>
+> **Role:** the **discovery and acquisition** plumbing.
 > Find scenes by AOI + time, download them, or read from a web tile server.
 > **No ASCII diagrams in any of these.** They're all small utility modules.
 

--- a/projects/geotoolz/geostack_notes.md
+++ b/projects/geotoolz/geostack_notes.md
@@ -23,9 +23,13 @@ keywords: geospatial, ecosystem, motivation, geotoolz, xrtoolz, geocatalog
 
 ## Primer for newcomers
 
-> **ELI5.** Imagine a planetary **shipping network**. **Warehouses** all over the world hold the cargo. **Trucks and ships** move it between ports. **Dock workers** crack open containers and stack the contents on **standard pallets**, which feed **factories** that build finished products. Customers find what they want through a **shipping registry**, and they see the result in **storefronts**.
->
-> Modern geospatial software is exactly this network — but the cargo is *data* (satellite pixels, climate cubes, building footprints) instead of widgets, and the warehouses span continents and petabytes. The libraries I'm building are the missing pieces in this network: better **factories** for raster and cube data, and a better **registry** to tie everything together.
+> **ELI5.** Imagine a planetary **shipping network**.
+> **Warehouses** all over the world hold the cargo.
+> **Trucks and ships** move it between ports.
+> **Dock workers** crack open containers and stack the contents on **standard pallets**, which feed **factories** that build finished products.
+> Customers find what they want through a **shipping registry**, and they see the result in **storefronts**.
+> Modern geospatial software is exactly this network — but the cargo is *data* (satellite pixels, climate cubes, building footprints) instead of widgets, and the warehouses span continents and petabytes.
+> The libraries I'm building are the missing pieces in this network: better **factories** for raster and cube data, and a better **registry** to tie everything together.
 
 ### The five-layer view
 
@@ -34,36 +38,80 @@ A flattened picture of the whole stack, before the detailed walk-through:
 :::{include} diagrams/01_five_layer.html
 :::
 
-Read it from the bottom: bytes sit in **warehouses**, **forklifts** haul them out only when asked, the **registry** tells the forklift *which* warehouse to go to, **factories** turn raw cargo into finished products, and the **storefront** shows it to the human. Every layer above is useless without the one below — but the *registry* is the layer most people skip and then regret.
+Read it from the bottom: bytes sit in **warehouses**, **forklifts** haul them out only when asked, the **registry** tells the forklift *which* warehouse to go to, **factories** turn raw cargo into finished products, and the **storefront** shows it to the human.
+Every layer above is useless without the one below — but the *registry* is the layer most people skip and then regret.
 
 ### Walking down the stack
 
-The stack is eight conceptual layers — same anatomy whether the cargo is a satellite scene, a climate cube, or a building footprint. For each: what it does, how we used to do it, what changed, and what's still awkward.
+The stack is eight conceptual layers — same anatomy whether the cargo is a satellite scene, a climate cube, or a building footprint.
+For each: what it does, how we used to do it, what changed, and what's still awkward.
 
-**1. The warehouses (Storage).** Where the data physically lives. Today these are **object stores** in the cloud — buckets full of files, stacked in racks the size of city blocks, billed by the byte. *Old world:* tape archives, FTP servers, lab NAS appliances. Data lived where the people who collected it happened to work, and you got a copy by emailing someone or `scp`-ing it overnight. *What changed:* one address — `s3://…`, `gs://…` — for everyone, with effectively infinite capacity, and fault-tolerance baked in. *Still awkward:* the bytes alone are dumb; nothing useful happens until something fetches them, and "where exactly is my pallet inside this warehouse?" is a real problem (see layer 7).
+**1. The warehouses (Storage).** Where the data physically lives.
+Today these are **object stores** in the cloud — buckets full of files, stacked in racks the size of city blocks, billed by the byte.
+*Old world:* tape archives, FTP servers, lab NAS appliances.
+Data lived where the people who collected it happened to work, and you got a copy by emailing someone or `scp`-ing it overnight.
+*What changed:* one address — `s3://…`, `gs://…` — for everyone, with effectively infinite capacity, and fault-tolerance baked in.
+*Still awkward:* the bytes alone are dumb; nothing useful happens until something fetches them, and "where exactly is my pallet inside this warehouse?" is a real problem (see layer 7).
 
-**2. The forklifts (Transport).** Getting bytes out of the warehouse and onto your laptop. Modern transport speaks **HTTP** with **range requests** — "give me bytes 4096–8191 of this 10 GB file" — and dispatches many in parallel. *Old world:* full-file FTP downloads, mounted network shares, vendor-specific transfer protocols. If you wanted one tile out of a satellite scene, you downloaded the whole scene. *What changed:* concurrency hides latency; you only pay for what you read; a single laptop can saturate a 10 Gbps link. *Still awkward:* range reads only help if the **file format** lets you compute *which* bytes you want without reading the whole thing first — most pre-2015 formats don't.
+**2. The forklifts (Transport).** Getting bytes out of the warehouse and onto your laptop.
+Modern transport speaks **HTTP** with **range requests** — "give me bytes 4096–8191 of this 10 GB file" — and dispatches many in parallel.
+*Old world:* full-file FTP downloads, mounted network shares, vendor-specific transfer protocols.
+If you wanted one tile out of a satellite scene, you downloaded the whole scene.
+*What changed:* concurrency hides latency; you only pay for what you read; a single laptop can saturate a 10 Gbps link.
+*Still awkward:* range reads only help if the **file format** lets you compute *which* bytes you want without reading the whole thing first — most pre-2015 formats don't.
 
-**3. The retrofit team (Virtualisation).** A clever hack for legacy cargo. The world has petabytes of data sitting in monolithic file formats (HDF4, HDF5, NetCDF-3) that *aren't* range-readable. Rather than rewrite all of it, the retrofit team scans each old crate once, writes a tiny "where everything is inside" index, and exposes the index so modern forklifts can pretend the old crate is a new one. *Old world:* migrate everything — years of effort, double storage costs while in flight, and political fights over who owns the canonical copy. *What changed:* zero-migration access to legacy archives — the old data didn't move, but it now behaves cloud-native. *Still awkward:* one more layer of indirection to maintain, and the indices go stale when the underlying files change.
+**3. The retrofit team (Virtualisation).** A clever hack for legacy cargo.
+The world has petabytes of data sitting in monolithic file formats (HDF4, HDF5, NetCDF-3) that *aren't* range-readable.
+Rather than rewrite all of it, the retrofit team scans each old crate once, writes a tiny "where everything is inside" index, and exposes the index so modern forklifts can pretend the old crate is a new one.
+*Old world:* migrate everything — years of effort, double storage costs while in flight, and political fights over who owns the canonical copy.
+*What changed:* zero-migration access to legacy archives — the old data didn't move, but it now behaves cloud-native.
+*Still awkward:* one more layer of indirection to maintain, and the indices go stale when the underlying files change.
 
-**4. The dock workers (Readers).** The code that actually opens a file and turns its bytes into something you can compute on. Modern readers are **asynchronous and concurrent** — many small range reads dispatched in parallel — and *lazy*, deferring work until you ask for the result. *Old world:* synchronous, one-file-at-a-time, blocking; or worse, click-through GUI dialogs in a vendor application (ArcToolbox, ENVI menus). *What changed:* a single Python process can drive thousands of concurrent reads. *Still awkward:* async code is harder to reason about, and each data geometry (raster vs cube vs vector) needs its own specialised reader — there's no one universal "open this geo-thing" function.
+**4. The dock workers (Readers).** The code that actually opens a file and turns its bytes into something you can compute on.
+Modern readers are **asynchronous and concurrent** — many small range reads dispatched in parallel — and *lazy*, deferring work until you ask for the result.
+*Old world:* synchronous, one-file-at-a-time, blocking; or worse, click-through GUI dialogs in a vendor application (ArcToolbox, ENVI menus).
+*What changed:* a single Python process can drive thousands of concurrent reads.
+*Still awkward:* async code is harder to reason about, and each data geometry (raster vs cube vs vector) needs its own specialised reader — there's no one universal "open this geo-thing" function.
 
-**5. The standard pallet (Substrate).** Once cargo is unloaded, what *shape* does it take in memory? The modern answer is a **typed carrier** — an array (or table) that remembers its coordinates: which axis is latitude, which row is "Paris", which column is "geometry", what the units are, what projection the world is in. *Old world:* bare arrays plus sidecar files (`.prj`, `.tfw`, `.hdr`, `.aux.xml`) you had to read by hand and keep in sync. Lose the sidecar, lose the meaning. *What changed:* coordinate-aware operations don't need manual bookkeeping; downstream code stays geographically honest. *Still awkward:* the three data geometries (raster / cube / vector) each have a different idea of "the right pallet" — there isn't yet one universal carrier.
+**5. The standard pallet (Substrate).** Once cargo is unloaded, what *shape* does it take in memory?
+The modern answer is a **typed carrier** — an array (or table) that remembers its coordinates: which axis is latitude, which row is "Paris", which column is "geometry", what the units are, what projection the world is in.
+*Old world:* bare arrays plus sidecar files (`.prj`, `.tfw`, `.hdr`, `.aux.xml`) you had to read by hand and keep in sync.
+Lose the sidecar, lose the meaning.
+*What changed:* coordinate-aware operations don't need manual bookkeeping; downstream code stays geographically honest.
+*Still awkward:* the three data geometries (raster / cube / vector) each have a different idea of "the right pallet" — there isn't yet one universal carrier.
 
-**6. The factories (Compute / engines).** Where the science actually happens — pixel math, regridding, climatologies, spatial joins, ensemble statistics. Modern factories are **composable**: small typed operators chained into pipelines, like Lego blocks for analysis. *Old world:* monolithic GIS suites (ArcGIS, ENVI, GRASS, IDL) where every workflow was a vendor-specific click-trail, plus a long tail of one-off scripts copy-pasted between projects. *What changed:* reusable, testable units that work the same in a notebook, a script, and a server. *Still awkward:* the factory ecosystem is **fragmented** — each data geometry has its own factory, and operators don't always compose cleanly across them. (This is one of the gaps the libraries below try to close.)
+**6. The factories (Compute / engines).** Where the science actually happens — pixel math, regridding, climatologies, spatial joins, ensemble statistics.
+Modern factories are **composable**: small typed operators chained into pipelines, like Lego blocks for analysis.
+*Old world:* monolithic GIS suites (ArcGIS, ENVI, GRASS, IDL) where every workflow was a vendor-specific click-trail, plus a long tail of one-off scripts copy-pasted between projects.
+*What changed:* reusable, testable units that work the same in a notebook, a script, and a server.
+*Still awkward:* the factory ecosystem is **fragmented** — each data geometry has its own factory, and operators don't always compose cleanly across them.
+(This is one of the gaps the libraries below try to close.)
 
-**7. The shipping registry (Discovery / Catalog).** The single most underrated layer. A registry knows *what* exists, *where* each pallet is stored, and *what's inside* each container — without having to physically open them. You query the registry first, get back a short list of warehouse addresses, then send the forklifts. *Old world:* directory-of-files plus a README, hand-maintained CSV indices, FGDC metadata XML no one updated, or full-blown enterprise spatial databases for the lucky few. At petabyte scale there are heavyweight standardised registries (you'll meet them later); at lab scale most teams still wing it. *What changed:* the same columnar file format used for tabular data can *hold* the metadata index, queryable with the same SQL engine you already use for analytics — the registry becomes "just another file". *Still awkward:* no universal agreement on *what* metadata to record, and registries decay if no one keeps the crawls running.
+**7. The shipping registry (Discovery / Catalog).** The single most underrated layer.
+A registry knows *what* exists, *where* each pallet is stored, and *what's inside* each container — without having to physically open them.
+You query the registry first, get back a short list of warehouse addresses, then send the forklifts.
+*Old world:* directory-of-files plus a README, hand-maintained CSV indices, FGDC metadata XML no one updated, or full-blown enterprise spatial databases for the lucky few.
+At petabyte scale there are heavyweight standardised registries (you'll meet them later); at lab scale most teams still wing it.
+*What changed:* the same columnar file format used for tabular data can *hold* the metadata index, queryable with the same SQL engine you already use for analytics — the registry becomes "just another file".
+*Still awkward:* no universal agreement on *what* metadata to record, and registries decay if no one keeps the crawls running.
 
-**8. The storefront (Viz / UX).** Where humans actually see the result. Modern storefronts are **GPU-accelerated** and **in-browser**, reading straight from cloud storage — interactive maps that fetch tiles on demand and render millions of features at 60 fps. *Old world:* render to PNG, save to disk, open in a desktop GIS (QGIS, ArcMap), or maintain a heavyweight tile-server farm pre-rendering images for the web. *What changed:* the same notebook that ran the analysis can also render the map; the same cloud bytes feed both. *Still awkward:* GPU memory is finite, browsers have limits, and "ship a million polygons to a tablet" is still a real engineering problem.
+**8. The storefront (Viz / UX).** Where humans actually see the result.
+Modern storefronts are **GPU-accelerated** and **in-browser**, reading straight from cloud storage — interactive maps that fetch tiles on demand and render millions of features at 60 fps.
+*Old world:* render to PNG, save to disk, open in a desktop GIS (QGIS, ArcMap), or maintain a heavyweight tile-server farm pre-rendering images for the web.
+*What changed:* the same notebook that ran the analysis can also render the map; the same cloud bytes feed both.
+*Still awkward:* GPU memory is finite, browsers have limits, and "ship a million polygons to a tablet" is still a real engineering problem.
 
 ### Two organising ideas
 
 Borrowing the networking metaphor: the modern stack splits cleanly into a **control plane** and a **data plane**.
 
-- **Control plane (the brain).** Knows *what* exists, *where* it lives, and *how* to find it. This is the **registry** (layer 7).
-- **Data plane (the muscle).** Moves bytes, decodes pixels, runs math. This is layers 1–6 plus 8.
+- **Control plane (the brain).** Knows *what* exists, *where* it lives, and *how* to find it.
+  This is the **registry** (layer 7).
+- **Data plane (the muscle).** Moves bytes, decodes pixels, runs math.
+  This is layers 1–6 plus 8.
 
-You need both. A registry with no readers is a phone book with no phones; readers with no registry means every workflow re-implements path-globbing and metadata parsing.
+You need both.
+A registry with no readers is a phone book with no phones; readers with no registry means every workflow re-implements path-globbing and metadata parsing.
 
 ### The three stacks
 
@@ -83,13 +131,16 @@ The registry sits *above* all three and uses the **vector stack** to govern the 
 
 ## Why this exists
 
-The cloud-native geospatial ecosystem is **mature at the edges** (storage formats, byte transport, viz) and **fragmented in the middle** (slicing, indexing, composition). Three concrete gaps motivate this work:
+The cloud-native geospatial ecosystem is **mature at the edges** (storage formats, byte transport, viz) and **fragmented in the middle** (slicing, indexing, composition).
+Three concrete gaps motivate this work:
 
 **1. No unified compute layer for imagery.** `rio-tiler` does web tiles, `rasterio` does GDAL-backed reads, `eo-learn` does workflow DAGs — but nothing composes pixel-level operators (band math, masking, regridding, sensor calibration) over a typed `GeoTensor` carrier with the same ergonomics as PyTorch's `nn.Sequential`. → **`geotoolz`**.
 
-**2. No first-class operator algebra for dense cubes.** `xarray` is a brilliant *substrate* (labelled arrays, coordinates, chunking) but operator composition still happens as ad-hoc function chains. Climatologies, regridding, EOF decompositions, and ensemble statistics all want a shared shape. → **`xrtoolz`**.
+**2. No first-class operator algebra for dense cubes.** `xarray` is a brilliant *substrate* (labelled arrays, coordinates, chunking) but operator composition still happens as ad-hoc function chains.
+Climatologies, regridding, EOF decompositions, and ensemble statistics all want a shared shape. → **`xrtoolz`**.
 
-**3. No lightweight catalog for personal/lab-scale work.** STAC is the gold standard at petabyte scale, but spinning up a STAC API for a few hundred TB of project data is overkill. A GeoParquet-backed catalog queryable with DuckDB closes the gap between "directory of files" and "full STAC deployment". → **`GeoCatalog`** (see [`plans/geodatabase/`](plans/geodatabase/)).
+**3. No lightweight catalog for personal/lab-scale work.** STAC is the gold standard at petabyte scale, but spinning up a STAC API for a few hundred TB of project data is overkill.
+A GeoParquet-backed catalog queryable with DuckDB closes the gap between "directory of files" and "full STAC deployment". → **`GeoCatalog`** (see [`plans/geodatabase/`](plans/geodatabase/)).
 
 ---
 
@@ -104,7 +155,9 @@ The full stack, with `GeoCatalog` as the discovery layer that ties the three dat
 
 ### The catalog is the glue
 
-The key move across all three stacks: the **vector stack** (GeoParquet metadata, DuckDB query) is what makes the **imagery** and **dense** stacks navigable. Without a catalog, every workflow re-implements `glob()` + STAC parsing and the boilerplate compounds across projects. Each stack below ends with a **lifecycle of a query** sequence diagram showing exactly how the catalog hand-off works for that data geometry.
+The key move across all three stacks: the **vector stack** (GeoParquet metadata, DuckDB query) is what makes the **imagery** and **dense** stacks navigable.
+Without a catalog, every workflow re-implements `glob()` + STAC parsing and the boilerplate compounds across projects.
+Each stack below ends with a **lifecycle of a query** sequence diagram showing exactly how the catalog hand-off works for that data geometry.
 
 ---
 
@@ -135,31 +188,49 @@ The same six layers repeat across all three stacks; only the row contents change
 
 #### Layers
 
-**Storage — [COG (Cloud Optimized GeoTIFF)](https://www.cogeo.org/).** A standard GeoTIFF with two structural choices: pixels are organised into internal tiles (typically 256×256 or 512×512), and decimated overviews (½, ¼, ⅛ resolution) are appended to the same file. The IFD (Image File Directory) at the start of the file lists the byte offset and length of every tile and every overview. Because clients can read the IFD with a single small HEAD/GET, then fetch only the tiles overlapping their AOI via HTTP range requests, a 10 GB Sentinel-2 scene becomes a few-MB read for a small region. *Advantage: arbitrary spatial subsetting over HTTP without downloading the whole file.*
+**Storage — [COG (Cloud Optimized GeoTIFF)](https://www.cogeo.org/).** A standard GeoTIFF with two structural choices: pixels are organised into internal tiles (typically 256×256 or 512×512), and decimated overviews (½, ¼, ⅛ resolution) are appended to the same file.
+The IFD (Image File Directory) at the start of the file lists the byte offset and length of every tile and every overview.
+Because clients can read the IFD with a single small HEAD/GET, then fetch only the tiles overlapping their AOI via HTTP range requests, a 10 GB Sentinel-2 scene becomes a few-MB read for a small region.
+*Advantage: arbitrary spatial subsetting over HTTP without downloading the whole file.*
 
-**Transport — [`obstore`](https://github.com/developmentseed/obstore) and [GDAL/VSI](https://gdal.org/user/virtual_file_systems.html).** Two parallel paths into cloud storage. **`obstore`** is a Python wrapper around the Rust [`object_store`](https://docs.rs/object_store/) crate — it speaks S3, GCS, Azure Blob, and HTTP natively, dispatches concurrent range requests, and benchmarks 2–5× faster than `fsspec`-based alternatives for byte-range workloads. **GDAL/VSI** is the C++ "Virtual File System" baked into GDAL (`vsis3://`, `vsigs://`, `vsicurl://` etc.), which is what `rasterio` uses by default — mature, ubiquitous, but synchronous, and configured through environment variables (`AWS_*`, `GDAL_HTTP_*`). *Advantage: `obstore` for new async pipelines, GDAL/VSI for the long tail of formats GDAL already understands.*
+**Transport — [`obstore`](https://github.com/developmentseed/obstore) and [GDAL/VSI](https://gdal.org/user/virtual_file_systems.html).** Two parallel paths into cloud storage.
+**`obstore`** is a Python wrapper around the Rust [`object_store`](https://docs.rs/object_store/) crate — it speaks S3, GCS, Azure Blob, and HTTP natively, dispatches concurrent range requests, and benchmarks 2–5× faster than `fsspec`-based alternatives for byte-range workloads.
+**GDAL/VSI** is the C++ "Virtual File System" baked into GDAL (`vsis3://`, `vsigs://`, `vsicurl://` etc.), which is what `rasterio` uses by default — mature, ubiquitous, but synchronous, and configured through environment variables (`AWS_*`, `GDAL_HTTP_*`).
+*Advantage: `obstore` for new async pipelines, GDAL/VSI for the long tail of formats GDAL already understands.*
 
 **Readers — `RasterioReader`, [`async-tiff`](https://github.com/developmentseed/async-tiff), [`rio-tiler`](https://github.com/cogeotiff/rio-tiler).** This is where bytes become arrays.
-- **`RasterioReader`** — `rasterio`/GDAL-backed, synchronous, the workhorse. Supports every format GDAL does, not just COG. When you just want to open a file and read pixels, this is it.
-- **`async-tiff`** — pure-Rust async COG reader. Parses IFDs and dispatches concurrent tile fetches through `object_store`. No GDAL dependency. Optimised for many-small-tiles workloads (web tile servers, parallel scene processing).
+- **`RasterioReader`** — `rasterio`/GDAL-backed, synchronous, the workhorse.
+  Supports every format GDAL does, not just COG. When you just want to open a file and read pixels, this is it.
+- **`async-tiff`** — pure-Rust async COG reader.
+  Parses IFDs and dispatches concurrent tile fetches through `object_store`.
+  No GDAL dependency.
+  Optimised for many-small-tiles workloads (web tile servers, parallel scene processing).
 - **`rio-tiler`** — handles web-tile coordinate math: given an XYZ tile coordinate, compute the COG pixel window, read it, resample to 256×256, encode as PNG/JPEG.
 
 *Advantage: pick the reader that matches your concurrency model — sync for scripts, async for high-concurrency servers and batch fan-out.*
 
 **Substrate — [`georeader`](https://github.com/spaceml-org/georeader).** A small object model that lets every reader hand back the same shape of object, so downstream code doesn't care which reader produced it.
 - **`GeoTensor`** — an N-D array (numpy `ndarray` subclass) carrying its CRS and affine transform, so coordinate-aware ops never lose georeferencing.
-- **`GeoSlice`** — a declarative crop specification (bounds + CRS + optional time window). Decouples *what region* from *which file*.
+- **`GeoSlice`** — a declarative crop specification (bounds + CRS + optional time window).
+  Decouples *what region* from *which file*.
 - **`GeoData`** — protocol-style container any reader can satisfy.
 - **`GeoCatalog`** — index over `GeoData` instances, queryable by bounds/time/attrs.
 
 *Advantage: a typed carrier means coordinate metadata propagates automatically through pipelines, no `crs=` arguments threaded through every call.*
 
-**Compute — `geotoolz`.** Operator algebra over `GeoTensor`. A single `Operator` is a typed function `GeoTensor → GeoTensor`; `Sequential` composes a linear chain (e.g. `mask → calibrate → NDVI`); `Graph` handles multi-input DAGs (e.g. fusing radar + optical inputs). Mirrors the ergonomics of PyTorch's `nn.Sequential`/`nn.Module` but for georeferenced rasters. *Advantage: composable, testable units with carrier-aware semantics.* See [`plans/geotoolz/`](plans/geotoolz/).
+**Compute — `geotoolz`.** Operator algebra over `GeoTensor`.
+A single `Operator` is a typed function `GeoTensor → GeoTensor`; `Sequential` composes a linear chain (e.g. `mask → calibrate → NDVI`); `Graph` handles multi-input DAGs (e.g. fusing radar + optical inputs).
+Mirrors the ergonomics of PyTorch's `nn.Sequential`/`nn.Module` but for georeferenced rasters.
+*Advantage: composable, testable units with carrier-aware semantics.* See [`plans/geotoolz/`](plans/geotoolz/).
 
 **Viz / UX — [`titiler`](https://github.com/developmentseed/titiler), [`terracotta`](https://github.com/DHI-GRAS/terracotta), [`lonboard`](https://github.com/developmentseed/lonboard).**
-- **`titiler`** — FastAPI-based dynamic tile server. Reads COGs directly from cloud storage and returns XYZ tiles on demand. The standard for "give me a URL, get a slippy map".
-- **`terracotta`** — lighter-weight, SQLite-indexed, pre-processed-tile server. Trades flexibility for raw serving speed.
-- **`lonboard`** — GPU-accelerated Jupyter renderer using deck.gl. Pushes raw arrays straight to the GPU; ideal for inline notebook exploration of millions of pixels.
+- **`titiler`** — FastAPI-based dynamic tile server.
+  Reads COGs directly from cloud storage and returns XYZ tiles on demand.
+  The standard for "give me a URL, get a slippy map".
+- **`terracotta`** — lighter-weight, SQLite-indexed, pre-processed-tile server.
+  Trades flexibility for raw serving speed.
+- **`lonboard`** — GPU-accelerated Jupyter renderer using deck.gl.
+  Pushes raw arrays straight to the GPU; ideal for inline notebook exploration of millions of pixels.
 
 *Advantage: dynamic vs pre-baked tile serving for production; in-notebook GPU rendering for exploration.*
 
@@ -172,12 +243,14 @@ A user asks for a low-cloud Sentinel-2 mosaic of Paris in 2024:
 
 **The trick.** The reader makes *two* round trips — first a cheap header read to learn tile layout, then a fan-out of concurrent range reads for just the tiles that overlap the AOI. That's how you turn a 10 GB scene into a 3 MB transfer.
 
-**What's specific.** GDAL/VSI is the *legacy* transport for synchronous readers; `obstore` is the *modern* transport for async readers. `geotoolz` carries `GeoTensor` (CRS + affine + array) end-to-end so operators stay coordinate-aware.
+**What's specific.** GDAL/VSI is the *legacy* transport for synchronous readers; `obstore` is the *modern* transport for async readers.
+`geotoolz` carries `GeoTensor` (CRS + affine + array) end-to-end so operators stay coordinate-aware.
 
 ### Stack B — Dense (Xarray territory)
 
 **Focus.** Multi-dimensional scientific grids — climate, weather, oceanography.
-**Philosophy.** Coordinate-based DataCubes. Time, altitude, and variable are physical dimensions of a single labelled array.
+**Philosophy.** Coordinate-based DataCubes.
+Time, altitude, and variable are physical dimensions of a single labelled array.
 
 :::{include} diagrams/05_stack_dense.html
 :::
@@ -185,20 +258,29 @@ A user asks for a low-cloud Sentinel-2 mosaic of Paris in 2024:
 #### Layers
 
 **Storage — [Zarr](https://zarr.dev/), [HDF5](https://www.hdfgroup.org/solutions/hdf5/), [NetCDF](https://www.unidata.ucar.edu/software/netcdf/).** All three store N-D arrays plus metadata, but with very different physical layouts.
-- **Zarr** is *cloud-native by design*: the array is split into chunks, each chunk is a separate file (e.g. `var/0.0.5`), and metadata lives in small JSON files (`.zarray`, `.zattrs`). Readers fetch only the chunks they need.
-- **HDF5 / NetCDF-4** are *legacy* monolithic binary formats — single big files with internal B-tree indices. Brilliant on local disk; painful in object storage because reading any chunk often requires walking the tree, which means many small range reads.
+- **Zarr** is *cloud-native by design*: the array is split into chunks, each chunk is a separate file (e.g. `var/0.0.5`), and metadata lives in small JSON files (`.zarray`, `.zattrs`).
+  Readers fetch only the chunks they need.
+- **HDF5 / NetCDF-4** are *legacy* monolithic binary formats — single big files with internal B-tree indices.
+  Brilliant on local disk; painful in object storage because reading any chunk often requires walking the tree, which means many small range reads.
 
-*Advantage of Zarr: parallel reads/writes scale linearly with object-store concurrency. Advantage of HDF5/NetCDF: ubiquitous in climate science and decades of tooling.*
+*Advantage of Zarr: parallel reads/writes scale linearly with object-store concurrency.
+Advantage of HDF5/NetCDF: ubiquitous in climate science and decades of tooling.*
 
-**Transport — [`obstore`](https://github.com/developmentseed/obstore).** Same Rust-backed mover as Stack A. Zarr's "many small files" workload is exactly what `object_store` is tuned for — concurrent GETs without the per-request overhead of `s3fs`/`gcsfs`. *Advantage: makes a Zarr that lives in S3 feel like a Zarr that lives on a fast local disk.*
+**Transport — [`obstore`](https://github.com/developmentseed/obstore).** Same Rust-backed mover as Stack A. Zarr's "many small files" workload is exactly what `object_store` is tuned for — concurrent GETs without the per-request overhead of `s3fs`/`gcsfs`.
+*Advantage: makes a Zarr that lives in S3 feel like a Zarr that lives on a fast local disk.*
 
-**Virtualisation — [`kerchunk`](https://github.com/fsspec/kerchunk) / [VirtualiZarr](https://github.com/zarr-developers/VirtualiZarr).** A clever trick for the legacy formats: scan an HDF5/NetCDF file once, record the byte offsets of every chunk into a small JSON or Parquet "reference file", then expose that reference as a virtual Zarr store. Readers see a Zarr; under the hood `obstore` is doing range reads into the original HDF5. *Advantage: no rewriting of petabytes of legacy data — you get cloud-native access patterns for free.*
+**Virtualisation — [`kerchunk`](https://github.com/fsspec/kerchunk) / [VirtualiZarr](https://github.com/zarr-developers/VirtualiZarr).** A clever trick for the legacy formats: scan an HDF5/NetCDF file once, record the byte offsets of every chunk into a small JSON or Parquet "reference file", then expose that reference as a virtual Zarr store.
+Readers see a Zarr; under the hood `obstore` is doing range reads into the original HDF5. *Advantage: no rewriting of petabytes of legacy data — you get cloud-native access patterns for free.*
 
 **Readers — [`zarr-python`](https://github.com/zarr-developers/zarr-python), [`Icechunk`](https://icechunk.io/), [`stackstac`](https://stackstac.readthedocs.io/) / [`odc-stac`](https://odc-stac.readthedocs.io/), [`lazycogs`](https://github.com/developmentseed/lazycogs).**
-- **`zarr-python`** — the canonical Zarr reader. Recently (Zarr v3) gained a Rust-backed obstore-aware backend.
-- **`Icechunk`** — Earthmover's transactional, version-controlled storage engine on top of Zarr. Adds Git-like snapshots, atomic commits, and time-travel to climate datasets — critical when you're updating a global temperature cube nightly and need rollback semantics.
-- **`stackstac` / `odc-stac`** — the established pattern for "take a STAC item collection, expose it as a spatially-aligned `xarray.DataArray`". GDAL/rasterio under the hood.
-- **`lazycogs`** — DevSeed's Rust-native answer to the same pattern. Same surface (a lazy `(band, time, y, x)` `xarray.DataArray` from a STAC-geoparquet collection of COGs), but the I/O stack is `async-geotiff` + `obstore` + `rustac` (DuckDB on stac-geoparquet) — no GDAL. **Independently validates the GeoCatalog Phase 2 design** by using the same `stac-geoparquet` + DuckDB pattern for catalog discovery.
+- **`zarr-python`** — the canonical Zarr reader.
+  Recently (Zarr v3) gained a Rust-backed obstore-aware backend.
+- **`Icechunk`** — Earthmover's transactional, version-controlled storage engine on top of Zarr.
+  Adds Git-like snapshots, atomic commits, and time-travel to climate datasets — critical when you're updating a global temperature cube nightly and need rollback semantics.
+- **`stackstac` / `odc-stac`** — the established pattern for "take a STAC item collection, expose it as a spatially-aligned `xarray.DataArray`".
+  GDAL/rasterio under the hood.
+- **`lazycogs`** — DevSeed's Rust-native answer to the same pattern.
+  Same surface (a lazy `(band, time, y, x)` `xarray.DataArray` from a STAC-geoparquet collection of COGs), but the I/O stack is `async-geotiff` + `obstore` + `rustac` (DuckDB on stac-geoparquet) — no GDAL. **Independently validates the GeoCatalog Phase 2 design** by using the same `stac-geoparquet` + DuckDB pattern for catalog discovery.
 
 *Advantage: `zarr-python` for vanilla cubes, `Icechunk` when you need ACID-like guarantees on a writable cube, `stackstac` / `odc-stac` for STAC-driven cube assembly via GDAL, `lazycogs` for the same pattern with a Rust-native I/O stack and STAC-geoparquet predicate pushdown.*
 
@@ -209,11 +291,14 @@ A user asks for a low-cloud Sentinel-2 mosaic of Paris in 2024:
 
 *Advantage: coordinate-aware indexing (`ds.sel(time="2024-06", lat=slice(45, 50))`) means you write the science in the units of the science, not array indices.*
 
-**Compute — `xrtoolz`.** Operator algebra over `xarray.Dataset`/`DataArray`, mirroring `geotoolz` but for cubes. Targets the recurring patterns: climatologies (rolling means, seasonal anomalies), regridding (between map projections), EOF / spectral decompositions, and ensemble statistics. *Advantage: composable units that respect xarray's labelled-coordinate semantics, instead of ad-hoc `groupby().mean()` chains scattered across notebooks.*
+**Compute — `xrtoolz`.** Operator algebra over `xarray.Dataset`/`DataArray`, mirroring `geotoolz` but for cubes.
+Targets the recurring patterns: climatologies (rolling means, seasonal anomalies), regridding (between map projections), EOF / spectral decompositions, and ensemble statistics.
+*Advantage: composable units that respect xarray's labelled-coordinate semantics, instead of ad-hoc `groupby().mean()` chains scattered across notebooks.*
 
 **Viz / UX — [`lonboard`](https://github.com/developmentseed/lonboard), [HoloViz](https://holoviz.org/) ([Datashader](https://datashader.org/), [hvPlot](https://hvplot.holoviz.org/)).**
 - **`lonboard`** — pushes raw grid values to the GPU for real-time interaction with scientific data.
-- **HoloViz / Datashader** — server-side aggregation of massive grids into browser-readable rasters. Essential when the data exceeds millions of points and naive rendering would melt the browser.
+- **HoloViz / Datashader** — server-side aggregation of massive grids into browser-readable rasters.
+  Essential when the data exceeds millions of points and naive rendering would melt the browser.
 
 *Advantage: GPU rendering for interactive exploration; server-side aggregation for browser-friendly delivery of huge cubes.*
 
@@ -224,9 +309,11 @@ A climate scientist asks for monthly mean SST over the North Atlantic for 1990�
 :::{include} diagrams/06_lifecycle_dense.html
 :::
 
-**The trick.** Coordinate selection (`.sel`) is translated into chunk indices *before* any bytes are read; only the chunks intersecting the requested coordinate hyperrectangle are fetched. Lazy evaluation through Dask means downstream reductions (`.mean()`) collapse the chunk-fetch + compute graph into a single optimised pass.
+**The trick.** Coordinate selection (`.sel`) is translated into chunk indices *before* any bytes are read; only the chunks intersecting the requested coordinate hyperrectangle are fetched.
+Lazy evaluation through Dask means downstream reductions (`.mean()`) collapse the chunk-fetch + compute graph into a single optimised pass.
 
-**What's specific.** A *virtualisation* layer (`kerchunk`) sits between readers and transport — it makes legacy HDF5/NetCDF behave like Zarr without rewriting the underlying files. `xrtoolz` provides operator composition over `Dataset`/`DataArray` (climatologies, regridding, EOFs, ensemble statistics).
+**What's specific.** A *virtualisation* layer (`kerchunk`) sits between readers and transport — it makes legacy HDF5/NetCDF behave like Zarr without rewriting the underlying files.
+`xrtoolz` provides operator composition over `Dataset`/`DataArray` (climatologies, regridding, EOFs, ensemble statistics).
 
 ### Stack C — Vector (GeoPandas territory)
 
@@ -239,36 +326,49 @@ A climate scientist asks for monthly mean SST over the North Atlantic for 1990�
 #### Layers
 
 **Storage — [GeoParquet](https://geoparquet.org/), [PostgreSQL/PostGIS](https://postgis.net/), [FlatGeobuf](https://flatgeobuf.org/).**
-- **GeoParquet** — the modern standard. Apache Parquet (columnar, compressed, partitioned into row groups) with a spec extension for storing geometries (WKB or GeoArrow encoding) and per-row-group bbox statistics. Cloud-native, range-readable, predicate-pushdown friendly.
-- **PostgreSQL + PostGIS** — the relational gold standard for stateful, multi-user vector data. Stores geometries as binary blobs with R-tree (GiST) indexes; handles concurrent writes and complex spatial joins.
-- **FlatGeobuf** — a streamable flatbuffer format with a packed Hilbert R-tree at the start of the file. Allows fast spatial filtering over plain HTTP without any SQL engine.
+- **GeoParquet** — the modern standard.
+  Apache Parquet (columnar, compressed, partitioned into row groups) with a spec extension for storing geometries (WKB or GeoArrow encoding) and per-row-group bbox statistics.
+  Cloud-native, range-readable, predicate-pushdown friendly.
+- **PostgreSQL + PostGIS** — the relational gold standard for stateful, multi-user vector data.
+  Stores geometries as binary blobs with R-tree (GiST) indexes; handles concurrent writes and complex spatial joins.
+- **FlatGeobuf** — a streamable flatbuffer format with a packed Hilbert R-tree at the start of the file.
+  Allows fast spatial filtering over plain HTTP without any SQL engine.
 
 *Advantage: GeoParquet for analytical workloads on cloud storage; PostGIS for transactional / multi-user; FlatGeobuf for lightweight HTTP-only access patterns.*
 
-**Transport — [`obstore`](https://github.com/developmentseed/obstore), [GDAL/VSI](https://gdal.org/user/virtual_file_systems.html).** `obstore` pulls Parquet row groups from cloud storage; GDAL/VSI is what `pyogrio` uses to interface with the long tail of vector formats (GPKG, SHP, GeoJSON, KML, …). *Advantage: same dual-path story as Stack A — modern async path for Parquet, mature GDAL path for legacy formats.*
+**Transport — [`obstore`](https://github.com/developmentseed/obstore), [GDAL/VSI](https://gdal.org/user/virtual_file_systems.html).** `obstore` pulls Parquet row groups from cloud storage; GDAL/VSI is what `pyogrio` uses to interface with the long tail of vector formats (GPKG, SHP, GeoJSON, KML, …).
+*Advantage: same dual-path story as Stack A — modern async path for Parquet, mature GDAL path for legacy formats.*
 
 **Readers — [`pyogrio`](https://github.com/geopandas/pyogrio), [PostGIS](https://postgis.net/), [Sedona](https://sedona.apache.org/).**
-- **`pyogrio`** — vectorised interface to GDAL/OGR vector drivers. Reads/writes via Arrow buffers, an order of magnitude faster than the legacy `fiona`-based path.
+- **`pyogrio`** — vectorised interface to GDAL/OGR vector drivers.
+  Reads/writes via Arrow buffers, an order of magnitude faster than the legacy `fiona`-based path.
 - **PostGIS** — the actual reader for rows out of a PostgreSQL spatial table; uses GiST indexes for spatial filtering.
-- **Apache Sedona** — distributed engine for petabyte-scale vector data on Spark/Flink clusters. The right tool when "global road network" or "every building footprint on Earth" doesn't fit on one machine.
+- **Apache Sedona** — distributed engine for petabyte-scale vector data on Spark/Flink clusters.
+  The right tool when "global road network" or "every building footprint on Earth" doesn't fit on one machine.
 
 *Advantage: `pyogrio` for single-node analytics, PostGIS for transactional, Sedona for distributed.*
 
 **Substrate — [GeoArrow](https://geoarrow.org/), [GeoPandas](https://geopandas.org/).**
-- **GeoArrow** — a standardised Arrow memory layout for spatial data. Geometries are stored as native Arrow extension types (interleaved or struct coordinates), so DuckDB can hand a query result to `lonboard` *without re-serialising* — both speak Arrow buffers.
-- **GeoPandas** — the Python `DataFrame`-with-a-geometry-column standard. Familiar pandas-like API; in-memory, single-node.
+- **GeoArrow** — a standardised Arrow memory layout for spatial data.
+  Geometries are stored as native Arrow extension types (interleaved or struct coordinates), so DuckDB can hand a query result to `lonboard` *without re-serialising* — both speak Arrow buffers.
+- **GeoPandas** — the Python `DataFrame`-with-a-geometry-column standard.
+  Familiar pandas-like API; in-memory, single-node.
 
 *Advantage: GeoArrow's zero-copy hand-off eliminates the "serialise to GeoJSON, parse, re-serialise" tax that used to dominate vector pipelines.*
 
 **Compute / Engines — [DuckDB](https://duckdb.org/) (with [`spatial`](https://duckdb.org/docs/extensions/spatial/overview)), [PostGIS](https://postgis.net/), [Sedona](https://sedona.apache.org/).**
-- **DuckDB + `spatial`** — in-process SQL engine that reads GeoParquet directly from S3, with predicate pushdown on the bbox column. The closest thing the geospatial world has to "SQLite for analytics".
-- **PostgreSQL + PostGIS** — production multi-user spatial database. Concurrent writes, complex joins, mature query planner.
+- **DuckDB + `spatial`** — in-process SQL engine that reads GeoParquet directly from S3, with predicate pushdown on the bbox column.
+  The closest thing the geospatial world has to "SQLite for analytics".
+- **PostgreSQL + PostGIS** — production multi-user spatial database.
+  Concurrent writes, complex joins, mature query planner.
 - **Sedona** — distributed spatial SQL on Spark.
 
-*Advantage: DuckDB collapses a whole category of "load shapefile → filter in pandas" workflows into a single SQL statement against cloud storage. **This is the engine that powers `GeoCatalog`.***
+*Advantage: DuckDB collapses a whole category of "load shapefile → filter in pandas" workflows into a single SQL statement against cloud storage.
+**This is the engine that powers `GeoCatalog`.***
 
 **Viz / UX — [`lonboard`](https://github.com/developmentseed/lonboard), [Felt](https://felt.com/).**
-- **`lonboard`** — pushes GeoArrow buffers directly to the GPU via deck.gl. Renders millions of polygons smoothly inside Jupyter.
+- **`lonboard`** — pushes GeoArrow buffers directly to the GPU via deck.gl.
+  Renders millions of polygons smoothly inside Jupyter.
 - **Felt** — collaborative web mapping for sharing finished vector products with non-technical stakeholders.
 
 *Advantage: GPU-rendered interactive exploration in notebooks; collaborative web sharing for handoff.*
@@ -280,34 +380,46 @@ An analyst asks for all building footprints in a flood zone:
 :::{include} diagrams/08_lifecycle_vector.html
 :::
 
-**The trick.** Two stages of filtering: (1) **row-group pruning** using the bbox statistics in the Parquet footer skips entire row groups that can't possibly intersect, and only the surviving groups are fetched. (2) **column pruning** means non-needed attribute columns are never read off the wire. The result lands as Arrow buffers, so the hand-off to `lonboard` or GeoPandas is zero-copy.
+**The trick.** Two stages of filtering: (1) **row-group pruning** using the bbox statistics in the Parquet footer skips entire row groups that can't possibly intersect, and only the surviving groups are fetched.
+(2) **column pruning** means non-needed attribute columns are never read off the wire.
+The result lands as Arrow buffers, so the hand-off to `lonboard` or GeoPandas is zero-copy.
 
-**What's specific.** `GeoArrow` enables *zero-copy* hand-off — DuckDB can stream query results straight into `lonboard` without re-serialisation. This is also the stack that powers `GeoCatalog`: the catalog *is* a GeoParquet file queried with DuckDB.
+**What's specific.** `GeoArrow` enables *zero-copy* hand-off — DuckDB can stream query results straight into `lonboard` without re-serialisation.
+This is also the stack that powers `GeoCatalog`: the catalog *is* a GeoParquet file queried with DuckDB.
 
 ---
 
 ## Where my libraries fit
 
-Most of the modern stack is **already there**. Two of the three libraries below (`georeader` modernisation, `GeoCatalog`) are *reconciliation* work — taking pieces that already work and giving them a coherent surface. The third (`geotoolz` + `xrtoolz`) is the genuinely missing piece: the **factory layer** that doesn't yet have a good general-purpose shape.
+Most of the modern stack is **already there**.
+Two of the three libraries below (`georeader` modernisation, `GeoCatalog`) are *reconciliation* work — taking pieces that already work and giving them a coherent surface.
+The third (`geotoolz` + `xrtoolz`) is the genuinely missing piece: the **factory layer** that doesn't yet have a good general-purpose shape.
 
 :::{include} diagrams/09_libraries_fit.html
 :::
 
-Stars mark where my libraries plug in. Read it from the top: a user wants something → engines compose carriers → the registry tells them which files to open → readers translate cloud bytes into typed carriers → transport hauls only the bytes needed → cloud storage is the source of truth.
+Stars mark where my libraries plug in.
+Read it from the top: a user wants something → engines compose carriers → the registry tells them which files to open → readers translate cloud bytes into typed carriers → transport hauls only the bytes needed → cloud storage is the source of truth.
 
 ---
 
 ### 1. Modernising `georeader` *(reconciliation, not invention)*
 
-`georeader` already gives us a clean object model: **`GeoTensor`** (georeferenced array), **`GeoSlice`** (declarative crop), and a small reader surface anchored on **`RasterioReader`**. What it doesn't yet have is a *protocol* — a shared shape every reader can satisfy — which means async / GDAL-free readers reinvent the substrate every time.
+`georeader` already gives us a clean object model: **`GeoTensor`** (georeferenced array), **`GeoSlice`** (declarative crop), and a small reader surface anchored on **`RasterioReader`**.
+What it doesn't yet have is a *protocol* — a shared shape every reader can satisfy — which means async / GDAL-free readers reinvent the substrate every time.
 
 **What plugs in.**
-- **[`async-geotiff`](https://github.com/developmentseed/async-geotiff)** — DevSeed's high-level async COG reader, Rust-backed via [`async-tiff`](https://github.com/developmentseed/async-tiff). Already does IFD walk, tile-fetch, decompression dispatch, request coalescing, and decoding off the event loop. We wrap it in a ~80-LOC `AsyncGeoTIFFReader` adapter.
-- **[`obspec`](https://github.com/developmentseed/obspec)** — the upstream typed Protocol for object-store byte access (DevSeed). [`obstore`](https://github.com/developmentseed/obstore) is the reference implementation. We pass `obspec.AsyncStore` straight through to `async-geotiff`; we don't define our own `ByteStore` Protocol.
+- **[`async-geotiff`](https://github.com/developmentseed/async-geotiff)** — DevSeed's high-level async COG reader, Rust-backed via [`async-tiff`](https://github.com/developmentseed/async-tiff).
+  Already does IFD walk, tile-fetch, decompression dispatch, request coalescing, and decoding off the event loop.
+  We wrap it in a ~80-LOC `AsyncGeoTIFFReader` adapter.
+- **[`obspec`](https://github.com/developmentseed/obspec)** — the upstream typed Protocol for object-store byte access (DevSeed).
+  [`obstore`](https://github.com/developmentseed/obstore) is the reference implementation.
+  We pass `obspec.AsyncStore` straight through to `async-geotiff`; we don't define our own `ByteStore` Protocol.
 
 **What falls out for free.** Today's **`GeoData` / `GeoDataBase`** Protocols stay as the sync surface; we add a single new **`AsyncGeoData`** Protocol mirror (~30 LOC) for the async reader; cross-cutting types (`GeoSlice`, `Credential`) live in a shared home in [`plans/types/`](plans/types/); existing `RasterioReader` keeps doing what it does well; the new async reader is a thin adapter rather than a from-scratch COG reimplementation.
 
-> **What about `lazycogs`?** [`developmentseed/lazycogs`](https://github.com/developmentseed/lazycogs) is excellent — but it returns `xarray.DataArray`, not `GeoTensor`, so it belongs in **Stack B (Dense / xarray)** above as a STAC-driven peer of `stackstac` / `odc-stac`. A sync GDAL-free `GeoTensor` reader for `geotoolz` was floated and deferred to v0.5+ (no clear customer that `RasterioReader` + `AsyncGeoTIFFReader` don't already cover); see [`plans/georeader/README.md` open question §3](plans/georeader/README.md).
+> **What about `lazycogs`?** [`developmentseed/lazycogs`](https://github.com/developmentseed/lazycogs) is excellent — but it returns `xarray.DataArray`, not `GeoTensor`, so it belongs in **Stack B (Dense / xarray)** above as a STAC-driven peer of `stackstac` / `odc-stac`.
+> A sync GDAL-free `GeoTensor` reader for `geotoolz` was floated and deferred to v0.5+ (no clear customer that `RasterioReader` + `AsyncGeoTIFFReader` don't already cover); see [`plans/georeader/README.md` open question §3](plans/georeader/README.md).
 
 **Sensor-specific readers built on the same Protocol.** Once the Reader Protocol stabilises, per-sensor readers slot in without re-inventing the substrate — each handles its own quirks (`+proj=geos` affines, bowtie distortion, irregular file formats) but emits the same `GeoTensor` carrier:
 
@@ -317,7 +429,9 @@ Stars mark where my libraries plug in. Read it from the top: a user wants someth
 
 → [`plans/readers/`](plans/readers/) for the per-sensor designs.
 
-**Honest framing.** This isn't a new library. It's a refactor that turns several already-working tools into a coherent stack with a single Reader Protocol surface. *It's the prerequisite for everything else below* — `geotoolz` operators don't compose if every reader hands back a different shape of object.
+**Honest framing.** This isn't a new library.
+It's a refactor that turns several already-working tools into a coherent stack with a single Reader Protocol surface.
+*It's the prerequisite for everything else below* — `geotoolz` operators don't compose if every reader hands back a different shape of object.
 
 → Designs: [`plans/georeader/`](plans/georeader/), [`plans/types/`](plans/types/), [`plans/readers/`](plans/readers/).
 
@@ -327,23 +441,33 @@ Stars mark where my libraries plug in. Read it from the top: a user wants someth
 
 The pitch in one line: **store metadata as GeoParquet, query it with the tool that fits the scale — GeoPandas for most cases, DuckDB when the catalog gets big.**
 
-**Why now.** [STAC](https://stacspec.org/) is the gold-standard registry at petabyte scale where you have a team running an API. It's overkill for the *lab-scale* problem most teams actually have: a few TB of project data on object storage that you want to slice by bbox + date + attribute without spinning up infrastructure. Meanwhile [GeoParquet](https://geoparquet.org/), [GeoPandas](https://geopandas.org/), and [DuckDB Spatial](https://duckdb.org/docs/extensions/spatial/overview) have matured to the point where the metadata index can be *just another file*.
+**Why now.** [STAC](https://stacspec.org/) is the gold-standard registry at petabyte scale where you have a team running an API. It's overkill for the *lab-scale* problem most teams actually have: a few TB of project data on object storage that you want to slice by bbox + date + attribute without spinning up infrastructure.
+Meanwhile [GeoParquet](https://geoparquet.org/), [GeoPandas](https://geopandas.org/), and [DuckDB Spatial](https://duckdb.org/docs/extensions/spatial/overview) have matured to the point where the metadata index can be *just another file*.
 
 **Two backends, one API.**
 
-- **Phase 1 — GeoPandas in memory.** The catalog is *literally* a `geopandas.GeoDataFrame` with a `pd.IntervalIndex` for time. R-tree spatial indexing and interval-tree temporal lookup come for free from the existing libraries — no new spatial data-structure code. This handles the **90% case**: ≤10⁵ rows, fits in RAM, runs without a query engine. Round-trip via `to_geoparquet(...)` / `from_geoparquet(...)` for portability.
-- **Phase 2 — DuckDB on GeoParquet.** When the catalog grows past ~10⁶ rows or has to live in cloud storage, the same API switches to a `DuckDBGeoCatalog`. SQL queries with predicate pushdown via the GeoParquet 1.1 bbox column; no daemon, no server. Most projects never need this — but the upgrade path is one constructor swap.
+- **Phase 1 — GeoPandas in memory.** The catalog is *literally* a `geopandas.GeoDataFrame` with a `pd.IntervalIndex` for time.
+  R-tree spatial indexing and interval-tree temporal lookup come for free from the existing libraries — no new spatial data-structure code.
+  This handles the **90% case**: ≤10⁵ rows, fits in RAM, runs without a query engine.
+  Round-trip via `to_geoparquet(...)` / `from_geoparquet(...)` for portability.
+- **Phase 2 — DuckDB on GeoParquet.** When the catalog grows past ~10⁶ rows or has to live in cloud storage, the same API switches to a `DuckDBGeoCatalog`.
+  SQL queries with predicate pushdown via the GeoParquet 1.1 bbox column; no daemon, no server.
+  Most projects never need this — but the upgrade path is one constructor swap.
 
 **The point: GeoParquet is the artifact, GeoPandas is the default tool, DuckDB is the scale-up.** You can do 90% of analysis with just the first two — `gpd.read_parquet(...)` plus the geopandas API you already know — and the third joins in transparently when row counts demand it.
 
 **What's in the API.**
-- **Builders** — one per substrate (`build_raster_*`, `build_xarray_*`, `build_vector_*`). Crawl storage once, extract bounds + CRS + timestamps, emit a `GeoCatalog`. Sensor-aware presets handle Sentinel-1/2, MODIS, VIIRS, ABI, SEVIRI, etc.
+- **Builders** — one per substrate (`build_raster_*`, `build_xarray_*`, `build_vector_*`).
+  Crawl storage once, extract bounds + CRS + timestamps, emit a `GeoCatalog`.
+  Sensor-aware presets handle Sentinel-1/2, MODIS, VIIRS, ABI, SEVIRI, etc.
 - **Loaders** — return `GeoTensor` (raster) or `xr.Dataset` (xarray-backed) for each catalog row, ready to compose with operators downstream.
 - **Samplers** — `random_geo_sampler`, `grid_geo_sampler` produce `GeoSlice` objects from the catalog; `stitch_predictions` reassembles inference outputs back into geographic coordinates.
 - **Set algebra** — `intersect`, `union`, `query` for cross-catalog operations (raster × label fusion, multi-sensor pairing, change-detection across epochs).
 - **Adapters** — `GeoDataset` (torch `IterableDataset`); STAC read/write so a STAC catalogue can be lifted into the lighter format and back.
 
-**Honest framing.** Nothing here is new technology. The contribution is the **convention** — the canonical schema, the IntervalIndex+R-tree pairing, the GeoParquet 1.1 bbox column convention — plus a thin Python API that hides the schema and connection plumbing. STAC-compatible read/write keeps the door open when you scale past lab size.
+**Honest framing.** Nothing here is new technology.
+The contribution is the **convention** — the canonical schema, the IntervalIndex+R-tree pairing, the GeoParquet 1.1 bbox column convention — plus a thin Python API that hides the schema and connection plumbing.
+STAC-compatible read/write keeps the door open when you scale past lab size.
 
 → Designs: [`plans/geodatabase/geocatalog.md`](plans/geodatabase/geocatalog.md) (Phase 1, GeoPandas), [`plans/geodatabase/geoduckdb.md`](plans/geodatabase/geoduckdb.md) (Phase 2, DuckDB).
 
@@ -351,58 +475,99 @@ The pitch in one line: **store metadata as GeoParquet, query it with the tool th
 
 ### 3. `geotoolz` + `xrtoolz` — *the factory layer that's missing*
 
-This is the part of the stack where I keep hitting the same gap, regardless of which institution or project I'm working at. The storage / transport / discovery layers have gotten brilliant. The **research-notebook → operational-pipeline** leap is still mostly hand-rolled glue.
+This is the part of the stack where I keep hitting the same gap, regardless of which institution or project I'm working at.
+The storage / transport / discovery layers have gotten brilliant.
+The **research-notebook → operational-pipeline** leap is still mostly hand-rolled glue.
 
 #### What shape is actually missing?
 
-There *are* operator-flavoured libraries in the geospatial ecosystem. Each is excellent at what it does. None of them hits all three of *typed carrier* + *composable algebra* + *backend-agnostic execution*:
+There *are* operator-flavoured libraries in the geospatial ecosystem.
+Each is excellent at what it does.
+None of them hits all three of *typed carrier* + *composable algebra* + *backend-agnostic execution*:
 
-- **[`eo-learn`](https://github.com/sentinel-hub/eo-learn)** (Sentinel Hub) — workflow DAG over Earth-observation tasks. Wraps each step as an `EOTask` operating on a heavyweight `EOPatch` container, chained via `EOWorkflow`. **Different shape:** tightly coupled to `EOPatch` (not a general-purpose carrier); `EOWorkflow` is a *workflow runner*, not an operator algebra in the `nn.Module` sense; designed for batch processing, less so for interactive composition; doesn't address the dense-cube domain.
-- **[`torchgeo`](https://github.com/microsoft/torchgeo)** — PyTorch-native datasets, samplers, and model architectures for ML on remote-sensing imagery. **Different shape:** ML-pipeline focused (`Dataset`/`DataLoader`/`LightningModule`), not a general analysis library; no `Sequential`-style composition for non-ML transforms; doesn't cover cubes.
-- **[`xclim`](https://github.com/Ouranosinc/xclim)** (Ouranos) — climate indicators on `xarray` with rigorous CF-convention handling. **Different shape:** a domain-specific function library tied to climate-index semantics; no composition primitives; each indicator is a standalone callable.
+- **[`eo-learn`](https://github.com/sentinel-hub/eo-learn)** (Sentinel Hub) — workflow DAG over Earth-observation tasks.
+  Wraps each step as an `EOTask` operating on a heavyweight `EOPatch` container, chained via `EOWorkflow`.
+  **Different shape:** tightly coupled to `EOPatch` (not a general-purpose carrier); `EOWorkflow` is a *workflow runner*, not an operator algebra in the `nn.Module` sense; designed for batch processing, less so for interactive composition; doesn't address the dense-cube domain.
+- **[`torchgeo`](https://github.com/microsoft/torchgeo)** — PyTorch-native datasets, samplers, and model architectures for ML on remote-sensing imagery.
+  **Different shape:** ML-pipeline focused (`Dataset`/`DataLoader`/`LightningModule`), not a general analysis library; no `Sequential`-style composition for non-ML transforms; doesn't cover cubes.
+- **[`xclim`](https://github.com/Ouranosinc/xclim)** (Ouranos) — climate indicators on `xarray` with rigorous CF-convention handling.
+  **Different shape:** a domain-specific function library tied to climate-index semantics; no composition primitives; each indicator is a standalone callable.
 - **[`xesmf`](https://github.com/pangeo-data/xESMF)** — regridding between map projections via ESMF. **Different shape:** a single-capability tool, brilliant at it; doesn't claim to be more.
-- **[`xarray-spatial`](https://github.com/makepath/xarray-spatial)** — spatial-analytics primitives (slope, aspect, hillshade, viewshed, focal stats). **Different shape:** a pure-function library; no typed-operator surface, no composition machinery, no backend abstraction.
-- **[`coordax`](https://github.com/neuralgcm/coordax)** (Google / NeuralGCM) — a JAX-native labelled-array library from the NeuralGCM team. Coordinate-aware arrays in the spirit of xarray but built for the differentiable / JAX ecosystem. **Closest thing to the missing carrier shape.** Different shape relative to the *operator-algebra* gap: `coordax` solves the carrier (and the JAX backend) but does not itself ship `Operator`/`Sequential`/`Graph` composition. **The honest take: `xrtoolz` should probably build *on top of* `coordax` rather than reinvent the carrier — and if `coordax` matures further, much of the cube-side work collapses to "just add the operator-algebra layer".**
-- **[`geocube`](https://github.com/corteva/geocube)** — vector-to-raster rasterisation. Narrow scope.
+- **[`xarray-spatial`](https://github.com/makepath/xarray-spatial)** — spatial-analytics primitives (slope, aspect, hillshade, viewshed, focal stats).
+  **Different shape:** a pure-function library; no typed-operator surface, no composition machinery, no backend abstraction.
+- **[`coordax`](https://github.com/neuralgcm/coordax)** (Google / NeuralGCM) — a JAX-native labelled-array library from the NeuralGCM team.
+  Coordinate-aware arrays in the spirit of xarray but built for the differentiable / JAX ecosystem.
+  **Closest thing to the missing carrier shape.** Different shape relative to the *operator-algebra* gap: `coordax` solves the carrier (and the JAX backend) but does not itself ship `Operator`/`Sequential`/`Graph` composition.
+  **The honest take: `xrtoolz` should probably build *on top of* `coordax` rather than reinvent the carrier — and if `coordax` matures further, much of the cube-side work collapses to "just add the operator-algebra layer".**
+- **[`geocube`](https://github.com/corteva/geocube)** — vector-to-raster rasterisation.
+  Narrow scope.
 - **[`rio-cogeo`](https://github.com/cogeotiff/rio-cogeo)**, **[`pyresample`](https://github.com/pytroll/pyresample)**, **[`rasterio.features`](https://rasterio.readthedocs.io/en/stable/topics/features.html)** — single-purpose utility libraries, not algebras.
 
-What's missing is a **general-purpose operator algebra over typed georeferenced carriers** — the `nn.Module`/`Sequential`/`Graph` shape, but for `GeoTensor` (raster) and `Dataset`/`DataArray`/`coordax.Array` (cube). The libraries above each fill *one or two* of those properties; none combines all three. `coordax` gets us closest, and is treated below as a likely *foundation* for the cube side rather than competition.
+What's missing is a **general-purpose operator algebra over typed georeferenced carriers** — the `nn.Module`/`Sequential`/`Graph` shape, but for `GeoTensor` (raster) and `Dataset`/`DataArray`/`coordax.Array` (cube).
+The libraries above each fill *one or two* of those properties; none combines all three.
+`coordax` gets us closest, and is treated below as a likely *foundation* for the cube side rather than competition.
 
 #### The two-layer ladder *(Keras-style progression of complexity)*
 
-One of the best lessons from Keras is that **complexity should be opt-in**. Beginners reach for `model = Sequential([Dense(10), Dense(1)])`; experts reach for the functional API or `Module` subclasses. The same library scales with the user's expertise. `geotoolz` and `xrtoolz` apply the same lesson:
+One of the best lessons from Keras is that **complexity should be opt-in**.
+Beginners reach for `model = Sequential([Dense(10), Dense(1)])`; experts reach for the functional API or `Module` subclasses.
+The same library scales with the user's expertise.
+`geotoolz` and `xrtoolz` apply the same lesson:
 
-- **Layer 0 — Primitives.** Pure `np.ndarray → np.ndarray` functions, jaxtyped at the signature (`Float[ndarray, "*batch bands H W"]`) so callers see expected dimensions in their IDE. `ndvi(arr)`, `mask(arr, cloud_mask)`, `lee_speckle(arr, window=7)`. Drop-in replacements for the one-liner you'd write today; nothing to learn beyond Python functions + jaxtyping shape annotations.
-- **Layer 1 — Operators.** Composable typed objects on the carrier: `NDVI()`, `Mask()`, `LeeSpeckle()`. Take and return `GeoTensor`. Plug into `Sequential` chains and `Graph` DAGs. Pickle-able, version-pinnable, swappable, testable in isolation.
+- **Layer 0 — Primitives.** Pure `np.ndarray → np.ndarray` functions, jaxtyped at the signature (`Float[ndarray, "*batch bands H W"]`) so callers see expected dimensions in their IDE. `ndvi(arr)`, `mask(arr, cloud_mask)`, `lee_speckle(arr, window=7)`.
+  Drop-in replacements for the one-liner you'd write today; nothing to learn beyond Python functions + jaxtyping shape annotations.
+- **Layer 1 — Operators.** Composable typed objects on the carrier: `NDVI()`, `Mask()`, `LeeSpeckle()`.
+  Take and return `GeoTensor`.
+  Plug into `Sequential` chains and `Graph` DAGs.
+  Pickle-able, version-pinnable, swappable, testable in isolation.
 
-The same operation lives at both layers — `NDVI()(tensor)` and `ndvi(np.asarray(tensor))` produce the same result. The choice is ergonomic, not semantic. *This is the on-ramp that lets a researcher write a one-liner today, lift it into a pipeline tomorrow, and ship it as a serving endpoint next month — without rewriting.*
+The same operation lives at both layers — `NDVI()(tensor)` and `ndvi(np.asarray(tensor))` produce the same result.
+The choice is ergonomic, not semantic.
+*This is the on-ramp that lets a researcher write a one-liner today, lift it into a pipeline tomorrow, and ship it as a serving endpoint next month — without rewriting.*
 
-*(`geotoolz` deliberately ships **only** these two tiers, where its sibling `xrtoolz` ships three. The asymmetry is architectural: `GeoTensor` is an `np.ndarray` subclass with `__array_ufunc__`, so metadata round-trips through ufunc-pure primitives for free, and non-ufunc primitives get wrapped at the Operator boundary in a single line. `xarray.DataArray` is composition over `ndarray`, not a subclass — its middle "tensor function" tier earns its keep. Substrate dictates tier count.)*
+*(`geotoolz` deliberately ships **only** these two tiers, where its sibling `xrtoolz` ships three.
+The asymmetry is architectural: `GeoTensor` is an `np.ndarray` subclass with `__array_ufunc__`, so metadata round-trips through ufunc-pure primitives for free, and non-ufunc primitives get wrapped at the Operator boundary in a single line.
+`xarray.DataArray` is composition over `ndarray`, not a subclass — its middle "tensor function" tier earns its keep.
+Substrate dictates tier count.)*
 
 #### The pattern
 
-- **`Operator`** — a typed function `Carrier → Carrier`. Stateful when needed (config, learnable weights), stateless otherwise.
+- **`Operator`** — a typed function `Carrier → Carrier`.
+  Stateful when needed (config, learnable weights), stateless otherwise.
 - **`Sequential`** — a linear chain of operators with type-checked composition.
 - **`Graph`** — a multi-input DAG built from `Input` and `Node` primitives, for fusion workflows (e.g. radar + optical + DEM into a single classifier).
-- **`ModelOp`** — a framework-agnostic operator that wraps any callable from `torch`, `jax`, or `sklearn`. Inference becomes just another node in the graph.
-- **Sensor presets** — one-line constructors (`Sentinel2RGB()`, `S2NDVI()`, `EmitMethanePlume()`, …) that pre-configure entire pipelines for common sensors. Newcomers get a working pipeline in a single line; experts pop the hood and inspect the operator chain.
+- **`ModelOp`** — a framework-agnostic operator that wraps any callable from `torch`, `jax`, or `sklearn`.
+  Inference becomes just another node in the graph.
+- **Sensor presets** — one-line constructors (`Sentinel2RGB()`, `S2NDVI()`, `EmitMethanePlume()`, …) that pre-configure entire pipelines for common sensors.
+  Newcomers get a working pipeline in a single line; experts pop the hood and inspect the operator chain.
 - **Hydra / hydra-zen friendly.** Every Operator is config-serialisable, so YAML-driven pipelines are first-class — the same graph runs from a notebook, a script, or a config file.
-- **Carrier-aware.** CRS, transform, coordinates, units, fill values propagate automatically. The pipeline stays geographically honest without manual bookkeeping.
+- **Carrier-aware.** CRS, transform, coordinates, units, fill values propagate automatically.
+  The pipeline stays geographically honest without manual bookkeeping.
 - **Backend-agnostic.** ***Carriers determine the surface, backends determine the scale.***
 
 #### Why this matters — the use-case spectrum
 
 The same operator graph supports:
 
-- **Research notebooks** — composition of typed building blocks beats a 200-line one-shot script. Easier to read, easier to share.
-- **Production pipelines** — the same graph runs in CI, batch jobs, scheduled tasks. No translation step.
-- **Backend APIs / model serving** — lift the research graph straight into a FastAPI handler or a streaming worker. The operator graph *is* the request handler. No glue layer to maintain.
-- **Reproducibility & governance** — operator graphs are serialisable, version-pinnable, and auditable. Run the same analysis on the same inputs years later; ship it as a regulatory deliverable; diff two analyses.
-- **Composability across teams** — operators are installable units. A colleague's calibration operator drops into your pipeline like a Python package, because it *is* one. (`eo-learn`'s vision tied to `EOPatch`; this version is carrier-typed and lighter.)
-- **Testability** — every operator is a typed function. Golden-file regression tests, property-based tests, and isolation testing become trivial.
-- **Education / pedagogy** — composition of typed blocks is easier to teach than monolithic notebooks. Students learn the *shape* of an analysis instead of memorising a script.
+- **Research notebooks** — composition of typed building blocks beats a 200-line one-shot script.
+  Easier to read, easier to share.
+- **Production pipelines** — the same graph runs in CI, batch jobs, scheduled tasks.
+  No translation step.
+- **Backend APIs / model serving** — lift the research graph straight into a FastAPI handler or a streaming worker.
+  The operator graph *is* the request handler.
+  No glue layer to maintain.
+- **Reproducibility & governance** — operator graphs are serialisable, version-pinnable, and auditable.
+  Run the same analysis on the same inputs years later; ship it as a regulatory deliverable; diff two analyses.
+- **Composability across teams** — operators are installable units.
+  A colleague's calibration operator drops into your pipeline like a Python package, because it *is* one.
+  (`eo-learn`'s vision tied to `EOPatch`; this version is carrier-typed and lighter.)
+- **Testability** — every operator is a typed function.
+  Golden-file regression tests, property-based tests, and isolation testing become trivial.
+- **Education / pedagogy** — composition of typed blocks is easier to teach than monolithic notebooks.
+  Students learn the *shape* of an analysis instead of memorising a script.
 
-The throughline: **the gap I keep running into, across affiliations and projects, is the research-to-production translation step.** The modern stack has gotten brilliant at storage and transport; the *factory layer* that lets a research idea graduate into operational infrastructure without a rewrite is still mostly hand-rolled. That's what these libraries aim at.
+The throughline: **the gap I keep running into, across affiliations and projects, is the research-to-production translation step.** The modern stack has gotten brilliant at storage and transport; the *factory layer* that lets a research idea graduate into operational infrastructure without a rewrite is still mostly hand-rolled.
+That's what these libraries aim at.
 
 #### The scale spectrum
 
@@ -414,13 +579,17 @@ The same composition pattern carries across data sizes — *the carrier determin
 | **Medium** | fits on one box, doesn't fit in RAM | Dask, async batch, Ray | per-tile parallel processing, daily-scale pipelines — same operators dispatched per chunk/tile |
 | **Big** | needs a cluster | distributed JAX (via `coordax`) | continental-scale ensemble analyses — same composition pattern, JAX-backed carriers |
 
-The architectural commitment: operators don't bake in a backend. They run on whatever the carrier wraps.
+The architectural commitment: operators don't bake in a backend.
+They run on whatever the carrier wraps.
 
-**Honest scope.** "Same operator everywhere" holds for **single-machine numpy, Dask-orchestrated batch, and distributed JAX** — same composition pattern, sometimes with backend-specific implementations under one signature. Sedona / Spark and other distributed-SQL engines are *not* covered by the same code path; if you need them, the operator graph would have to emit Sedona SQL, which is a separate library and not currently planned. We'd rather deliver the 80% case cleanly than over-promise the 100%.
+**Honest scope.** "Same operator everywhere" holds for **single-machine numpy, Dask-orchestrated batch, and distributed JAX** — same composition pattern, sometimes with backend-specific implementations under one signature.
+Sedona / Spark and other distributed-SQL engines are *not* covered by the same code path; if you need them, the operator graph would have to emit Sedona SQL, which is a separate library and not currently planned.
+We'd rather deliver the 80% case cleanly than over-promise the 100%.
 
 #### Honest research-to-prod scope
 
-"Production" is a slippery word. The marquee pitch — *the same operator graph runs in a notebook and a serving endpoint* — holds for these targets:
+"Production" is a slippery word.
+The marquee pitch — *the same operator graph runs in a notebook and a serving endpoint* — holds for these targets:
 
 - ✅ **Notebooks** (Jupyter, Marimo) — the native habitat.
 - ✅ **Scripts** (`python pipeline.py`) — pickle-able Operator graphs.
@@ -430,16 +599,24 @@ The architectural commitment: operators don't bake in a backend. They run on wha
 
 What is *not* directly covered:
 
-- ⚠️ **Distributed SQL engines** (Sedona, Spark, Snowflake) — different paradigm. Would require emitting SQL from operator graphs (out of scope, possible future work).
-- ⚠️ **Streaming pipelines** (Flink, Beam, Kafka Streams) — operator graphs aren't streaming-aware. Wrapping each Operator as a Flink UDF works but loses composition guarantees.
+- ⚠️ **Distributed SQL engines** (Sedona, Spark, Snowflake) — different paradigm.
+  Would require emitting SQL from operator graphs (out of scope, possible future work).
+- ⚠️ **Streaming pipelines** (Flink, Beam, Kafka Streams) — operator graphs aren't streaming-aware.
+  Wrapping each Operator as a Flink UDF works but loses composition guarantees.
 - ⚠️ **Edge / mobile inference** (TFLite, ONNX runtime on mobile) — `ModelOp` wraps a callable; if the callable is exportable (ONNX), you ship the *model*, not the surrounding pre/post-processing operators.
 
-The 80% case (notebook → API / pipeline / orchestrator / batch) is the deliverable target. The 20% (streaming, distributed SQL, edge) is acknowledged out-of-scope rather than promised and missed.
+The 80% case (notebook → API / pipeline / orchestrator / batch) is the deliverable target.
+The 20% (streaming, distributed SQL, edge) is acknowledged out-of-scope rather than promised and missed.
 
 #### Specialisations
 
-- **`geotoolz`** — carrier = **`GeoTensor`**. Domain = imagery (band math, cloud masking, atmospheric calibration, sensor presets, tile assembly, reprojection). Mirrors the "PyTorch for georeferenced rasters" shape. → [`plans/geotoolz/`](plans/geotoolz/).
-- **`xrtoolz`** — carrier = **`xarray.Dataset` / `DataArray`**, with a JAX-native option via **[`coordax`](https://github.com/neuralgcm/coordax)** (NeuralGCM's labelled-array library). Domain = dense cubes (climatologies, regridding, EOFs, anomalies, ensemble statistics, spectral analysis). The carrier story is largely already solved — `xarray` for numpy/Dask, `coordax` for JAX — so `xrtoolz`'s contribution is the *operator-algebra layer* on top, mirroring `geotoolz`'s `Operator`/`Sequential`/`Graph` shape. Don't reinvent the array; build the algebra. → [github.com/jejjohnson/xr_toolz](https://github.com/jejjohnson/xr_toolz).
+- **`geotoolz`** — carrier = **`GeoTensor`**.
+  Domain = imagery (band math, cloud masking, atmospheric calibration, sensor presets, tile assembly, reprojection).
+  Mirrors the "PyTorch for georeferenced rasters" shape. → [`plans/geotoolz/`](plans/geotoolz/).
+- **`xrtoolz`** — carrier = **`xarray.Dataset` / `DataArray`**, with a JAX-native option via **[`coordax`](https://github.com/neuralgcm/coordax)** (NeuralGCM's labelled-array library).
+  Domain = dense cubes (climatologies, regridding, EOFs, anomalies, ensemble statistics, spectral analysis).
+  The carrier story is largely already solved — `xarray` for numpy/Dask, `coordax` for JAX — so `xrtoolz`'s contribution is the *operator-algebra layer* on top, mirroring `geotoolz`'s `Operator`/`Sequential`/`Graph` shape.
+  Don't reinvent the array; build the algebra. → [github.com/jejjohnson/xr_toolz](https://github.com/jejjohnson/xr_toolz).
 
 ---
 
@@ -447,21 +624,27 @@ The 80% case (notebook → API / pipeline / orchestrator / batch) is the deliver
 
 The cross-cutting types that flow *between* layers each get their own design — small, but load-bearing.
 
-- **`GeoSlice`** — declarative crop specification (bbox + CRS + optional time window). Decouples *what region* from *which file*; produced by samplers, consumed by readers and operators. → [`plans/types/geoslice.md`](plans/types/geoslice.md).
-- **`Credential`** — Protocol + per-cloud subclasses (Azure SAS / managed identity, AWS static / profile, GCS service account) + `from_config(...)` factory. Replaces the env-var-soup pattern every project currently re-implements. → [`plans/types/credentials.md`](plans/types/credentials.md).
-- **Cloud byte transport — defer to [`obspec`](https://github.com/developmentseed/obspec).** We don't ship a Protocol of our own; `obspec.AsyncStore` is the upstream surface and `async-geotiff` already consumes it. We ship one tiny `geotoolz.io.open_store(url)` factory and nothing else. → [`plans/types/bytestore.md`](plans/types/bytestore.md).
+- **`GeoSlice`** — declarative crop specification (bbox + CRS + optional time window).
+  Decouples *what region* from *which file*; produced by samplers, consumed by readers and operators. → [`plans/types/geoslice.md`](plans/types/geoslice.md).
+- **`Credential`** — Protocol + per-cloud subclasses (Azure SAS / managed identity, AWS static / profile, GCS service account) + `from_config(...)` factory.
+  Replaces the env-var-soup pattern every project currently re-implements. → [`plans/types/credentials.md`](plans/types/credentials.md).
+- **Cloud byte transport — defer to [`obspec`](https://github.com/developmentseed/obspec).** We don't ship a Protocol of our own; `obspec.AsyncStore` is the upstream surface and `async-geotiff` already consumes it.
+  We ship one tiny `geotoolz.io.open_store(url)` factory and nothing else. → [`plans/types/bytestore.md`](plans/types/bytestore.md).
 
 ---
 
 ### Future work — JAX bridge *(via `coordax`)*
 
-`GeoTensor` is a `numpy.ndarray` subclass — fine for 99% of cases, but it walls off **differentiability**. The future-work direction is a thin bridge that translates `GeoTensor ↔ jax.Array` (most likely via `coordax`'s coordinate-aware array) while preserving CRS / transform metadata, opening the door to:
+`GeoTensor` is a `numpy.ndarray` subclass — fine for 99% of cases, but it walls off **differentiability**.
+The future-work direction is a thin bridge that translates `GeoTensor ↔ jax.Array` (most likely via `coordax`'s coordinate-aware array) while preserving CRS / transform metadata, opening the door to:
 
 - **Differentiable operators** — calibration, atmospheric correction, geometric warps as learnable layers.
 - **Surrogate models** — physics-informed networks where the simulator and the data sit in the same operator graph.
 - **End-to-end training** — gradients propagating through the geospatial pipeline.
 
-The bridge does **not** need to be invented from scratch — [`coordax`](https://github.com/neuralgcm/coordax) is JAX-native, coordinate-aware, and probably the right backbone. The real work is the `GeoTensor ↔ coordax.Array` adapter and the CRS-preserving operator implementations, not a new array library. (An earlier working name for this glue was `geoarrax`; if `coordax` keeps maturing, even the glue may shrink to a handful of converter functions.)
+The bridge does **not** need to be invented from scratch — [`coordax`](https://github.com/neuralgcm/coordax) is JAX-native, coordinate-aware, and probably the right backbone.
+The real work is the `GeoTensor ↔ coordax.Array` adapter and the CRS-preserving operator implementations, not a new array library.
+(An earlier working name for this glue was `geoarrax`; if `coordax` keeps maturing, even the glue may shrink to a handful of converter functions.)
 
 Out of scope for the initial library push; flagged here so the architecture leaves room for it — operators avoid `numpy`-only assumptions, carriers stay duck-typed where possible.
 
@@ -486,7 +669,8 @@ Out of scope for the initial library push; flagged here so the architecture leav
 
 ## See also
 
-- [`plans/geostack.md`](plans/geostack.md) — the engineering-focused ecosystem reference (strategy tables, bytes-paths triage, end-to-end flows). Eventually this motivation doc will merge in.
+- [`plans/geostack.md`](plans/geostack.md) — the engineering-focused ecosystem reference (strategy tables, bytes-paths triage, end-to-end flows).
+  Eventually this motivation doc will merge in.
 - [`plans/geotoolz/`](plans/geotoolz/) — `geotoolz` operator library design.
 - [`plans/geodatabase/`](plans/geodatabase/) — `GeoCatalog` + DuckDB backend design.
 - [`plans/georeader/`](plans/georeader/) — reader Protocols and concrete reader designs.
@@ -495,7 +679,8 @@ Out of scope for the initial library push; flagged here so the architecture leav
 
 ### The success-story anchor
 
-The motivation in this doc is anchored on a concrete, projected end-to-end pipeline: **MARS-style methane attribution** rebuilt on the unified stack across three instruments (TROPOMI + GHGSat + EMIT) and three orchestration phases (research notebook → batch pipeline → FastAPI alert service). The full plan lives in:
+The motivation in this doc is anchored on a concrete, projected end-to-end pipeline: **MARS-style methane attribution** rebuilt on the unified stack across three instruments (TROPOMI + GHGSat + EMIT) and three orchestration phases (research notebook → batch pipeline → FastAPI alert service).
+The full plan lives in:
 
 - [`operational_attribution.md`](operational_attribution.md) — projected end-to-end pipeline + validation plan + migration story from current MARS-style work.
 

--- a/projects/geotoolz/operational_attribution.md
+++ b/projects/geotoolz/operational_attribution.md
@@ -15,25 +15,32 @@ license: CC-BY-4.0
 keywords: methane, attribution, plume, MARS, geotoolz, plumax, operational, satellite
 ---
 
-> **Status.** Forward-looking plan. Projected pipeline assuming the unified stack lands. Treats everything except the current `georeader` package as future work.
->
-> **Scope.** MARS-style methane source attribution from satellite observations. Three instruments (TROPOMI + GHGSat + EMIT). Covers **exploration, preprocessing, inference, and serving** — explicitly **not** model training.
->
+> **Status.** Forward-looking plan.
+> Projected pipeline assuming the unified stack lands.
+> Treats everything except the current `georeader` package as future work.
+> **Scope.** MARS-style methane source attribution from satellite observations.
+> Three instruments (TROPOMI + GHGSat + EMIT).
+> Covers **exploration, preprocessing, inference, and serving** — explicitly **not** model training.
 > **Audience.** Three layers in one doc: an executive summary for funders/talks, an architectural plan for engineers, a validation + migration story for paper/blog framing.
 
 ---
 
 ## TL;DR
 
-Methane attribution from satellite imagery — *"this scene shows a plume; what is the source rate, where is the source, with what uncertainty?"* — is what UNEP-IMEO's **Methane Alert and Response System (MARS)** does operationally today. It works. It's also rebuilt as bespoke glue code in nearly every research project that touches the same problem. *Across the institutions I've worked at — FIT, RIT, Universidad de Valencia, CNRS, CSIC, UNEP-IMEO, MARS — the same research-to-production gap appears every time, with the storage and transport layers getting steadily better while the **factory layer** (the science composition) stays hand-rolled.*
+Methane attribution from satellite imagery — *"this scene shows a plume; what is the source rate, where is the source, with what uncertainty?"* — is what UNEP-IMEO's **Methane Alert and Response System (MARS)** does operationally today.
+It works.
+It's also rebuilt as bespoke glue code in nearly every research project that touches the same problem.
+*Across the institutions I've worked at — FIT, RIT, Universidad de Valencia, CNRS, CSIC, UNEP-IMEO, MARS — the same research-to-production gap appears every time, with the storage and transport layers getting steadily better while the **factory layer** (the science composition) stays hand-rolled.*
 
-This doc projects what an operational attribution pipeline looks like once the unified stack lands: **`georeader` 2.0 (modernised reader Protocol), `GeoCatalog` (multi-satellite metadata index), `geotoolz`/`xrtoolz` (operator algebra), `plumax` (forward models)**. The same operator graph runs in:
+This doc projects what an operational attribution pipeline looks like once the unified stack lands: **`georeader` 2.0 (modernised reader Protocol), `GeoCatalog` (multi-satellite metadata index), `geotoolz`/`xrtoolz` (operator algebra), `plumax` (forward models)**.
+The same operator graph runs in:
 
 1. **A research notebook** — exploration, single-event analysis, MAP via NumPyro.
 2. **A batch pipeline** — last-week's-overpasses fanned out across detections, posteriors written to GeoParquet.
 3. **An alert service** — a FastAPI handler that takes a detection event and returns a posterior in seconds.
 
-One graph, three orchestration modes, zero rewrites between research and production. *That's* the substrate gap this stack is meant to close.
+One graph, three orchestration modes, zero rewrites between research and production.
+*That's* the substrate gap this stack is meant to close.
 
 ---
 
@@ -43,8 +50,11 @@ MARS-style attribution is a real, deployed operational system at UNEP-IMEO. **Th
 
 Two motivations sit underneath:
 
-1. **The same pipeline shape recurs everywhere.** Methane plume attribution, NO₂ inversion, CO₂ flux estimation, oil-spill backtracking, wildfire-emission attribution — all are: *(satellite L1/L2 data) → (forward model with met forcing) → (Bayesian inversion) → (posterior on source parameters)*. The science differs; the **plumbing is identical**. Today every project rebuilds the plumbing.
-2. **MARS is a proof point that the operational form exists.** The constraint isn't "can this be done"; it's "can this be done with a *unified, composable, reproducible* substrate that other groups can pick up and extend without re-implementing the IO layer". Plumax + geotoolz is that substrate.
+1. **The same pipeline shape recurs everywhere.** Methane plume attribution, NO₂ inversion, CO₂ flux estimation, oil-spill backtracking, wildfire-emission attribution — all are: *(satellite L1/L2 data) → (forward model with met forcing) → (Bayesian inversion) → (posterior on source parameters)*.
+   The science differs; the **plumbing is identical**.
+   Today every project rebuilds the plumbing.
+2. **MARS is a proof point that the operational form exists.** The constraint isn't "can this be done"; it's "can this be done with a *unified, composable, reproducible* substrate that other groups can pick up and extend without re-implementing the IO layer".
+   Plumax + geotoolz is that substrate.
 
 This doc projects how the v1 plumax target — **Tier I + AK + multi-satellite L2 fusion across {TROPOMI, GHGSat, EMIT}** — would be implemented end-to-end on the unified stack, with three orchestration phases demonstrating the research-to-prod arc.
 
@@ -106,13 +116,15 @@ Operational attribution today is the composition of half a dozen well-understood
 | Inference loop | NumPyro / TensorFlow Probability / Stan, hand-wired to the forward; switching requires rewriting | Slow methods iteration |
 | Operational delivery | Inference moved into a FastAPI / Cloud Function via cut-and-paste from the research notebook; metadata round-trips lost | Production code drifts from research code; can't validate prod against research |
 
-The unified stack closes each of these seams with a typed, composable surface. The next sections show how.
+The unified stack closes each of these seams with a typed, composable surface.
+The next sections show how.
 
 ---
 
 ## 3. The three-instrument scope
 
-The v1 target is **TROPOMI + GHGSat + EMIT** — the same set the [Tier IV plumax design](../plume_simulation/notes/roadmap/05_tier4_coupled.md) targets for v1 multi-instrument fusion. Each instrument contributes a different role; the demo's value is precisely in the *fusion*, not in any single instrument.
+The v1 target is **TROPOMI + GHGSat + EMIT** — the same set the [Tier IV plumax design](../plume_simulation/notes/roadmap/05_tier4_coupled.md) targets for v1 multi-instrument fusion.
+Each instrument contributes a different role; the demo's value is precisely in the *fusion*, not in any single instrument.
 
 | Instrument | Role | Resolution | Cadence | Native product | What it constrains |
 |---|---|---|---|---|---|
@@ -122,9 +134,12 @@ The v1 target is **TROPOMI + GHGSat + EMIT** — the same set the [Tier IV pluma
 
 **Why these three, why this fusion:**
 
-- **Independent verification.** Three independent instruments observing the same plume with different physics (TROPOMI's full-disk averaging-kernel, GHGSat's pointed retrieval, EMIT's hyperspectral matched-filter) is the strongest possible evidence basis for an attribution claim. Single-instrument attributions are routinely contested.
-- **Different latencies.** TROPOMI is ~near-real-time global; GHGSat is tasked (latency ~hours); EMIT is ISS-cadence (latency ~days). The fusion is *temporally heterogeneous* — `Q(t)` as a stochastic process (per [Tier IV §3](../plume_simulation/notes/roadmap/05_tier4_coupled.md)) handles this naturally.
-- **Different state-vector constraints.** TROPOMI constrains regional background; GHGSat constrains source rate; EMIT validates the plume signature spectrally. Together they solve a system that no single instrument solves alone.
+- **Independent verification.** Three independent instruments observing the same plume with different physics (TROPOMI's full-disk averaging-kernel, GHGSat's pointed retrieval, EMIT's hyperspectral matched-filter) is the strongest possible evidence basis for an attribution claim.
+  Single-instrument attributions are routinely contested.
+- **Different latencies.** TROPOMI is ~near-real-time global; GHGSat is tasked (latency ~hours); EMIT is ISS-cadence (latency ~days).
+  The fusion is *temporally heterogeneous* — `Q(t)` as a stochastic process (per [Tier IV §3](../plume_simulation/notes/roadmap/05_tier4_coupled.md)) handles this naturally.
+- **Different state-vector constraints.** TROPOMI constrains regional background; GHGSat constrains source rate; EMIT validates the plume signature spectrally.
+  Together they solve a system that no single instrument solves alone.
 - **MARS pattern.** This three-instrument fusion is the operational reality at UNEP-IMEO. The unified stack should match that reality without forcing a re-architecture.
 
 **What's explicitly out of scope for v1:** Sentinel-2 / Landsat (cloud-shadow vegetation-index methane proxies — useful but different physics); PRISMA / Tanager (similar to EMIT, additive once the EMIT pipeline works); CarbonMapper (commercial, schema TBD).
@@ -133,7 +148,8 @@ The v1 target is **TROPOMI + GHGSat + EMIT** — the same set the [Tier IV pluma
 
 ## 4. Mapping the unified stack to the attribution pipeline
 
-Each layer of the [geostack](geostack_notes.md) maps onto a concrete piece of the attribution pipeline. The point of the table below is that **none of this is novel science** — the science modules already have well-understood mathematical structure; the substrate work is making them compose cleanly.
+Each layer of the [geostack](geostack_notes.md) maps onto a concrete piece of the attribution pipeline.
+The point of the table below is that **none of this is novel science** — the science modules already have well-understood mathematical structure; the substrate work is making them compose cleanly.
 
 ```text
         ┌─────────────────────────────────────────────────────────────┐
@@ -170,19 +186,24 @@ Layer by layer, what each contributes to the attribution pipeline:
 
 ### 4.1 Storage
 
-Already exists. EMIT lives on AWS / DAAC; TROPOMI on Copernicus / GES DISC; GHGSat on the vendor's portal; ERA5 on Copernicus CDS; WRF outputs on local compute. **No new storage** — the unified stack is about access patterns, not new repositories.
+Already exists.
+EMIT lives on AWS / DAAC; TROPOMI on Copernicus / GES DISC; GHGSat on the vendor's portal; ERA5 on Copernicus CDS; WRF outputs on local compute.
+**No new storage** — the unified stack is about access patterns, not new repositories.
 
 ### 4.2 Transport — `obstore`
 
-Single byte mover for all cloud buckets. Three concrete payoffs over the current per-project mix of `s3fs` / `boto3` / `gcsfs`:
+Single byte mover for all cloud buckets.
+Three concrete payoffs over the current per-project mix of `s3fs` / `boto3` / `gcsfs`:
 
 - Concurrent range reads make per-event AOI extraction (e.g. EMIT 1 km × 1 km AOI from a 100 km × 50 km scene) feasible without downloading the whole scene.
 - One credential model across S3 / GCS / Azure (where MARS partner data lives) — the [`Credential`](plans/types/credentials.md) Protocol abstracts the auth dance.
-- Reproducibility — `obstore` calls are pure functions of `(url, range, credential)`. No global env-var state.
+- Reproducibility — `obstore` calls are pure functions of `(url, range, credential)`.
+  No global env-var state.
 
 ### 4.3 Substrate — modernised `georeader` + per-sensor readers
 
-The most concrete user-visible payoff. Today's per-project ingest replaced with five typed readers conforming to one Protocol:
+The most concrete user-visible payoff.
+Today's per-project ingest replaced with five typed readers conforming to one Protocol:
 
 | Reader | Status today | What lands in the unified stack |
 |---|---|---|
@@ -196,11 +217,15 @@ Cross-cutting: `Credential` (typed Protocol per [`plans/types/credentials.md`](p
 
 ### 4.4 Discovery — `GeoCatalog`
 
-The single biggest leap from "hand-rolled per project" to "shared substrate". The catalog is a **multi-satellite spatiotemporal index** keyed on `(instrument, time, footprint, quality, native_url)`.
+The single biggest leap from "hand-rolled per project" to "shared substrate".
+The catalog is a **multi-satellite spatiotemporal index** keyed on `(instrument, time, footprint, quality, native_url)`.
 
-**Phase 1 (in-memory, per-basin / per-event):** a `geopandas.GeoDataFrame` plus `pd.IntervalIndex`, built once per session by crawling instrument-specific URL conventions. Sufficient for ≤10⁵ overpasses (a basin × multi-year window). Persisted as GeoParquet via `to_geoparquet()` so the same catalog feeds research and batch.
+**Phase 1 (in-memory, per-basin / per-event):** a `geopandas.GeoDataFrame` plus `pd.IntervalIndex`, built once per session by crawling instrument-specific URL conventions.
+Sufficient for ≤10⁵ overpasses (a basin × multi-year window).
+Persisted as GeoParquet via `to_geoparquet()` so the same catalog feeds research and batch.
 
-**Phase 2 (DuckDB on GeoParquet):** when the catalog goes operational and global, the same API but DuckDB-backed with predicate pushdown via the GeoParquet 1.1 bbox column. **Most of MARS's catalog needs probably stay in Phase 1** — operational attribution is event-driven, with each event filtering to a small AOI × time window where Phase 1 is more than fast enough.
+**Phase 2 (DuckDB on GeoParquet):** when the catalog goes operational and global, the same API but DuckDB-backed with predicate pushdown via the GeoParquet 1.1 bbox column.
+**Most of MARS's catalog needs probably stay in Phase 1** — operational attribution is event-driven, with each event filtering to a small AOI × time window where Phase 1 is more than fast enough.
 
 **The query that anchors everything:**
 
@@ -220,7 +245,8 @@ That single query replaces the per-project glob+filter+join logic that today eve
 
 ### 4.5 Compute — `geotoolz` × `plumax` × `xrtoolz`
 
-The **factory layer** is where the science composition lives. Three libraries with a clean separation of concerns:
+The **factory layer** is where the science composition lives.
+Three libraries with a clean separation of concerns:
 
 | Library | What it owns in the attribution pipeline |
 |---|---|
@@ -276,11 +302,14 @@ attribution = Graph(
 )
 ```
 
-That's **the** graph. Notebook, batch worker, and FastAPI handler all instantiate this same `Graph` and call it. The orchestration changes around it; the graph itself is identical.
+That's **the** graph.
+Notebook, batch worker, and FastAPI handler all instantiate this same `Graph` and call it.
+The orchestration changes around it; the graph itself is identical.
 
 ### 4.6 Serving
 
-Three orchestration modes share the graph above. See §5 for each.
+Three orchestration modes share the graph above.
+See §5 for each.
 
 ---
 
@@ -292,7 +321,8 @@ Each phase uses the **identical** operator graph from §4.5. What changes is the
 
 **Goal.** Validate that the unified-stack operator graph runs and produces a posterior consistent with hand-rolled MARS-style outputs on a known event.
 
-**Anchor event.** A single Permian basin methane release with all three instruments observing within a 24-hour window. (Pick a published event from the literature so we have a published posterior to bench against.)
+**Anchor event.** A single Permian basin methane release with all three instruments observing within a 24-hour window.
+(Pick a published event from the literature so we have a published posterior to bench against.)
 
 **Notebook flow:**
 
@@ -339,7 +369,8 @@ plot_observations_vs_simulated(posterior, emit_gt, tropomi_gt, ghgsat_gt)
 - Multi-instrument fusion produces a tighter posterior than any single instrument (the differentiated payoff vs current per-instrument MARS practice).
 - Bench against published posterior for the chosen event — within published uncertainty.
 
-**Estimated effort.** ~2–3 weeks of focused work after georeader 2.0 + the v0.1 geotoolz core land. Most of the work is in `plumax` operator wrappers (`GaussianPlume`, `JointLikelihood`, `BiasCorrect`) — the plumax tier-I math already exists in the roadmap; the work is wrapping it as Operators with `get_config` for Hydra serialisation.
+**Estimated effort.** ~2–3 weeks of focused work after georeader 2.0 + the v0.1 geotoolz core land.
+Most of the work is in `plumax` operator wrappers (`GaussianPlume`, `JointLikelihood`, `BiasCorrect`) — the plumax tier-I math already exists in the roadmap; the work is wrapping it as Operators with `get_config` for Hydra serialisation.
 
 ### 5.2 Phase 2 — Batch pipeline
 
@@ -387,7 +418,8 @@ write_posteriors_geoparquet(posteriors, "s3://mars/posteriors/2026-W19.parquet")
 
 **What this validates:**
 
-- The graph is **pickleable** — Dask / Ray serialisation works without per-Operator special-casing. (CI test from [`geotoolz.md` §11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci) directly applies.)
+- The graph is **pickleable** — Dask / Ray serialisation works without per-Operator special-casing.
+  (CI test from [`geotoolz.md` §11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci) directly applies.)
 - Per-event parallelism scales linearly with worker count (no shared global state).
 - Posteriors round-trip to GeoParquet with full provenance — the resulting file is a queryable record of every attribution the pipeline produced, hashable, reproducible.
 - Catalog-driven dispatch (Phase 1 catalog → list of events → graph per event) replaces today's bespoke `glob() + groupby + apply` notebooks.
@@ -441,7 +473,8 @@ async def attribute(req: AttributionRequest) -> AttributionResponse:
 
 **What this validates:**
 
-- The "marquee pitch" — *the same operator graph runs in research and production* — actually delivers. The `attribution_graph` object in the FastAPI handler is the *same Python object* you'd import in a notebook.
+- The "marquee pitch" — *the same operator graph runs in research and production* — actually delivers.
+  The `attribution_graph` object in the FastAPI handler is the *same Python object* you'd import in a notebook.
 - Async readers (`AsyncGeoData` Protocol from [`plans/georeader/`](plans/georeader/)) integrate cleanly with FastAPI's async stack.
 - Response payload includes complete provenance — every overpass URL, met source, prior version, operator graph hash — making each attribution audit-able.
 
@@ -451,12 +484,15 @@ async def attribute(req: AttributionRequest) -> AttributionResponse:
 
 ## 6. Operator catalog — what the `Sequential` actually contains
 
-For engineers: the concrete operators each library would contribute. This is the *first-pass* surface — exact signatures land in each library's plans.
+For engineers: the concrete operators each library would contribute.
+This is the *first-pass* surface — exact signatures land in each library's plans.
 
 ### 6.1 `geotoolz` operators (existing per [`plans/geotoolz/`](plans/geotoolz/), with one addition)
 
-- `MatchedFilter(target: spectrum)` — hyperspectral plume detection. Hyperspectral module.
-- `ApplyAK(instrument: str)` — averaging-kernel application. New for v0.x — currently lives in plumax; promote when stable.
+- `MatchedFilter(target: spectrum)` — hyperspectral plume detection.
+  Hyperspectral module.
+- `ApplyAK(instrument: str)` — averaging-kernel application.
+  New for v0.x — currently lives in plumax; promote when stable.
 - `Mask(qa_band: str, min: int|float)` — cloud + QA masking.
 - `Crop(geoslice: GeoSlice)` — AOI extraction.
 - `Reproject(target_crs: CRS, target_transform: Affine)` — Case-3 (shape-changing) operator.
@@ -465,11 +501,13 @@ For engineers: the concrete operators each library would contribute. This is the
 
 ### 6.2 `plumax` operators (projected — see [plumax roadmap](../plume_simulation/notes/roadmap/README.md))
 
-- `GaussianPlume(instrument, axis_convention)` — Tier I forward, `(Q, x₀, ū, θ_wind, c_bg) → concentration_field → column_via_AK → simulated_observation`. Wraps the existing tier-I math from [`01_tier1_gaussian.md`](../plume_simulation/notes/roadmap/01_tier1_gaussian.md) as an Operator.
+- `GaussianPlume(instrument, axis_convention)` — Tier I forward, `(Q, x₀, ū, θ_wind, c_bg) → concentration_field → column_via_AK → simulated_observation`.
+  Wraps the existing tier-I math from [`01_tier1_gaussian.md`](../plume_simulation/notes/roadmap/01_tier1_gaussian.md) as an Operator.
 - `LagrangianPlume(...)` — Tier II forward. v2+.
 - `EulerianPlume(...)` — Tier III forward. v3+.
 - `BiasCorrect(instrument: str)` — per-instrument additive bias as a learnable Operator (compute via the split-object pattern from [§4.3 of geotoolz.md](plans/geotoolz/geotoolz.md)).
-- `JointLikelihood(instruments: list[str])` — multi-instrument fusion at native resolution. Returns a callable likelihood; downstream `MAPInverter` / `NUTSInverter` consumes it.
+- `JointLikelihood(instruments: list[str])` — multi-instrument fusion at native resolution.
+  Returns a callable likelihood; downstream `MAPInverter` / `NUTSInverter` consumes it.
 - `MAPInverter(prior, init)` — wraps NumPyro's MAP. Output: `Posterior` PyTree.
 - `NUTSInverter(prior, n_warmup, n_samples)` — wraps NumPyro's NUTS. Output: `Posterior` PyTree with full chain.
 - `MetFieldLoader(source: str)` — wraps WRF / ERA5 readers from [`prerequisites.md`](../plume_simulation/notes/roadmap/00_prerequisites.md), emits `MetField`.
@@ -483,7 +521,9 @@ For engineers: the concrete operators each library would contribute. This is the
 
 ### 6.4 What lives in `plumax`, not `geotoolz`
 
-The substrate-split rule from [`geotoolz.md` §10.1](plans/geotoolz/geotoolz.md): operators that are *domain-specific* (Gaussian plume math, AK application, methane likelihoods) live in `plumax`. Operators that are *generic* (matched filter, masking, cropping, reprojection) live in `geotoolz`. The split is enforced by import direction — `plumax` imports `geotoolz`, never the reverse.
+The substrate-split rule from [`geotoolz.md` §10.1](plans/geotoolz/geotoolz.md): operators that are *domain-specific* (Gaussian plume math, AK application, methane likelihoods) live in `plumax`.
+Operators that are *generic* (matched filter, masking, cropping, reprojection) live in `geotoolz`.
+The split is enforced by import direction — `plumax` imports `geotoolz`, never the reverse.
 
 ---
 
@@ -491,12 +531,18 @@ The substrate-split rule from [`geotoolz.md` §10.1](plans/geotoolz/geotoolz.md)
 
 For all three demo phases:
 
-- **Model training.** `geotoolz`, `xrtoolz`, and `plumax` cover *exploration*, *preprocessing*, *inference*, and *serving*. Training (e.g. an emulator surrogate for the forward model, per [plumax Step 3](../plume_simulation/notes/roadmap/README.md#the-data-driven-modeling-cycle)) stays in the user's framework (PyTorch, JAX, equinox). `ModelOp` wraps a *trained* callable for inference; nothing in this stack abstracts over training loops.
-- **Tier IV neural RTM.** The current RTM stack ([`04_rtm_stack.md`](../plume_simulation/notes/roadmap/04_rtm_stack.md)) is matrix-based. A neural-network surrogate for the RTM is a v2+ optional upgrade.
+- **Model training.** `geotoolz`, `xrtoolz`, and `plumax` cover *exploration*, *preprocessing*, *inference*, and *serving*.
+  Training (e.g. an emulator surrogate for the forward model, per [plumax Step 3](../plume_simulation/notes/roadmap/README.md#the-data-driven-modeling-cycle)) stays in the user's framework (PyTorch, JAX, equinox).
+  `ModelOp` wraps a *trained* callable for inference; nothing in this stack abstracts over training loops.
+- **Tier IV neural RTM.** The current RTM stack ([`04_rtm_stack.md`](../plume_simulation/notes/roadmap/04_rtm_stack.md)) is matrix-based.
+  A neural-network surrogate for the RTM is a v2+ optional upgrade.
 - **Tier V population / forecasting.** The TMTPP intensity-process work in [`06_tier5_population.md`](../plume_simulation/notes/roadmap/06_tier5_population.md) is downstream of single-event posteriors; it consumes Phase 2's GeoParquet output but isn't part of v1.
-- **Distributed-SQL execution.** Sedona / Spark are not on the path. If catalog scale outgrows DuckDB Phase 2, the next step is sharded GeoParquet, not SQL emission from operator graphs.
-- **Streaming pipelines.** Flink / Beam / Kafka Streams are not modelled. Operator graphs run per-event, not per-byte-stream.
-- **Edge inference.** No mobile / TFLite / ONNX-runtime targets. The amortised predictor (plumax Step 5) could ship as ONNX, but operator-graph orchestration around it remains server-side.
+- **Distributed-SQL execution.** Sedona / Spark are not on the path.
+  If catalog scale outgrows DuckDB Phase 2, the next step is sharded GeoParquet, not SQL emission from operator graphs.
+- **Streaming pipelines.** Flink / Beam / Kafka Streams are not modelled.
+  Operator graphs run per-event, not per-byte-stream.
+- **Edge inference.** No mobile / TFLite / ONNX-runtime targets.
+  The amortised predictor (plumax Step 5) could ship as ONNX, but operator-graph orchestration around it remains server-side.
 
 These exclusions are deliberate, per the [scope-honesty discussion in geostack_notes.md](geostack_notes.md#honest-research-to-prod-scope) — keeping the in-scope list deliverable rather than the out-of-scope list aspirational.
 
@@ -508,9 +554,11 @@ Validation is layered to match the [plumax architectural principle 2](../plume_s
 
 ### 8.1 Per-operator (geotoolz / plumax / xrtoolz)
 
-- **Tier A primitive correctness.** Analytic ground truth on numpy arrays. NDVI, matched filter, AK application — each has a textbook-canonical reference output for known inputs.
+- **Tier A primitive correctness.** Analytic ground truth on numpy arrays.
+  NDVI, matched filter, AK application — each has a textbook-canonical reference output for known inputs.
 - **Tier B Operator metadata round-trip.** Transform / CRS / fill-value preserved through every Operator type (the three cases from [§1.1 of geotoolz.md](plans/geotoolz/geotoolz.md)).
-- **Operator pickleability.** Every Operator in §6 round-trips through `pickle.dumps` / `pickle.loads`. Already a CI test per [§11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci).
+- **Operator pickleability.** Every Operator in §6 round-trips through `pickle.dumps` / `pickle.loads`.
+  Already a CI test per [§11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci).
 
 ### 8.2 Per-graph (the §4.5 attribution `Graph`)
 
@@ -520,12 +568,14 @@ Validation is layered to match the [plumax architectural principle 2](../plume_s
 
 ### 8.3 End-to-end (against published events)
 
-- **Anchor event.** Pick one published Permian methane release with documented MARS-style attribution. The unified-stack posterior must be consistent with the published posterior.
+- **Anchor event.** Pick one published Permian methane release with documented MARS-style attribution.
+  The unified-stack posterior must be consistent with the published posterior.
 - **Cross-instrument independence.** Posterior obtained from {EMIT only}, {TROPOMI only}, {GHGSat only}, and {all three jointly} — the joint posterior should be the precision-weighted combination of the individual posteriors (within model misspecification).
 
 ### 8.4 Operational continuity
 
-- **Phase 3 vs Phase 1 parity.** The FastAPI service, given the same inputs as the Phase 1 notebook, returns the same posterior to within numerical noise. *This is the marquee parity test* — if it fails, the "same graph in research and prod" claim fails.
+- **Phase 3 vs Phase 1 parity.** The FastAPI service, given the same inputs as the Phase 1 notebook, returns the same posterior to within numerical noise.
+  *This is the marquee parity test* — if it fails, the "same graph in research and prod" claim fails.
 
 ---
 
@@ -545,44 +595,64 @@ For audiences asking *"what changes for the people doing this work today?"* — 
 
 **What does *not* change for current MARS workflows:**
 
-- The science. Tier I math, AK conventions, multi-instrument fusion logic — all stay the same. The substrate changes; the equations don't.
-- The operational reality. UNEP-IMEO partners, alert-response protocols, public reporting cadence — all unchanged.
-- The data sources. EMIT on AWS, TROPOMI on Copernicus, GHGSat on the vendor portal — same buckets, same auth, same products.
+- The science.
+  Tier I math, AK conventions, multi-instrument fusion logic — all stay the same.
+  The substrate changes; the equations don't.
+- The operational reality.
+  UNEP-IMEO partners, alert-response protocols, public reporting cadence — all unchanged.
+- The data sources.
+  EMIT on AWS, TROPOMI on Copernicus, GHGSat on the vendor portal — same buckets, same auth, same products.
 
 ---
 
 ## 10. Risks and open questions
 
-The full risks tracker for the underlying libraries lives in their own design docs ([`plans/geotoolz/geotoolz.md` §11](plans/geotoolz/geotoolz.md), [`plans/geodatabase/`](plans/geodatabase/), [`plans/georeader/`](plans/georeader/)). The risks specific to *this* attribution pipeline:
+The full risks tracker for the underlying libraries lives in their own design docs ([`plans/geotoolz/geotoolz.md` §11](plans/geotoolz/geotoolz.md), [`plans/geodatabase/`](plans/geodatabase/), [`plans/georeader/`](plans/georeader/)).
+The risks specific to *this* attribution pipeline:
 
 ### 10.1 Critical-path
 
-- **`georeader 2.0` lands.** Every reader in §4.3 depends on the `feature/geotensor_npapi` branch merging upstream. If it stalls, vendor a `GeoTensor` in `plumax` until upstream catches up — but the contingency cost is one library duplication.
+- **`georeader 2.0` lands.** Every reader in §4.3 depends on the `feature/geotensor_npapi` branch merging upstream.
+  If it stalls, vendor a `GeoTensor` in `plumax` until upstream catches up — but the contingency cost is one library duplication.
 - **Geocatalog Phase 1 ships.** Without it, Phase 2 / Phase 3 fall back to per-script glob-and-filter — the demo still works for one event, but the *catalog-driven* pitch evaporates.
 
 ### 10.2 Per-instrument
 
-- **GHGSat schema stability.** Commercial product, schema changes per release. Pin reader to a documented product version; bump `_v2` per breaking change. Same convention as plumax sensor presets.
-- **EMIT product latency.** EMIT L1B can be hours to days behind acquisition. Phase 3 alert latency claims are bounded by this — no operational fixes available.
-- **TROPOMI L2 averaging-kernel format heterogeneity.** Different processors emit different AK schemas. The `Instrument` registry from [prerequisites §5](../plume_simulation/notes/roadmap/00_prerequisites.md#l1--l2-ingest) absorbs this — but the registry must stay maintained, or the unified pipeline breaks per-product-bump.
+- **GHGSat schema stability.** Commercial product, schema changes per release.
+  Pin reader to a documented product version; bump `_v2` per breaking change.
+  Same convention as plumax sensor presets.
+- **EMIT product latency.** EMIT L1B can be hours to days behind acquisition.
+  Phase 3 alert latency claims are bounded by this — no operational fixes available.
+- **TROPOMI L2 averaging-kernel format heterogeneity.** Different processors emit different AK schemas.
+  The `Instrument` registry from [prerequisites §5](../plume_simulation/notes/roadmap/00_prerequisites.md#l1--l2-ingest) absorbs this — but the registry must stay maintained, or the unified pipeline breaks per-product-bump.
 
 ### 10.3 Inference
 
 - **Three-instrument MAP convergence.** With heterogeneous noise models and a non-trivial `Q(t)` prior, MAP can be hard to converge. v1 ships with NumPyro-default optimizers; v2 may need basin-hopping or sequential Monte Carlo for hard events.
-- **Posterior representation.** A `Posterior` PyTree on output of `MAPInverter` / `NUTSInverter` needs a stable schema. Pin in v0.1 of `plumax`; bump the artifact `schema_version` (per [`geocatalog.md` §10.4](plans/geodatabase/geocatalog.md)) when changes happen.
+- **Posterior representation.** A `Posterior` PyTree on output of `MAPInverter` / `NUTSInverter` needs a stable schema.
+  Pin in v0.1 of `plumax`; bump the artifact `schema_version` (per [`geocatalog.md` §10.4](plans/geodatabase/geocatalog.md)) when changes happen.
 
 ### 10.4 Operational
 
 - **Alert-payload schema is operator-defined.** What goes in `AttributionResponse` matters for downstream responders. v1 should mirror MARS's existing alert schema where possible, with extensions for provenance.
-- **Provenance-as-data.** Each posterior must carry: catalog query → resolved overpass URLs → met source + version → operator-graph hash → library versions. Without this, the "auditable" claim doesn't hold. Worth a dedicated `Provenance` PyTree in `plumax`.
-- **Phase 3 cold-start budget.** 30 s is plausible if `attribution_graph.compile()` is cheap; if NumPyro JIT-compiles per request, the budget breaks. Pin compilation to import-time, not request-time.
+- **Provenance-as-data.** Each posterior must carry: catalog query → resolved overpass URLs → met source + version → operator-graph hash → library versions.
+  Without this, the "auditable" claim doesn't hold.
+  Worth a dedicated `Provenance` PyTree in `plumax`.
+- **Phase 3 cold-start budget.** 30 s is plausible if `attribution_graph.compile()` is cheap; if NumPyro JIT-compiles per request, the budget breaks.
+  Pin compilation to import-time, not request-time.
 
 ### 10.5 Open questions to settle before v1
 
-- **Where does `ApplyAK` live — `geotoolz` or `plumax`?** Current proposal: in `geotoolz` (it's a generic operator over averaging-kernel-bearing observations), with the per-instrument AK schema registry in `plumax`. Could go the other way.
-- **Async at the graph boundary or per-Operator?** Phase 3 uses async I/O via `AsyncGeoData`; the graph itself is sync. Open per [`geotoolz.md` §11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci). Decision affects FastAPI throughput.
-- **`coordax` for `MetField` from day one?** The plumax roadmap leans yes ([prerequisites open questions](../plume_simulation/notes/roadmap/00_prerequisites.md#open-questions)). If `coordax` proves unstable per [geotoolz.md §11.1](plans/geotoolz/geotoolz.md#111-strategic-risks), fall back to plain xarray.
-- **Global vs basin catalogs.** Phase 1 fits ≤10⁵ overpasses, which covers a basin × multi-year window. A *global* catalog (every TROPOMI / EMIT / GHGSat overpass, multi-year) is Phase 2 territory. Decide per-deployment.
+- **Where does `ApplyAK` live — `geotoolz` or `plumax`?** Current proposal: in `geotoolz` (it's a generic operator over averaging-kernel-bearing observations), with the per-instrument AK schema registry in `plumax`.
+  Could go the other way.
+- **Async at the graph boundary or per-Operator?** Phase 3 uses async I/O via `AsyncGeoData`; the graph itself is sync.
+  Open per [`geotoolz.md` §11.2](plans/geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci).
+  Decision affects FastAPI throughput.
+- **`coordax` for `MetField` from day one?** The plumax roadmap leans yes ([prerequisites open questions](../plume_simulation/notes/roadmap/00_prerequisites.md#open-questions)).
+  If `coordax` proves unstable per [geotoolz.md §11.1](plans/geotoolz/geotoolz.md#111-strategic-risks), fall back to plain xarray.
+- **Global vs basin catalogs.** Phase 1 fits ≤10⁵ overpasses, which covers a basin × multi-year window.
+  A *global* catalog (every TROPOMI / EMIT / GHGSat overpass, multi-year) is Phase 2 territory.
+  Decide per-deployment.
 
 ---
 

--- a/projects/geotoolz/plans/geodatabase/README.md
+++ b/projects/geotoolz/plans/geodatabase/README.md
@@ -16,20 +16,28 @@ keywords: design, geodatabase, catalog, geoparquet
 ---
 
 > **Status:** design proposal — split into two phases (Phase 1 + Phase 2 below).
-> **Scope:** the long-term shape of the catalog layer in `georeader`. A single `GeoCatalog` Protocol with two backends — an in-memory GeoDataFrame (Phase 1) and a DuckDB-backed GeoParquet store (Phase 2) — that share the same query API and the same `GeoSlice` unit of work.
+> **Scope:** the long-term shape of the catalog layer in `georeader`.
+> A single `GeoCatalog` Protocol with two backends — an in-memory GeoDataFrame (Phase 1) and a DuckDB-backed GeoParquet store (Phase 2) — that share the same query API and the same `GeoSlice` unit of work.
 > **Audience:** anyone touching `georeader`'s catalog module, or building downstream pipelines (`geotoolz.catalog_ops.CatalogPipeline`, ML training set builders) that consume catalogs.
 
 ---
 
 ## Summary
 
-A *geocatalog* in this design is a **spatiotemporal index over geospatial files** — a queryable mapping from `(geometry, time interval, metadata)` to a backend-specific path or asset. Today, every project that wants one rolls its own (the `jej_vc_snippets` repo has three: one for rasters, one for xarray datasets, one for vector files). This design promotes those snippets into `georeader` as a single unified API, then extends it to scale.
+A *geocatalog* in this design is a **spatiotemporal index over geospatial files** — a queryable mapping from `(geometry, time interval, metadata)` to a backend-specific path or asset.
+Today, every project that wants one rolls its own (the `jej_vc_snippets` repo has three: one for rasters, one for xarray datasets, one for vector files).
+This design promotes those snippets into `georeader` as a single unified API, then extends it to scale.
 
-**Phase 1** ships an in-memory `GeoCatalog` Protocol with one default implementation (`InMemoryGeoCatalog`) that wraps a `gpd.GeoDataFrame` with an `IntervalIndex` for time and an R-tree for space. Three builder entry points (`build_raster_catalog`, `build_xarray_catalog`, `build_vector_catalog`) cover the three backend types. Set algebra (`query`, `intersect`, `union`) operates over catalogs. A `GeoSlice` dataclass is the unit of work passed to samplers and loaders.
+**Phase 1** ships an in-memory `GeoCatalog` Protocol with one default implementation (`InMemoryGeoCatalog`) that wraps a `gpd.GeoDataFrame` with an `IntervalIndex` for time and an R-tree for space.
+Three builder entry points (`build_raster_catalog`, `build_xarray_catalog`, `build_vector_catalog`) cover the three backend types.
+Set algebra (`query`, `intersect`, `union`) operates over catalogs.
+A `GeoSlice` dataclass is the unit of work passed to samplers and loaders.
 
-**Phase 2** adds a `DuckDBGeoCatalog` backend that swaps the in-memory GeoDataFrame for DuckDB's `spatial` extension over a GeoParquet artifact. Same Protocol, same `GeoSlice`, same `query` / `intersect` / `union` shape — but now scaling to 10⁶+ rows, queryable via SQL, persistent as a portable GeoParquet file, and analyzable without loading into Python.
+**Phase 2** adds a `DuckDBGeoCatalog` backend that swaps the in-memory GeoDataFrame for DuckDB's `spatial` extension over a GeoParquet artifact.
+Same Protocol, same `GeoSlice`, same `query` / `intersect` / `union` shape — but now scaling to 10⁶+ rows, queryable via SQL, persistent as a portable GeoParquet file, and analyzable without loading into Python.
 
-The work splits into two reviewable phases. Phase 1 must land first; Phase 2 builds on it.
+The work splits into two reviewable phases.
+Phase 1 must land first; Phase 2 builds on it.
 
 ---
 
@@ -37,27 +45,38 @@ The work splits into two reviewable phases. Phase 1 must land first; Phase 2 bui
 
 Three pressures make a unified catalog layer worth doing now:
 
-1. **Every project rolls its own catalog.** The `jej_vc_snippets/remote_sensing/` directory contains three near-identical catalog implementations (raster, xarray, vector), each ~1500–1900 LOC, with subtly different APIs. Promoting them into `georeader` as one Protocol with three builders eliminates the duplication and gives downstream consumers a stable surface.
+1. **Every project rolls its own catalog.** The `jej_vc_snippets/remote_sensing/` directory contains three near-identical catalog implementations (raster, xarray, vector), each ~1500–1900 LOC, with subtly different APIs.
+   Promoting them into `georeader` as one Protocol with three builders eliminates the duplication and gives downstream consumers a stable surface.
 
-2. **Catalog scale has outgrown the GeoDataFrame.** A single Sentinel-2 archive across a continent is ~10⁵–10⁶ scenes; a 10-year time series across multiple sensors easily exceeds 10⁶. Phase 1's `gpd.GeoDataFrame` works fine up to ~10⁵ rows, then `gpd.overlay`-style operations become painful and RAM eats the gdf. A SQL-native backend handles the same operations on a different cost model.
+2. **Catalog scale has outgrown the GeoDataFrame.** A single Sentinel-2 archive across a continent is ~10⁵–10⁶ scenes; a 10-year time series across multiple sensors easily exceeds 10⁶. Phase 1's `gpd.GeoDataFrame` works fine up to ~10⁵ rows, then `gpd.overlay`-style operations become painful and RAM eats the gdf.
+   A SQL-native backend handles the same operations on a different cost model.
 
-3. **Catalogs need to be portable artifacts.** A pickled GeoDataFrame is fragile across versions. A serialised GeoParquet file is the emerging standard for portable spatial tables, queryable directly by DuckDB / GDAL / pandas / geopandas without ceremony. Making the Phase 2 backend GeoParquet-native turns the catalog itself into a shareable artifact.
+3. **Catalogs need to be portable artifacts.** A pickled GeoDataFrame is fragile across versions.
+   A serialised GeoParquet file is the emerging standard for portable spatial tables, queryable directly by DuckDB / GDAL / pandas / geopandas without ceremony.
+   Making the Phase 2 backend GeoParquet-native turns the catalog itself into a shareable artifact.
 
-The status quo can absorb each of these one at a time, but the three concerns are coupled — making the catalog SQL-native and making it portable are the same change. A two-phase plan (in-memory first, scale-aware second) lets the design land incrementally without forcing a SQL dependency on small-scale users.
+The status quo can absorb each of these one at a time, but the three concerns are coupled — making the catalog SQL-native and making it portable are the same change.
+A two-phase plan (in-memory first, scale-aware second) lets the design land incrementally without forcing a SQL dependency on small-scale users.
 
 ---
 
 ## Primer for newcomers
 
-> **ELI5.** A geocatalog is like a **library card catalog for satellite files**: each card lists where the file is, what area it covers, and when it was taken. Searching for *"all files over Madagascar in June 2023"* becomes flipping through index cards, not opening every book.
+> **ELI5.** A geocatalog is like a **library card catalog for satellite files**: each card lists where the file is, what area it covers, and when it was taken.
+> Searching for *"all files over Madagascar in June 2023"* becomes flipping through index cards, not opening every book.
 
 ### What's a "geocatalog"?
 
-**What it is.** A *queryable index over geospatial files* — a table where each row describes one file and records its bbox, time interval, CRS, and path. Given a query like "files overlapping AOI X between dates Y and Z," the catalog returns the matching paths fast without opening any of the files.
+**What it is.** A *queryable index over geospatial files* — a table where each row describes one file and records its bbox, time interval, CRS, and path.
+Given a query like "files overlapping AOI X between dates Y and Z," the catalog returns the matching paths fast without opening any of the files.
 
-**How it works.** Each row carries a `geometry` column (a polygon — typically each file's bbox in some CRS) and time columns (start/end). A spatial index over `geometry` and a time index over the dates lets queries skip non-matching rows without scanning the table. The result is "STAC, but local and Pythonic" — same idea (a file index), different shape (in-process Python instead of a JSON API).
+**How it works.** Each row carries a `geometry` column (a polygon — typically each file's bbox in some CRS) and time columns (start/end).
+A spatial index over `geometry` and a time index over the dates lets queries skip non-matching rows without scanning the table.
+The result is "STAC, but local and Pythonic" — same idea (a file index), different shape (in-process Python instead of a JSON API).
 
-**What this means for us.** Today, every project that wants to scale beyond "open one file at a time" rolls its own catalog. This design promotes the pattern into `georeader` as a single shape: one Protocol, two backends (in-memory for ≤10⁵ rows, DuckDB for larger / persistent), three builders (raster / xarray / vector). Downstream code (`geotoolz.catalog_ops.CatalogPipeline`) consumes the Protocol, indifferent to which backend is in use.
+**What this means for us.** Today, every project that wants to scale beyond "open one file at a time" rolls its own catalog.
+This design promotes the pattern into `georeader` as a single shape: one Protocol, two backends (in-memory for ≤10⁵ rows, DuckDB for larger / persistent), three builders (raster / xarray / vector).
+Downstream code (`geotoolz.catalog_ops.CatalogPipeline`) consumes the Protocol, indifferent to which backend is in use.
 
 ```{mermaid}
 flowchart LR
@@ -71,27 +90,38 @@ flowchart LR
 
 ### R-tree spatial index
 
-**What it is.** An R-tree is a tree-shaped data structure that organises geometric objects (boxes, polygons) so that "find all objects intersecting this query box" runs in `O(log n + k)` instead of `O(n)`. Standard data structure for spatial queries.
+**What it is.** An R-tree is a tree-shaped data structure that organises geometric objects (boxes, polygons) so that "find all objects intersecting this query box" runs in `O(log n + k)` instead of `O(n)`.
+Standard data structure for spatial queries.
 
-**How it works.** The tree's leaves are the actual geometries; each internal node holds a bounding box that contains all of its children. To answer "what intersects this query box," you descend only into branches whose bounding boxes overlap — pruning whole subtrees in one comparison. `geopandas` builds an R-tree lazily on first spatial query; you don't construct it manually.
+**How it works.** The tree's leaves are the actual geometries; each internal node holds a bounding box that contains all of its children.
+To answer "what intersects this query box," you descend only into branches whose bounding boxes overlap — pruning whole subtrees in one comparison.
+`geopandas` builds an R-tree lazily on first spatial query; you don't construct it manually.
 
-**What this means for us.** Phase 1's `InMemoryGeoCatalog` uses geopandas's `gdf.cx[xmin:xmax, ymin:ymax]` accessor, which uses the R-tree under the hood. For a catalog of 10k tiles, queries are sub-millisecond. R-tree size is `O(n)`; the in-memory backend hits a wall around 10⁵–10⁶ rows because the gdf itself becomes painful, not because the index does.
+**What this means for us.** Phase 1's `InMemoryGeoCatalog` uses geopandas's `gdf.cx[xmin:xmax, ymin:ymax]` accessor, which uses the R-tree under the hood.
+For a catalog of 10k tiles, queries are sub-millisecond.
+R-tree size is `O(n)`; the in-memory backend hits a wall around 10⁵–10⁶ rows because the gdf itself becomes painful, not because the index does.
 
 ### IntervalIndex (temporal)
 
 **What it is.** A pandas `IntervalIndex` is the time-axis equivalent of an R-tree — given a query interval, it returns all stored intervals that overlap, fast.
 
-**How it works.** Each row in the catalog has a `pd.Interval(start, end, closed='both')`. Putting them into an `IntervalIndex` lets you call `.overlaps(query_interval)` and get a boolean mask in `O(log n + k)` time. Combined with the R-tree spatial filter, a `query(bbox, time)` is two index probes intersected.
+**How it works.** Each row in the catalog has a `pd.Interval(start, end, closed='both')`.
+Putting them into an `IntervalIndex` lets you call `.overlaps(query_interval)` and get a boolean mask in `O(log n + k)` time.
+Combined with the R-tree spatial filter, a `query(bbox, time)` is two index probes intersected.
 
-**What this means for us.** Time-aware catalog queries don't have to scan the full row list — even with a year of daily files (~365 rows per tile × N tiles) the temporal filter takes microseconds. The same `IntervalIndex` shape carries through Phase 2's DuckDB backend (as `bbox` + `start_time` + `end_time` columns with predicate pushdown).
+**What this means for us.** Time-aware catalog queries don't have to scan the full row list — even with a year of daily files (~365 rows per tile × N tiles) the temporal filter takes microseconds.
+The same `IntervalIndex` shape carries through Phase 2's DuckDB backend (as `bbox` + `start_time` + `end_time` columns with predicate pushdown).
 
 ### GeoParquet + DuckDB
 
 **What it is.** **GeoParquet** is the emerging standard for storing spatial tables as Parquet files (binary columnar format) with geometry columns encoded in WKB. **DuckDB** is an embedded SQL database (think SQLite, but column-oriented and analytics-tuned) with a `spatial` extension that reads GeoParquet natively.
 
-**How it works.** Build a catalog as a GeoParquet file once (`gdf.to_parquet("catalog.parquet")`). Open it as a DuckDB table, write SQL queries against it: `SELECT path FROM catalog WHERE ST_Intersects(geometry, AOI) AND date BETWEEN ...`. DuckDB pushes the spatial predicate down to the Parquet reader so most of the file is never read.
+**How it works.** Build a catalog as a GeoParquet file once (`gdf.to_parquet("catalog.parquet")`).
+Open it as a DuckDB table, write SQL queries against it: `SELECT path FROM catalog WHERE ST_Intersects(geometry, AOI) AND date BETWEEN ...`.
+DuckDB pushes the spatial predicate down to the Parquet reader so most of the file is never read.
 
-**What this means for us.** Phase 2 unlocks 10⁶+ row catalogs that don't fit in RAM, plus the catalog itself becomes a portable artifact you can share or query from another tool (pandas, geopandas, GDAL all read GeoParquet). The Protocol surface is unchanged from Phase 1; only the backend changes.
+**What this means for us.** Phase 2 unlocks 10⁶+ row catalogs that don't fit in RAM, plus the catalog itself becomes a portable artifact you can share or query from another tool (pandas, geopandas, GDAL all read GeoParquet).
+The Protocol surface is unchanged from Phase 1; only the backend changes.
 
 ```{mermaid}
 classDiagram
@@ -120,10 +150,13 @@ classDiagram
 
 ## Goals
 
-- **Single `GeoCatalog` Protocol** that all backends honour. Same `query` / `intersect` / `union` / `iter_slices` / `to_geoparquet` / `from_geoparquet` shape regardless of which backend is in use.
-- **Three storage backends covered:** raster files, xarray-shaped datasets (NetCDF/Zarr/HDF), vector files (Shapefile/GeoPackage/GeoJSON). One catalog API, three builder entry points.
+- **Single `GeoCatalog` Protocol** that all backends honour.
+  Same `query` / `intersect` / `union` / `iter_slices` / `to_geoparquet` / `from_geoparquet` shape regardless of which backend is in use.
+- **Three storage backends covered:** raster files, xarray-shaped datasets (NetCDF/Zarr/HDF), vector files (Shapefile/GeoPackage/GeoJSON).
+  One catalog API, three builder entry points.
 - **`GeoSlice` as the unit of work** (specified separately in [`types/geoslice.md`](../types/geoslice.md)) — a dataclass carrying `(bounds, interval, resolution, crs)` that flows from samplers to loaders without either side knowing about the catalog backend.
-- **Phase 1: in-memory backend** that's good for prototyping, ML training set construction, and catalogs up to ~10⁵ rows. Sub-second query times via R-tree + IntervalIndex.
+- **Phase 1: in-memory backend** that's good for prototyping, ML training set construction, and catalogs up to ~10⁵ rows.
+  Sub-second query times via R-tree + IntervalIndex.
 - **Phase 2: DuckDB backend** that scales to 10⁶+ rows, queries via SQL, persists as GeoParquet, and supports streaming construction for catalogs that don't fit in RAM during the build step.
 - **Round-tripping** between backends — load a Phase 2 catalog into Phase 1 for in-process operations, persist a Phase 1 catalog as GeoParquet for sharing.
 
@@ -133,16 +166,20 @@ classDiagram
 
 - **Replacing STAC.** STAC is an external interchange format; `GeoCatalog` is an in-package query API. A bridge to/from STAC is a separate, lighter design.
 - **Reimplementing geopandas or DuckDB.** The catalog is a thin layer over the right tool for each backend.
-- **Dataset-level transformations.** Catalogs index files; they don't apply operators. That's `geotoolz`'s job ([`catalog_ops.CatalogPipeline`](../geotoolz/geotoolz.md)).
-- **Cross-CRS unification at index time.** Catalogs store geometries in their native CRS; cross-CRS queries reproject at query time. Forcing a global CRS would lose information.
+- **Dataset-level transformations.** Catalogs index files; they don't apply operators.
+  That's `geotoolz`'s job ([`catalog_ops.CatalogPipeline`](../geotoolz/geotoolz.md)).
+- **Cross-CRS unification at index time.** Catalogs store geometries in their native CRS; cross-CRS queries reproject at query time.
+  Forcing a global CRS would lose information.
 - **Phase 1 backend retirement.** `InMemoryGeoCatalog` stays useful for small catalogs even after Phase 2 ships — no SQL dependency, no on-disk artifact required.
 
 ---
 
 ## Constraints
 
-- **Builds on `georeader.GeoTensor`** — the loaders return `GeoTensor` (raster), `xr.Dataset` (xarray), or `gpd.GeoDataFrame` (vector). The `GeoTensor` design itself is documented in [Ch. 1 of the tutorial](../../georeader_tutorial/01_geotensor.md).
-- **Builds on the reader Protocol from [Reader reconciliation](../georeader/README.md)** — loaders accept any `GeoData` (sync) or `AsyncGeoData` (async) reader. Catalog rows store paths/URIs; loaders open them via the configured reader class.
+- **Builds on `georeader.GeoTensor`** — the loaders return `GeoTensor` (raster), `xr.Dataset` (xarray), or `gpd.GeoDataFrame` (vector).
+  The `GeoTensor` design itself is documented in [Ch. 1 of the tutorial](../../georeader_tutorial/01_geotensor.md).
+- **Builds on the reader Protocol from [Reader reconciliation](../georeader/README.md)** — loaders accept any `GeoData` (sync) or `AsyncGeoData` (async) reader.
+  Catalog rows store paths/URIs; loaders open them via the configured reader class.
 - **`GeoSlice` is shared with multiple designs** — [`types/geoslice.md`](../types/geoslice.md) is the source of truth for the dataclass, samplers, and stitch. Changes to that contract ripple through this design and through [`geotoolz.md`](../geotoolz/geotoolz.md).
 - **Phase 2 introduces a DuckDB dependency** — opt-in via an extra (`georeader-spaceml[duckdb]`), not a hard dep.
 
@@ -245,7 +282,8 @@ These are unresolved and should be discussed before each phase starts.
 
 ### 1. Index-time CRS policy
 
-Catalogs store geometries in each file's native CRS. Cross-CRS queries reproject at query time. Alternatives:
+Catalogs store geometries in each file's native CRS. Cross-CRS queries reproject at query time.
+Alternatives:
 
 - **Native-CRS storage (current proposal):** preserves precision, defers reprojection to query.
 - **Force everything to EPSG:4326 at index time:** simpler queries, loses precision near poles and at high resolutions.
@@ -255,11 +293,13 @@ Catalogs store geometries in each file's native CRS. Cross-CRS queries reproject
 
 ### 2. `GeoSlice` semantics
 
-Open questions about the dataclass — `resolution` representation, antimeridian policy, time semantics in `stitch` — live in [`types/geoslice.md`](../types/geoslice.md) since they're cross-cutting. The resolution decision affects both this design (loaders consume it) and the geotoolz operator layer.
+Open questions about the dataclass — `resolution` representation, antimeridian policy, time semantics in `stitch` — live in [`types/geoslice.md`](../types/geoslice.md) since they're cross-cutting.
+The resolution decision affects both this design (loaders consume it) and the geotoolz operator layer.
 
 ### 3. Streaming construction in Phase 2
 
-A 10⁷-row catalog can't fit in RAM during build. Options:
+A 10⁷-row catalog can't fit in RAM during build.
+Options:
 
 - **Append-to-Parquet streaming:** builders write rows to GeoParquet incrementally; final file is sorted/optimised at the end.
 - **Build small, then concatenate:** builders run in shards, output multiple GeoParquet files, merged at the end.
@@ -280,11 +320,14 @@ A 10⁷-row catalog can't fit in RAM during build. Options:
 
 ## Connection to other designs
 
-- **[`geotoolz.md`](../geotoolz/geotoolz.md)** — `geotoolz.catalog_ops.CatalogPipeline(catalog, op)` consumes a `GeoCatalog`. The pipeline iterates the catalog, applies the operator per row, writes outputs.
-- **[Reader reconciliation](../georeader/README.md)** — catalog loaders open files via the configured reader class. The `reader_class=...` strategy injection from that design plugs into the loader at the point where bytes are first read.
+- **[`geotoolz.md`](../geotoolz/geotoolz.md)** — `geotoolz.catalog_ops.CatalogPipeline(catalog, op)` consumes a `GeoCatalog`.
+  The pipeline iterates the catalog, applies the operator per row, writes outputs.
+- **[Reader reconciliation](../georeader/README.md)** — catalog loaders open files via the configured reader class.
+  The `reader_class=...` strategy injection from that design plugs into the loader at the point where bytes are first read.
 - **[`geostack.md`](../geostack.md)** — situates the catalog layer in the broader ecosystem (where DuckDB sits relative to titiler / lonboard / obstore).
 
-The catalog layer sits between the reader layer (substrate) and the operator layer (composition). Each side talks to the other through `GeoSlice` — the catalog produces them, the reader+operator consume them.
+The catalog layer sits between the reader layer (substrate) and the operator layer (composition).
+Each side talks to the other through `GeoSlice` — the catalog produces them, the reader+operator consume them.
 
 ---
 
@@ -292,12 +335,20 @@ The catalog layer sits between the reader layer (substrate) and the operator lay
 
 The unifying GeoCatalog design is sound; cross-cutting concerns to track:
 
-- **Cross-CRS query footgun.** Catalogs are canonicalised to one CRS (Phase 2: EPSG:4326). User AOIs in another CRS silently return no rows. Mitigation lives in [`geocatalog.md` §10.1](geocatalog.md#101-cross-crs-query-footgun) — provide a CRS-aware query helper as the canonical path.
-- **GeoParquet 1.1 writer adoption is uneven** across `geopandas` and `duckdb-spatial`. Pin known-good versions; add a round-trip CI test. See [`geocatalog.md` §10.2](geocatalog.md#102-geoparquet-11-writer-adoption-is-uneven) and [`geoduckdb.md` Open questions](geoduckdb.md#geoparquet-11-writer-support).
-- **Phase 2 risk of bit-rot** if no real user emerges past 10⁶ rows. Gate Phase 2 release behind one real user or a multi-million-row CI fixture. See [`geocatalog.md` §10.3](geocatalog.md#103-phase-2-risk-of-bit-rot).
+- **Cross-CRS query footgun.** Catalogs are canonicalised to one CRS (Phase 2: EPSG:4326).
+  User AOIs in another CRS silently return no rows.
+  Mitigation lives in [`geocatalog.md` §10.1](geocatalog.md#101-cross-crs-query-footgun) — provide a CRS-aware query helper as the canonical path.
+- **GeoParquet 1.1 writer adoption is uneven** across `geopandas` and `duckdb-spatial`.
+  Pin known-good versions; add a round-trip CI test.
+  See [`geocatalog.md` §10.2](geocatalog.md#102-geoparquet-11-writer-adoption-is-uneven) and [`geoduckdb.md` Open questions](geoduckdb.md#geoparquet-11-writer-support).
+- **Phase 2 risk of bit-rot** if no real user emerges past 10⁶ rows.
+  Gate Phase 2 release behind one real user or a multi-million-row CI fixture.
+  See [`geocatalog.md` §10.3](geocatalog.md#103-phase-2-risk-of-bit-rot).
 - **`schema_version` column** reserved from v0.1; bump on first substantive schema change.
 - **Adapter scope honesty.** v0.1 ships `to_geoparquet` / `from_geoparquet` round-trip; STAC and torch adapters are v0.2+. Don't promise adapters that aren't built.
-- **Concurrent writes** are safe under append-only patterns, not under in-place mutation. Document the recommended write pattern when multi-writer use cases emerge.
-- **`ST_Transform` in WHERE clauses is slow.** The §4-style "store all geometries in 4326, native CRS as a column" convention exists exactly to avoid this. Loud documentation, not a code-level fix.
+- **Concurrent writes** are safe under append-only patterns, not under in-place mutation.
+  Document the recommended write pattern when multi-writer use cases emerge.
+- **`ST_Transform` in WHERE clauses is slow.** The §4-style "store all geometries in 4326, native CRS as a column" convention exists exactly to avoid this.
+  Loud documentation, not a code-level fix.
 
 The full lists live per-doc: [`geocatalog.md` §10](geocatalog.md#10-open-questions-gotchas-and-warnings) for Phase 1; [`geoduckdb.md` Open questions](geoduckdb.md#open-questions-gotchas-and-warnings) for Phase 2.

--- a/projects/geotoolz/plans/geodatabase/geocatalog.md
+++ b/projects/geotoolz/plans/geodatabase/geocatalog.md
@@ -16,14 +16,14 @@ keywords: design, geodatabase, catalog, geopandas
 ---
 
 > **Scope:** evaluating the `remote_sensing/dataset*.py`, `sampler.py`, `operations.py`, and `rasterio_utils.py` files in [`jejjohnson/jej_vc_snippets`](https://github.com/jejjohnson/jej_vc_snippets) for promotion into [`jejjohnson/georeader`](https://github.com/jejjohnson/georeader).
->
 > **Status:** design proposal, no code changed yet.
 
 ---
 
 ## 0. What I read
 
-I worked from the public-API view (signatures + docstrings) plus the algorithmic core of every function. The six files in `jej_vc_snippets/remote_sensing/` that are dataset-builder material are:
+I worked from the public-API view (signatures + docstrings) plus the algorithmic core of every function.
+The six files in `jej_vc_snippets/remote_sensing/` that are dataset-builder material are:
 
 | File | Lines | Top-level surface |
 | --- | ---: | --- |
@@ -34,7 +34,9 @@ I worked from the public-API view (signatures + docstrings) plus the algorithmic
 | `operations.py` | ~1000 | `query_spatiotemporal_index`, `intersect_spatiotemporal_indexes`, `union_spatiotemporal_indexes` |
 | `rasterio_utils.py` | ~250 | `update_metadata`, `read_metadata`, `filter_by_metadata`, `get_tags`, `print_all_metadata`, `save_image_with_tags`, `append_tags_to_existing` |
 
-> ⚠️ Found two literal syntax errors in `dataset_vector.py` (`return_meta bool = True` missing colon at line ~416; `if return_meta` missing colon at line ~1076). The file has never been imported successfully. Tests are therefore sparse to non-existent.
+> ⚠️ Found two literal syntax errors in `dataset_vector.py` (`return_meta bool = True` missing colon at line ~416; `if return_meta` missing colon at line ~1076).
+> The file has never been imported successfully.
+> Tests are therefore sparse to non-existent.
 
 ---
 
@@ -44,15 +46,20 @@ The six files form a small **catalog → query → load → sample → stitch** 
 
 ### 1.1 The shared index format
 
-Every `build_*_spatiotemporal_index` function emits the *same* object: a `geopandas.GeoDataFrame` whose row label is a `pd.IntervalIndex(name='datetime', closed='both')` and whose `geometry` column holds reprojected file footprints (bounding-box `Polygon`s in a uniform target CRS). One row per file. Extra columns differ by backend (`filepath` always; for xarray, also `data_vars`, `time_var`, `time_resolution`, `n_timesteps`; for vector, `layer`).
+Every `build_*_spatiotemporal_index` function emits the *same* object: a `geopandas.GeoDataFrame` whose row label is a `pd.IntervalIndex(name='datetime', closed='both')` and whose `geometry` column holds reprojected file footprints (bounding-box `Polygon`s in a uniform target CRS).
+One row per file.
+Extra columns differ by backend (`filepath` always; for xarray, also `data_vars`, `time_var`, `time_resolution`, `n_timesteps`; for vector, `layer`).
 
 This is the central design choice and it's a good one: **pandas + geopandas already give you `O(log n)` interval-tree temporal lookup and `O(log n)` R-tree spatial lookup for free.** No custom data structures needed.
 
 ### 1.2 The three backends
 
-- **Raster (`dataset.py`)** — file footprints come from `rasterio.open(...).bounds`, reprojected to `target_crs` via a lazy `WarpedVRT`. Loaders use `rasterio.merge.merge()` driven by query bounds and a target resolution; output is a numpy array `(bands, height, width)` plus a validity mask, plus an `Affine`.
-- **Xarray (`dataset_xarray.py`)** — opens each file with `xr.open_dataset(...)` (engine inferred from extension: `.zarr` → zarr, else netcdf4/h5netcdf), resolves CRS via `rio.crs` or a fallback, derives bounds from coordinate min/max, parses time from a `time_var` (default `'time'`). Loaders return `xr.Dataset` (or per-var numpy arrays); merging uses `rioxarray.merge.merge_datasets`.
-- **Vector (`dataset_vector.py`)** — opens each file with `geopandas.read_file(...)`, reprojects to target CRS, footprint = `total_bounds`. Loaders rasterize with `rasterio.features.rasterize` and return `torch.long` tensors keyed by ML task (`semantic_segmentation`, `object_detection`, `instance_segmentation`).
+- **Raster (`dataset.py`)** — file footprints come from `rasterio.open(...).bounds`, reprojected to `target_crs` via a lazy `WarpedVRT`.
+  Loaders use `rasterio.merge.merge()` driven by query bounds and a target resolution; output is a numpy array `(bands, height, width)` plus a validity mask, plus an `Affine`.
+- **Xarray (`dataset_xarray.py`)** — opens each file with `xr.open_dataset(...)` (engine inferred from extension: `.zarr` → zarr, else netcdf4/h5netcdf), resolves CRS via `rio.crs` or a fallback, derives bounds from coordinate min/max, parses time from a `time_var` (default `'time'`).
+  Loaders return `xr.Dataset` (or per-var numpy arrays); merging uses `rioxarray.merge.merge_datasets`.
+- **Vector (`dataset_vector.py`)** — opens each file with `geopandas.read_file(...)`, reprojects to target CRS, footprint = `total_bounds`.
+  Loaders rasterize with `rasterio.features.rasterize` and return `torch.long` tensors keyed by ML task (`semantic_segmentation`, `object_detection`, `instance_segmentation`).
 
 ### 1.3 The set algebra
 
@@ -66,28 +73,35 @@ All operate at the index level, never opening a file.
 
 ### 1.4 The sampler / inference layer
 
-`sampler.py` is the ML-glue: a `GeoSlice` dataclass + `random_geo_sampler` / `grid_geo_sampler` / `stitch_predictions` factories. The catalog is what the samplers iterate; the slices flow downstream into loaders and operators. Detailed design — dataclass invariants, sampling math, stitch reductions — lives in [`types/geoslice.md`](../types/geoslice.md). This document only covers how the catalog feeds the samplers.
+`sampler.py` is the ML-glue: a `GeoSlice` dataclass + `random_geo_sampler` / `grid_geo_sampler` / `stitch_predictions` factories.
+The catalog is what the samplers iterate; the slices flow downstream into loaders and operators.
+Detailed design — dataclass invariants, sampling math, stitch reductions — lives in [`types/geoslice.md`](../types/geoslice.md).
+This document only covers how the catalog feeds the samplers.
 
 ### 1.5 Auxiliary
 
-`rasterio_utils.py` is *not* a dataset builder — it's GDAL tag read/write helpers. It does not belong in this migration; fold the read helpers into georeader's existing `rasterio_reader.py` and drop the rest.
+`rasterio_utils.py` is *not* a dataset builder — it's GDAL tag read/write helpers.
+It does not belong in this migration; fold the read helpers into georeader's existing `rasterio_reader.py` and drop the rest.
 
 ---
 
 ## 2. User story
 
-**Persona.** A scientist or ML engineer with a folder (or bucket) of N satellite or model-output files spanning years and tiles. Possibly heterogeneous: S2 mixed with Landsat, NetCDF reanalysis mixed with ad-hoc Zarr stores, raster imagery alongside vector labels.
+**Persona.** A scientist or ML engineer with a folder (or bucket) of N satellite or model-output files spanning years and tiles.
+Possibly heterogeneous: S2 mixed with Landsat, NetCDF reanalysis mixed with ad-hoc Zarr stores, raster imagery alongside vector labels.
 
 **Goal arc:**
 
-1. *"I have 10 000 files. Make them queryable."* → `build_*_index(filepaths, regex, target_crs)` → one GeoDataFrame.
+1. *"I have 10 000 files.
+   Make them queryable."* → `build_*_index(filepaths, regex, target_crs)` → one GeoDataFrame.
 2. *"Give me the data for this bbox + this date range."* → `query_index(...)` → filtered subset → `load_and_merge_*(...)` → mosaicked numpy/xarray.
 3. *"Stream me ML training chips."* → `random_geo_sampler(index, chip_size).__call__()` → iterator of `GeoSlice` → call loader per slice → batch.
 4. *"Run my model over the whole AOI for the whole year and write a georeferenced raster."* → `run_inference_with_grid_sampler(index, model, output_path, chip_size, stride)` → stitched output.
 5. *"My imagery is in catalog A, my labels are in catalog B; pair them."* → `intersect_spatiotemporal_indexes(A, B)` → joint catalog, queries return only spatiotemporally-paired tiles.
 6. *"Combine Landsat 7 + Landsat 8 into one virtual dataset."* → `union_spatiotemporal_indexes(L7, L8)`.
 
-The stack is therefore not "yet another dataloader" — it's a **lightweight, file-based, Pythonic STAC**. No JSON catalog format, no service, no pgSTAC. Just a GeoDataFrame you can pickle.
+The stack is therefore not "yet another dataloader" — it's a **lightweight, file-based, Pythonic STAC**.
+No JSON catalog format, no service, no pgSTAC. Just a GeoDataFrame you can pickle.
 
 ---
 
@@ -95,7 +109,9 @@ The stack is therefore not "yet another dataloader" — it's a **lightweight, fi
 
 ### 3.1 The gap this fills in georeader
 
-`georeader` today is excellent at the *single-file* level: open a Sentinel-2 SAFE, read a bbox, get a `GeoTensor`, reproject, save COG. But it has **no story for collections of files**. If the user has ten years of daily files across many tiles, they're on their own to write the catalog, the query, the mosaic, and the temporal stack. These snippets are exactly that missing layer.
+`georeader` today is excellent at the *single-file* level: open a Sentinel-2 SAFE, read a bbox, get a `GeoTensor`, reproject, save COG. But it has **no story for collections of files**.
+If the user has ten years of daily files across many tiles, they're on their own to write the catalog, the query, the mosaic, and the temporal stack.
+These snippets are exactly that missing layer.
 
 The georeader modules these would build on are:
 
@@ -110,8 +126,11 @@ The georeader modules these would build on are:
 
 ### 3.2 Compared with alternatives
 
-- **TorchGeo `RasterDataset`** has the same idea (regex-parsed filename, R-tree, `BoundingBox` query). The snippets are a **lighter, GeoDataFrame-native reimagining** of that pattern, without the torch dependency in the index layer. That's a feature, not a bug — it lets non-ML users (analysis, mosaicking, inference) use the same catalog.
-- **STAC / pystac-client** is heavier: requires a JSON spec, an API, network fetches. The snippets work on local files and return a Python object you can ship around.
+- **TorchGeo `RasterDataset`** has the same idea (regex-parsed filename, R-tree, `BoundingBox` query).
+  The snippets are a **lighter, GeoDataFrame-native reimagining** of that pattern, without the torch dependency in the index layer.
+  That's a feature, not a bug — it lets non-ML users (analysis, mosaicking, inference) use the same catalog.
+- **STAC / pystac-client** is heavier: requires a JSON spec, an API, network fetches.
+  The snippets work on local files and return a Python object you can ship around.
 - **xbatcher / xarray-spatial / odc-geo** overlap with the *xarray* loader but not with the catalog/intersection logic.
 
 The concrete value-add over TorchGeo is therefore:
@@ -125,23 +144,34 @@ The concrete value-add over TorchGeo is therefore:
 
 ## 3.3 Primer for newcomers
 
-> **ELI5.** An R-tree is a **russian-doll of bounding boxes** — each big box knows what smaller boxes it contains. To find files in your area, you only open the boxes that overlap your area, never the rest. Combined with a similar trick for time, queries answer in milliseconds even over thousands of files.
+> **ELI5.** An R-tree is a **russian-doll of bounding boxes** — each big box knows what smaller boxes it contains.
+> To find files in your area, you only open the boxes that overlap your area, never the rest.
+> Combined with a similar trick for time, queries answer in milliseconds even over thousands of files.
 
 ### `gpd.GeoDataFrame` (geopandas)
 
-**What it is.** A `pandas.DataFrame` subclass with a `geometry` column holding Shapely geometries (Polygon, MultiPolygon, Point, LineString). Each row is a feature; rows behave like dataframe rows; the geometry column gets spatial-aware operations.
+**What it is.** A `pandas.DataFrame` subclass with a `geometry` column holding Shapely geometries (Polygon, MultiPolygon, Point, LineString).
+Each row is a feature; rows behave like dataframe rows; the geometry column gets spatial-aware operations.
 
-**How it works.** `gpd.GeoDataFrame({"path": [...], "date": [...], "geometry": [Polygon(...), ...]})` — same constructor pattern as a regular DataFrame, but the `geometry` column is special-cased. Geopandas wraps Shapely (Python bindings to GEOS, the C library) plus pyproj (CRS handling) plus rtree (spatial indexing) plus fiona (file I/O). All the heavy lifting is in C; the Python layer is convenient bookkeeping.
+**How it works.** `gpd.GeoDataFrame({"path": [...], "date": [...], "geometry": [Polygon(...), ...]})` — same constructor pattern as a regular DataFrame, but the `geometry` column is special-cased.
+Geopandas wraps Shapely (Python bindings to GEOS, the C library) plus pyproj (CRS handling) plus rtree (spatial indexing) plus fiona (file I/O).
+All the heavy lifting is in C; the Python layer is convenient bookkeeping.
 
-**What this means for us.** Phase 1's catalog is *literally* a GeoDataFrame plus an `IntervalIndex` for time. Builders read each file's bounds via `WarpedVRT` (lazy reprojection that doesn't read pixels), assemble those into geometries, and stick the result in a gdf. Queries leverage geopandas's existing R-tree + Shapely operations. No new spatial-data-structure code.
+**What this means for us.** Phase 1's catalog is *literally* a GeoDataFrame plus an `IntervalIndex` for time.
+Builders read each file's bounds via `WarpedVRT` (lazy reprojection that doesn't read pixels), assemble those into geometries, and stick the result in a gdf.
+Queries leverage geopandas's existing R-tree + Shapely operations.
+No new spatial-data-structure code.
 
 ### R-tree + IntervalIndex (the indices)
 
 **What it is.** Two indices stacked: an **R-tree** for "find rows whose `geometry` overlaps this bbox" and an **IntervalIndex** for "find rows whose `interval` overlaps this date range." Combined, they answer spatiotemporal queries in `O(log n + k)`.
 
-**How it works.** Geopandas builds the R-tree on first access via the `gdf.sindex` property — backed by libspatialindex's R-tree implementation in C. Pandas builds the IntervalIndex when you attach intervals via `gdf = gdf.set_index(pd.IntervalIndex.from_arrays(start, end, closed='both'))`. A combined query is `gdf[gdf.index.overlaps(query_interval)].cx[xmin:xmax, ymin:ymax]` — first the time filter, then the spatial filter.
+**How it works.** Geopandas builds the R-tree on first access via the `gdf.sindex` property — backed by libspatialindex's R-tree implementation in C. Pandas builds the IntervalIndex when you attach intervals via `gdf = gdf.set_index(pd.IntervalIndex.from_arrays(start, end, closed='both'))`.
+A combined query is `gdf[gdf.index.overlaps(query_interval)].cx[xmin:xmax, ymin:ymax]` — first the time filter, then the spatial filter.
 
-**What this means for us.** A catalog of 10k tile×date rows answers "files overlapping this AOI in June 2023" in sub-millisecond. The index is built lazily (first query pays the construction cost), so importing a Phase 1 catalog is fast even if you never query it. Beyond ~10⁵ rows the gdf's row-iteration overhead dominates and you should switch to Phase 2 (DuckDB).
+**What this means for us.** A catalog of 10k tile×date rows answers "files overlapping this AOI in June 2023" in sub-millisecond.
+The index is built lazily (first query pays the construction cost), so importing a Phase 1 catalog is fast even if you never query it.
+Beyond ~10⁵ rows the gdf's row-iteration overhead dominates and you should switch to Phase 2 (DuckDB).
 
 ```{mermaid}
 flowchart TD
@@ -162,11 +192,15 @@ flowchart TD
 
 ### Set algebra over catalogs
 
-**What it is.** Catalogs support `query`, `intersect`, and `union` operations that produce new catalogs — like set operations on indexed file collections. Lets you compose "data I have" with "data I want" without writing custom join code per workflow.
+**What it is.** Catalogs support `query`, `intersect`, and `union` operations that produce new catalogs — like set operations on indexed file collections.
+Lets you compose "data I have" with "data I want" without writing custom join code per workflow.
 
-**How it works.** `intersect(catalog_A, catalog_B)` walks pairs of geometries (using the R-tree to skip non-intersecting pairs), computes per-pair `(geom_A ∩ geom_B, max(start_A, start_B), min(end_A, end_B))`, drops empty intersections. `union` is the opposite — concatenate, then optionally dedupe. `query` is "intersect with a single-row catalog" — the AOI is a one-row catalog with one geometry and one interval.
+**How it works.** `intersect(catalog_A, catalog_B)` walks pairs of geometries (using the R-tree to skip non-intersecting pairs), computes per-pair `(geom_A ∩ geom_B, max(start_A, start_B), min(end_A, end_B))`, drops empty intersections.
+`union` is the opposite — concatenate, then optionally dedupe.
+`query` is "intersect with a single-row catalog" — the AOI is a one-row catalog with one geometry and one interval.
 
-**What this means for us.** Pairing imagery with labels (raster × vector across two backends), building cross-sensor catalogs (S2 + Landsat for change detection), filtering to "files that have all three of (S2, EnMAP, ERA5)" — all expressible as catalog set algebra, not bespoke pandas joins each time. Same shape carries to Phase 2 where it's SQL `INTERSECT` / `UNION` under the hood.
+**What this means for us.** Pairing imagery with labels (raster × vector across two backends), building cross-sensor catalogs (S2 + Landsat for change detection), filtering to "files that have all three of (S2, EnMAP, ERA5)" — all expressible as catalog set algebra, not bespoke pandas joins each time.
+Same shape carries to Phase 2 where it's SQL `INTERSECT` / `UNION` under the hood.
 
 ```{mermaid}
 sequenceDiagram
@@ -198,7 +232,8 @@ with rasterio.open(filepath) as src:
         polygon = shapely.geometry.box(xmin, ymin, xmax, ymax)
 ```
 
-`WarpedVRT` is a *lazy* virtual reprojection: bounds are computed analytically from the source's affine + CRS without resampling pixels. This is what makes indexing 10 000 files fast.
+`WarpedVRT` is a *lazy* virtual reprojection: bounds are computed analytically from the source's affine + CRS without resampling pixels.
+This is what makes indexing 10 000 files fast.
 
 ### 4.2 Temporal interval construction
 
@@ -209,7 +244,8 @@ mint = pd.Timestamp(date_str).floor('D')          # 00:00:00.000000
 maxt = pd.Timestamp(date_str).ceil('D') - 1e-6    # 23:59:59.999999
 ```
 
-For a `(start, stop)` filename, the interval is `[floor(start), ceil(stop) - 1µs]`. For files with no date, `(pd.Timestamp.min, pd.Timestamp.max)` — a point of contention; see [§7](#7-sharp-edges-to-fix-on-the-way-in).
+For a `(start, stop)` filename, the interval is `[floor(start), ceil(stop) - 1µs]`.
+For files with no date, `(pd.Timestamp.min, pd.Timestamp.max)` — a point of contention; see [§7](#7-sharp-edges-to-fix-on-the-way-in).
 
 ### 4.3 Combined query
 
@@ -235,7 +271,8 @@ $$
 [\max(a_1, a_2),\ \min(b_1, b_2)]
 $$
 
-discarded if `min(b₁, b₂) < max(a₁, a₂)`. Vectorised:
+discarded if `min(b₁, b₂) < max(a₁, a₂)`.
+Vectorised:
 
 ```python
 mint  = np.maximum(datetime_1.left,  datetime_2.left)
@@ -247,7 +284,8 @@ The result's `IntervalIndex` is built from those two arrays with `closed='both'`
 
 ### 4.5 Sampler and stitch math
 
-Random-sampler weighting (area-weighted tile selection + uniform chip placement), grid-sampler stride math, and the four stitch-reduction modes (`average` / `max` / `first` / `last`) are specified in [`types/geoslice.md`](../types/geoslice.md). Those primitives consume what this catalog produces but aren't catalog-specific — see that document for invariants and edge cases.
+Random-sampler weighting (area-weighted tile selection + uniform chip placement), grid-sampler stride math, and the four stitch-reduction modes (`average` / `max` / `first` / `last`) are specified in [`types/geoslice.md`](../types/geoslice.md).
+Those primitives consume what this catalog produces but aren't catalog-specific — see that document for invariants and edge cases.
 
 ---
 
@@ -297,7 +335,8 @@ georeader/
 
 ### 6.2 Core types
 
-`GeoSlice` is specified in [`types/geoslice.md`](../types/geoslice.md). The catalog imports and re-exports it for convenience.
+`GeoSlice` is specified in [`types/geoslice.md`](../types/geoslice.md).
+The catalog imports and re-exports it for convenience.
 
 ```python
 class GeoCatalog:
@@ -390,11 +429,14 @@ The shift from `dict[str, np.ndarray]` to `GeoTensor` is the single biggest clea
 
 ### 6.5 Samplers
 
-`random_sampler`, `grid_sampler`, and `stitch` are specified in [`types/geoslice.md`](../types/geoslice.md) — including signatures, area-weighting math, stride math, and the four stitch reduction modes. From the catalog's perspective the only API touchpoint is that all three accept a `GeoCatalog` and consume `iter_rows()` / `query()` to find tiles.
+`random_sampler`, `grid_sampler`, and `stitch` are specified in [`types/geoslice.md`](../types/geoslice.md) — including signatures, area-weighting math, stride math, and the four stitch reduction modes.
+From the catalog's perspective the only API touchpoint is that all three accept a `GeoCatalog` and consume `iter_rows()` / `query()` to find tiles.
 
 ### 6.6 What I'd cut
 
-- `run_inference_with_grid_sampler` — too opinionated. Replace with a 5-line cookbook example. Library shouldn't own the model loop.
+- `run_inference_with_grid_sampler` — too opinionated.
+  Replace with a 5-line cookbook example.
+  Library shouldn't own the model loop.
 - The `dict[str, np.ndarray]` return contract.
 - Hardcoded `torch.long` in the vector loaders; make torch optional, default to numpy with `dtype=np.int64`.
 - `loguru` as a hard dependency — switch to stdlib `logging`.
@@ -404,22 +446,35 @@ The shift from `dict[str, np.ndarray]` to `GeoTensor` is the single biggest clea
 
 ## 7. Sharp edges to fix on the way in
 
-1. **Two literal syntax errors in `dataset_vector.py`** — the file has never run. Tells you tests are sparse.
-2. **`pd.Timestamp.min` / `Timestamp.max` as fallback intervals** for date-less files will dominate `IntervalIndex` ranges and make logs misleading. Either require a date or carry an explicit `static` flag.
-3. **Bounds in unprojected lat/lon get distorted by `WarpedVRT`** — for files spanning the antimeridian or poles, `.bounds` is the *reprojected* envelope, not a great-circle hull. Document this; consider exposing a `densify=N` option that samples the boundary before reprojection.
-4. **`t_sample = interval.left.value / 1e9`** uses `Timestamp.value` (nanoseconds). Fine, but it'll silently break for `Timestamp.min` / `.max` (overflow on the float). Skip random temporal sampling when the interval is "infinite".
-5. **`gpd.overlay` is `O(n × m)`** worst-case despite the R-tree. For `10k × 10k` catalogs this is slow; document the cost or add a chunked variant.
-6. **Hardcoded `nodata=0`** in the xarray merge call. Should respect the source's `_FillValue` / `nodata`.
-7. **`merge_method='count'`** is listed in the raster loader signature but isn't a valid `rasterio.merge` method. Either implement or remove.
-8. **`use_cache=True` + `lru_cache`** on file handles in long-running processes — at fork time these break under multiprocessing dataloaders. Document or disable in worker contexts.
-9. **No tests, no examples** that exercise multi-CRS catalogs (e.g. mixing UTM zones). The most likely real-world failure mode.
-10. **`loguru` everywhere** — gives nice-looking logs but is a hard dep. Bury behind stdlib `logging` so georeader users aren't forced into it.
+1. **Two literal syntax errors in `dataset_vector.py`** — the file has never run.
+   Tells you tests are sparse.
+2. **`pd.Timestamp.min` / `Timestamp.max` as fallback intervals** for date-less files will dominate `IntervalIndex` ranges and make logs misleading.
+   Either require a date or carry an explicit `static` flag.
+3. **Bounds in unprojected lat/lon get distorted by `WarpedVRT`** — for files spanning the antimeridian or poles, `.bounds` is the *reprojected* envelope, not a great-circle hull.
+   Document this; consider exposing a `densify=N` option that samples the boundary before reprojection.
+4. **`t_sample = interval.left.value / 1e9`** uses `Timestamp.value` (nanoseconds).
+   Fine, but it'll silently break for `Timestamp.min` / `.max` (overflow on the float).
+   Skip random temporal sampling when the interval is "infinite".
+5. **`gpd.overlay` is `O(n × m)`** worst-case despite the R-tree.
+   For `10k × 10k` catalogs this is slow; document the cost or add a chunked variant.
+6. **Hardcoded `nodata=0`** in the xarray merge call.
+   Should respect the source's `_FillValue` / `nodata`.
+7. **`merge_method='count'`** is listed in the raster loader signature but isn't a valid `rasterio.merge` method.
+   Either implement or remove.
+8. **`use_cache=True` + `lru_cache`** on file handles in long-running processes — at fork time these break under multiprocessing dataloaders.
+   Document or disable in worker contexts.
+9. **No tests, no examples** that exercise multi-CRS catalogs (e.g. mixing UTM zones).
+   The most likely real-world failure mode.
+10. **`loguru` everywhere** — gives nice-looking logs but is a hard dep.
+    Bury behind stdlib `logging` so georeader users aren't forced into it.
 
 ---
 
 ## 8. End-to-end examples
 
-A varied gallery, organized by intent. Each example uses only the proposed API; small extensions beyond §6 are flagged inline as `# extension:` comments. Imports are kept minimal per snippet — assume `numpy as np`, `pandas as pd` everywhere.
+A varied gallery, organized by intent.
+Each example uses only the proposed API; small extensions beyond §6 are flagged inline as `# extension:` comments.
+Imports are kept minimal per snippet — assume `numpy as np`, `pandas as pd` everywhere.
 
 | § | Example | Pattern |
 | --- | --- | --- |
@@ -650,7 +705,8 @@ for sl in random_sampler(paired, chip_size=(512, 512)):
 
 #### I. SAR + optical fusion (Sentinel-1 GRD + Sentinel-2 L2A)
 
-Different acquisition cadences. Pad each S1 row's interval by ±3 days so `intersect` allows loose temporal pairing, then fuse on load.
+Different acquisition cadences.
+Pad each S1 row's interval by ±3 days so `intersect` allows loose temporal pairing, then fuse on load.
 
 ```python
 from georeader.catalog import build_raster_catalog
@@ -696,7 +752,9 @@ combined = np.concatenate([x_high.values, x_low.values], axis=0)                
 
 #### K. Multi-modal stack: optical + DEM (static) + ERA5 (coarse, lat/lon)
 
-Three backends and two CRSs. DEM has no time → `spatial_only=True`. ERA5 is xarray in EPSG:4326 → reproject the slice on the fly.
+Three backends and two CRSs.
+DEM has no time → `spatial_only=True`.
+ERA5 is xarray in EPSG:4326 → reproject the slice on the fly.
 
 ```python
 from georeader.catalog import build_raster_catalog, build_xarray_catalog, load_raster, load_xarray
@@ -781,7 +839,8 @@ for a, p in temporal_pair_sampler(catalog, (224, 224), 100_000):
 
 #### N. Spatial-block cross-validation (no spatial leakage)
 
-Cluster tile centroids into K spatial blocks; fold by block, never by row. Critical for honest generalization estimates on geospatial models.
+Cluster tile centroids into K spatial blocks; fold by block, never by row.
+Critical for honest generalization estimates on geospatial models.
 
 ```python
 from sklearn.cluster import KMeans
@@ -838,7 +897,9 @@ The new examples lean on a small set of conveniences that aren't in §6's minima
 
 ## 9. Verdict
 
-The snippets are the **right idea, executed roughly**. The shared GeoDataFrame index is genuinely good — the algebra (`intersect` / `union` / `query`) falls out for free, three backends share one shape, and the math is sound (modulo the sharp edges in [§7](#7-sharp-edges-to-fix-on-the-way-in)). The samplers and stitching are textbook but correct.
+The snippets are the **right idea, executed roughly**.
+The shared GeoDataFrame index is genuinely good — the algebra (`intersect` / `union` / `query`) falls out for free, three backends share one shape, and the math is sound (modulo the sharp edges in [§7](#7-sharp-edges-to-fix-on-the-way-in)).
+The samplers and stitching are textbook but correct.
 
 What needs work before promotion to a public georeader API:
 
@@ -859,29 +920,45 @@ The Phase 1 / Phase 2 design is sound; several execution-level concerns deserve 
 
 ### 10.1 Cross-CRS query footgun
 
-The catalog stores all geometries in a uniform target CRS (Phase 1 default: source CRS preserved per-row but reprojected for query; Phase 2 convention from `geoduckdb.md` §4: write all GeoParquet in EPSG:4326). Users querying `WHERE ST_Intersects(geom, AOI)` with AOI in a non-target CRS get **silently empty results** — no error, just no rows. **Mitigation:** provide a `query` helper that takes `(aoi: shapely.Geometry, aoi_crs: pyproj.CRS)` and projects internally before passing to the underlying engine. Make this the canonical path; the raw `gdf.cx[...]` / SQL paths assume the AOI is already in catalog CRS.
+The catalog stores all geometries in a uniform target CRS (Phase 1 default: source CRS preserved per-row but reprojected for query; Phase 2 convention from `geoduckdb.md` §4: write all GeoParquet in EPSG:4326).
+Users querying `WHERE ST_Intersects(geom, AOI)` with AOI in a non-target CRS get **silently empty results** — no error, just no rows.
+**Mitigation:** provide a `query` helper that takes `(aoi: shapely.Geometry, aoi_crs: pyproj.CRS)` and projects internally before passing to the underlying engine.
+Make this the canonical path; the raw `gdf.cx[...]` / SQL paths assume the AOI is already in catalog CRS.
 
 ### 10.2 GeoParquet 1.1 writer adoption is uneven
 
-`geopandas.to_parquet` defaults to GeoParquet 1.0; the per-row bbox column for predicate pushdown requires **GeoParquet 1.1**, which means an explicit `version="1.1"` flag (or whatever the geopandas writer uses) and a `geopandas` version pin. DuckDB's GeoParquet *write* path is newer than its read path. **Mitigation:** pin `geopandas >= 0.14` (or whatever first-shipped 1.1 writer) and `duckdb >= 1.1` explicitly in the package metadata; add a CI test that round-trips a small catalog through `to_geoparquet` → disk → `from_geoparquet` and verifies the bbox column survives.
+`geopandas.to_parquet` defaults to GeoParquet 1.0; the per-row bbox column for predicate pushdown requires **GeoParquet 1.1**, which means an explicit `version="1.1"` flag (or whatever the geopandas writer uses) and a `geopandas` version pin.
+DuckDB's GeoParquet *write* path is newer than its read path.
+**Mitigation:** pin `geopandas >= 0.14` (or whatever first-shipped 1.1 writer) and `duckdb >= 1.1` explicitly in the package metadata; add a CI test that round-trips a small catalog through `to_geoparquet` → disk → `from_geoparquet` and verifies the bbox column survives.
 
 ### 10.3 Phase 2 risk of bit-rot
 
-Most users will stay on Phase 1 (GeoPandas + IntervalIndex) for the 90% case. Phase 2 (DuckDB) won't get exercised unless someone hits the 10⁶+-row threshold. **Risk:** untested code paths on the upgrade. **Mitigation:** gate the Phase 2 release behind one real Phase 2 user (a multi-million-row catalog from your own work, or a community case study); add a multi-million-row CI fixture if no organic user emerges within v0.2.
+Most users will stay on Phase 1 (GeoPandas + IntervalIndex) for the 90% case.
+Phase 2 (DuckDB) won't get exercised unless someone hits the 10⁶+-row threshold.
+**Risk:** untested code paths on the upgrade.
+**Mitigation:** gate the Phase 2 release behind one real Phase 2 user (a multi-million-row catalog from your own work, or a community case study); add a multi-million-row CI fixture if no organic user emerges within v0.2.
 
 ### 10.4 `schema_version` column is reserved, not used yet
 
-GeoParquet schemas evolve. Reserve a `schema_version` column from v0.1 so future migrations are tractable; current Phase 1 schema is de facto v0; bump to v1 the first time we change anything substantive (e.g. add a `n_timesteps` column). Document the migration runbook so this doesn't turn into tribal knowledge.
+GeoParquet schemas evolve.
+Reserve a `schema_version` column from v0.1 so future migrations are tractable; current Phase 1 schema is de facto v0; bump to v1 the first time we change anything substantive (e.g. add a `n_timesteps` column).
+Document the migration runbook so this doesn't turn into tribal knowledge.
 
 ### 10.5 Concurrent write semantics
 
-Phase 1 (GeoPandas in memory) is single-writer. Phase 2 (DuckDB on a shared GeoParquet) is **read-safe** across processes; **write-safe only if you treat Parquet as append-only** (new row groups in new files, not in-place mutation). Document the recommended write pattern; users coordinating multiple crawlers will trip over this.
+Phase 1 (GeoPandas in memory) is single-writer.
+Phase 2 (DuckDB on a shared GeoParquet) is **read-safe** across processes; **write-safe only if you treat Parquet as append-only** (new row groups in new files, not in-place mutation).
+Document the recommended write pattern; users coordinating multiple crawlers will trip over this.
 
 ### 10.6 IntervalIndex edge cases
 
-`pd.IntervalIndex` with `closed="both"` handles overlapping intervals fine, but **back-to-back intervals** (one ends at `t`, next starts at `t`) double-count at the boundary. For sub-daily satellite data this rarely matters; for daily/hourly products it does. Decide on `closed="left"` vs `closed="both"` and stick with it; document the choice.
+`pd.IntervalIndex` with `closed="both"` handles overlapping intervals fine, but **back-to-back intervals** (one ends at `t`, next starts at `t`) double-count at the boundary.
+For sub-daily satellite data this rarely matters; for daily/hourly products it does.
+Decide on `closed="left"` vs `closed="both"` and stick with it; document the choice.
 
 ### 10.7 Adapter scope
 
-The plan mentions STAC read/write adapters and a `GeoDataset` torch adapter. Each adapter is a small library on its own — STAC has its own metadata model that doesn't round-trip cleanly to a GeoDataFrame in all cases (collections vs items, asset-level metadata). **Scope honestly:** v0.1 ships `to_geoparquet` / `from_geoparquet` round-trip; STAC and torch adapters are v0.2+. Don't promise adapters that aren't built.
+The plan mentions STAC read/write adapters and a `GeoDataset` torch adapter.
+Each adapter is a small library on its own — STAC has its own metadata model that doesn't round-trip cleanly to a GeoDataFrame in all cases (collections vs items, asset-level metadata).
+**Scope honestly:** v0.1 ships `to_geoparquet` / `from_geoparquet` round-trip; STAC and torch adapters are v0.2+. Don't promise adapters that aren't built.
 

--- a/projects/geotoolz/plans/geodatabase/geoduckdb.md
+++ b/projects/geotoolz/plans/geodatabase/geoduckdb.md
@@ -15,9 +15,8 @@ license: CC-BY-4.0
 keywords: design, geodatabase, duckdb, geoparquet
 ---
 
-> **Scope:** adding a DuckDB-backed catalog backend, GeoParquet-as-artifact, and SQL-native cross-catalog operations to the [`jejjohnson/georeader`](https://github.com/jejjohnson/georeader) `catalog` module proposed in Phase 1.
->
-> **Status:** design proposal, no code changed yet. Assumes Phase 1 (the in-memory `GeoCatalog`, builders, loaders, samplers, and `to_geoparquet`/`from_geoparquet` round-trip) has shipped.
+> **Scope:** adding a DuckDB-backed catalog backend, GeoParquet-as-artifact, and SQL-native cross-catalog operations to the [`jejjohnson/georeader`](https://github.com/jejjohnson/georeader) `catalog` module proposed in Phase 1.  **Status:** design proposal, no code changed yet.
+> Assumes Phase 1 (the in-memory `GeoCatalog`, builders, loaders, samplers, and `to_geoparquet`/`from_geoparquet` round-trip) has shipped.
 
 ---
 
@@ -63,7 +62,8 @@ DuckDB is an in-process columnar OLAP engine with a `spatial` extension that giv
 
 ### 1.2 Spatial extension
 
-GEOS-backed, GeoParquet 1.x compatible. The functions Phase 2 leans on:
+GEOS-backed, GeoParquet 1.x compatible.
+The functions Phase 2 leans on:
 
 | Category | Functions used |
 | --- | --- |
@@ -74,26 +74,32 @@ GEOS-backed, GeoParquet 1.x compatible. The functions Phase 2 leans on:
 | CRS | `ST_Transform` (requires the `spatial` extension's bundled PROJ data) |
 | Indexing | `CREATE INDEX ... USING RTREE` (on `.duckdb` table files only) |
 
-Spatial joins build an in-memory R-tree on the smaller side per query. Persistent on-disk R-trees are limited to materialized DuckDB tables, not Parquet — see [§7](#7-sharp-edges).
+Spatial joins build an in-memory R-tree on the smaller side per query.
+Persistent on-disk R-trees are limited to materialized DuckDB tables, not Parquet — see [§7](#7-sharp-edges).
 
 ### 1.3 GeoParquet support
 
 - Reads any GeoParquet 1.0/1.1 file produced by `geopandas.to_parquet` (or by DuckDB itself).
 - Writes via `COPY ... TO 'file.parquet' (FORMAT 'parquet', COMPRESSION 'zstd')` — schema includes WKB geometry + GeoParquet-style column metadata when the spatial extension is loaded.
-- GeoParquet **1.1** introduces a per-row `bbox` covering struct that lets the engine push spatial filters down to the row-group level *without parsing WKB*. For 10⁷-row catalogs this is roughly an order-of-magnitude speedup on selective queries.
+- GeoParquet **1.1** introduces a per-row `bbox` covering struct that lets the engine push spatial filters down to the row-group level *without parsing WKB*.
+  For 10⁷-row catalogs this is roughly an order-of-magnitude speedup on selective queries.
 
-> ⚠️ The `spatial` extension's GeoParquet *write* path is more recent than the read path. Pin a known-good DuckDB version (≥ 1.1) and add a smoke test that round-trips a small catalog.
+> ⚠️ The `spatial` extension's GeoParquet *write* path is more recent than the read path.
+> Pin a known-good DuckDB version (≥ 1.1) and add a smoke test that round-trips a small catalog.
 
 ---
 
 ## 2. User story
 
-**Persona shift.** Phase 1's user has hundreds to thousands of files in one project. Phase 2's user has *too many to load eagerly*, or *wants to publish* a catalog so a collaborator (or a CI job, or a notebook on a different machine) can query it without rebuilding.
+**Persona shift.** Phase 1's user has hundreds to thousands of files in one project.
+Phase 2's user has *too many to load eagerly*, or *wants to publish* a catalog so a collaborator (or a CI job, or a notebook on a different machine) can query it without rebuilding.
 
 **Goal arc:**
 
-1. *"I built a 1M-row catalog yesterday. Reload it instantly."* → `open_catalog("cat.parquet")` (no `build_*_catalog` needed).
-2. *"My collaborator wants to query my catalog from her laptop."* → I push to `s3://bucket/cat.parquet`; she runs `open_catalog("s3://bucket/cat.parquet")`. Only the row groups her query touches get downloaded.
+1. *"I built a 1M-row catalog yesterday.
+   Reload it instantly."* → `open_catalog("cat.parquet")` (no `build_*_catalog` needed).
+2. *"My collaborator wants to query my catalog from her laptop."* → I push to `s3://bucket/cat.parquet`; she runs `open_catalog("s3://bucket/cat.parquet")`.
+   Only the row groups her query touches get downloaded.
 3. *"Intersect 200k imagery rows with 500k label rows."* → SQL spatial join, parallel, minutes instead of an OOM.
 4. *"How does my coverage break down by month, by tile, by cloud %?"* → one SQL query against the catalog, no loop.
 5. *"Stream candidate slices into the random sampler without materializing the join."* → DuckDB cursor → `iter_rows()` → sampler.
@@ -130,34 +136,55 @@ The framing: **DuckDB doesn't replace Phase 1, it extends the working envelope b
 
 ### 3.3 Compared with alternatives
 
-- **STAC + pgSTAC / stac-fastapi.** Heavier: needs Postgres, a schema, an HTTP service. Wins on standardization and federated discovery. Loses on dev velocity for single-user / single-team workflows.
-- **PostGIS + GeoAlchemy.** Real database. More features (transactions, advanced indexes, triggers). Far more setup. Best when you already run Postgres for other reasons.
-- **xstac + intake-stac.** Library-only, no server. But STAC items are JSON-per-file, so a 1M-item catalog is 1M JSON files or one giant blob — both worse than one Parquet file for the queries we care about.
-- **Plain `gpd.read_parquet` + Python.** What Phase 1 already gives via `from_geoparquet`. Fine until you need joins or analytics at scale.
+- **STAC + pgSTAC / stac-fastapi.** Heavier: needs Postgres, a schema, an HTTP service.
+  Wins on standardization and federated discovery.
+  Loses on dev velocity for single-user / single-team workflows.
+- **PostGIS + GeoAlchemy.** Real database.
+  More features (transactions, advanced indexes, triggers).
+  Far more setup.
+  Best when you already run Postgres for other reasons.
+- **xstac + intake-stac.** Library-only, no server.
+  But STAC items are JSON-per-file, so a 1M-item catalog is 1M JSON files or one giant blob — both worse than one Parquet file for the queries we care about.
+- **Plain `gpd.read_parquet` + Python.** What Phase 1 already gives via `from_geoparquet`.
+  Fine until you need joins or analytics at scale.
 
-The unique slot DuckDB occupies: **zero-server, single-file, parallel, SQL, with native Parquet + spatial**. Nothing else hits all five.
+The unique slot DuckDB occupies: **zero-server, single-file, parallel, SQL, with native Parquet + spatial**.
+Nothing else hits all five.
 
 ---
 
 ## 3.4 Primer for newcomers
 
-> **ELI5.** GeoParquet is like a **phone book for spatial data** — alphabetised columns of data with bbox info on every page. DuckDB is the librarian who can read the bbox info to *skip 99% of pages* when you ask "who's in Madagascar?" — without ever opening those pages. The combination scales to millions of files because it never reads what it doesn't need.
+> **ELI5.** GeoParquet is like a **phone book for spatial data** — alphabetised columns of data with bbox info on every page.
+> DuckDB is the librarian who can read the bbox info to *skip 99% of pages* when you ask "who's in Madagascar?" — without ever opening those pages.
+> The combination scales to millions of files because it never reads what it doesn't need.
 
 ### DuckDB: an embedded SQL database
 
-**What it is.** DuckDB is a SQL database that runs in-process — no server, no daemon. Think SQLite, but column-oriented and tuned for analytics (OLAP) rather than transactional workloads. Open-source, fast, with a `spatial` extension that adds GIS functions.
+**What it is.** DuckDB is a SQL database that runs in-process — no server, no daemon.
+Think SQLite, but column-oriented and tuned for analytics (OLAP) rather than transactional workloads.
+Open-source, fast, with a `spatial` extension that adds GIS functions.
 
-**How it works.** `import duckdb; con = duckdb.connect()` gives you a SQL engine in your Python process. Queries run against tables (in-memory), Parquet files (read directly without import), or a persistent on-disk database. The `spatial` extension adds `ST_Intersects`, `ST_Contains`, `GEOMETRY` types — basically PostGIS in an embedded engine.
+**How it works.** `import duckdb; con = duckdb.connect()` gives you a SQL engine in your Python process.
+Queries run against tables (in-memory), Parquet files (read directly without import), or a persistent on-disk database.
+The `spatial` extension adds `ST_Intersects`, `ST_Contains`, `GEOMETRY` types — basically PostGIS in an embedded engine.
 
-**What this means for us.** Phase 2 stores catalogs as GeoParquet on disk (or in cloud storage); DuckDB reads them lazily. Queries are vanilla SQL: `SELECT path FROM catalog WHERE ST_Intersects(geometry, AOI) AND date BETWEEN '2023-01-01' AND '2023-12-31'`. No daemon, no schema migrations, no driver dance — it's a Python import.
+**What this means for us.** Phase 2 stores catalogs as GeoParquet on disk (or in cloud storage); DuckDB reads them lazily.
+Queries are vanilla SQL: `SELECT path FROM catalog WHERE ST_Intersects(geometry, AOI) AND date BETWEEN '2023-01-01' AND '2023-12-31'`.
+No daemon, no schema migrations, no driver dance — it's a Python import.
 
 ### GeoParquet 1.1 + bbox-column predicate pushdown
 
-**What it is.** **GeoParquet** is a spec for storing geometry columns inside Apache Parquet files. **Predicate pushdown** is the database-engine optimisation that lets a query skip reading rows that obviously can't match. **GeoParquet 1.1** adds an optional `bbox` column that makes spatial predicate pushdown work for cloud-hosted Parquet.
+**What it is.** **GeoParquet** is a spec for storing geometry columns inside Apache Parquet files.
+**Predicate pushdown** is the database-engine optimisation that lets a query skip reading rows that obviously can't match. **GeoParquet 1.1** adds an optional `bbox` column that makes spatial predicate pushdown work for cloud-hosted Parquet.
 
-**How it works.** Parquet stores data in row-groups (typically ~10⁵ rows each), each with min/max statistics per column. A query like `WHERE date > '2023-06-01'` skips row-groups whose date max is < 2023-06-01 without reading them. Adding a per-row `bbox` column (four floats: `xmin`, `ymin`, `xmax`, `ymax`) extends this to spatial predicates: `ST_Intersects(geometry, AOI)` translates to `bbox.xmin < AOI.xmax AND bbox.xmax > AOI.xmin AND ...`, which uses Parquet's column statistics. Now a 1M-row catalog answers a small-AOI query by reading ~10⁵ rows of bbox data, not all 1M geometries.
+**How it works.** Parquet stores data in row-groups (typically ~10⁵ rows each), each with min/max statistics per column.
+A query like `WHERE date > '2023-06-01'` skips row-groups whose date max is < 2023-06-01 without reading them.
+Adding a per-row `bbox` column (four floats: `xmin`, `ymin`, `xmax`, `ymax`) extends this to spatial predicates: `ST_Intersects(geometry, AOI)` translates to `bbox.xmin < AOI.xmax AND bbox.xmax > AOI.xmin AND ...`, which uses Parquet's column statistics.
+Now a 1M-row catalog answers a small-AOI query by reading ~10⁵ rows of bbox data, not all 1M geometries.
 
-**What this means for us.** A Phase 2 catalog hosted on S3 can be queried with sub-second latency for the typical AOI-bounded workload, even at multi-million row scales — without downloading the full catalog. The catalog *itself* becomes a queryable cloud artifact, not a thing you download to use.
+**What this means for us.** A Phase 2 catalog hosted on S3 can be queried with sub-second latency for the typical AOI-bounded workload, even at multi-million row scales — without downloading the full catalog.
+The catalog *itself* becomes a queryable cloud artifact, not a thing you download to use.
 
 ```{mermaid}
 flowchart TD
@@ -172,11 +199,15 @@ flowchart TD
 
 ### Lazy queries / cursors
 
-**What it is.** A *cursor* is a query handle that yields rows on demand, rather than materialising the whole result set up front. Standard database concept; the difference between `SELECT * FROM big_table` returning 10M rows in memory vs streaming them.
+**What it is.** A *cursor* is a query handle that yields rows on demand, rather than materialising the whole result set up front.
+Standard database concept; the difference between `SELECT * FROM big_table` returning 10M rows in memory vs streaming them.
 
-**How it works.** DuckDB returns query results lazily by default — `con.execute("SELECT ...")` returns a relation object that hasn't fetched anything yet. `.fetchall()` materialises; `.fetchmany(N)` streams N at a time; `.arrow()` returns an Arrow stream that downstream consumers (sampler, loader) can iterate without ever holding the full result.
+**How it works.** DuckDB returns query results lazily by default — `con.execute("SELECT ...")` returns a relation object that hasn't fetched anything yet.
+`.fetchall()` materialises; `.fetchmany(N)` streams N at a time; `.arrow()` returns an Arrow stream that downstream consumers (sampler, loader) can iterate without ever holding the full result.
 
-**What this means for us.** A `random_sampler` over a 10M-row catalog doesn't need to load 10M rows into Python — it iterates the cursor and reservoir-samples without ever materialising. Same for `grid_sampler` walking tiles in a continent-scale catalog. The streaming cursor is what makes Phase 2 the right tool above 10⁵ rows.
+**What this means for us.** A `random_sampler` over a 10M-row catalog doesn't need to load 10M rows into Python — it iterates the cursor and reservoir-samples without ever materialising.
+Same for `grid_sampler` walking tiles in a continent-scale catalog.
+The streaming cursor is what makes Phase 2 the right tool above 10⁵ rows.
 
 ```{mermaid}
 sequenceDiagram
@@ -202,9 +233,14 @@ sequenceDiagram
 
 **What it is.** Building a catalog one shard at a time without ever holding the full catalog in memory — needed when the catalog is too big to fit (e.g., the full Sentinel-2 archive is ~10⁷ scenes).
 
-**How it works.** Two patterns. **Append-to-Parquet:** write rows in chunks to a growing Parquet file; the writer holds only the current chunk. **DuckDB INSERT INTO:** create a table, insert rows in chunks, export to Parquet at the end; DuckDB handles its own paging. The Phase 2 builders use the first pattern (append-to-Parquet) because it doesn't require DuckDB during construction — just a Parquet writer.
+**How it works.** Two patterns.
+**Append-to-Parquet:** write rows in chunks to a growing Parquet file; the writer holds only the current chunk.
+**DuckDB INSERT INTO:** create a table, insert rows in chunks, export to Parquet at the end; DuckDB handles its own paging.
+The Phase 2 builders use the first pattern (append-to-Parquet) because it doesn't require DuckDB during construction — just a Parquet writer.
 
-**What this means for us.** Catalog builders that scan millions of files don't OOM partway through. Each shard is a small append; the final Parquet file is what users query against. Without streaming, Phase 2's "10⁶+ row catalog" claim wouldn't survive contact with reality at the build step.
+**What this means for us.** Catalog builders that scan millions of files don't OOM partway through.
+Each shard is a small append; the final Parquet file is what users query against.
+Without streaming, Phase 2's "10⁶+ row catalog" claim wouldn't survive contact with reality at the build step.
 
 ---
 
@@ -212,7 +248,8 @@ sequenceDiagram
 
 ### 4.1 Predicate pushdown via Parquet zone maps
 
-A Parquet file is a sequence of *row groups*; each row group has, per column, min/max statistics. GeoParquet adds a per-row-group geometry bbox (and, in 1.1, an optional per-row bbox column).
+A Parquet file is a sequence of *row groups*; each row group has, per column, min/max statistics.
+GeoParquet adds a per-row-group geometry bbox (and, in 1.1, an optional per-row bbox column).
 
 For a query
 
@@ -241,7 +278,8 @@ $$
 \text{cost} \;\approx\; \underbrace{n \log n}_{\text{R-tree build on A}} \;+\; \underbrace{m \log n}_{\text{probes from B}} \;+\; \underbrace{k}_{\text{candidate refinement}}
 $$
 
-where `k` is the candidate match count after bbox filtering, refined by the exact `ST_Intersects` predicate. Compare with `gpd.overlay`'s effective `O(n + m + n × m')` (R-tree filter then per-pair intersection check), which dominates for dense overlap.
+where `k` is the candidate match count after bbox filtering, refined by the exact `ST_Intersects` predicate.
+Compare with `gpd.overlay`'s effective `O(n + m + n × m')` (R-tree filter then per-pair intersection check), which dominates for dense overlap.
 
 Empirically, on the same machine: a 200 k × 500 k spatial join takes minutes in DuckDB, hours in geopandas, and OOMs at 1M × 1M in geopandas while completing in DuckDB.
 
@@ -253,7 +291,8 @@ The interval-overlap predicate
 a.tmax >= b.tmin AND a.tmin <= b.tmax
 ```
 
-is recognized by DuckDB's optimizer as a **range join** (a.k.a. band join). The algorithm sorts both sides by `tmin`, then sweeps:
+is recognized by DuckDB's optimizer as a **range join** (a.k.a. band join).
+The algorithm sorts both sides by `tmin`, then sweeps:
 
 ```
 sort A by tmin, B by tmin
@@ -267,13 +306,15 @@ Cost: $O(n \log n + m \log m + |\text{matches}|)$. No nested-loop blow-up.
 
 ### 4.4 Combined spatiotemporal join cost
 
-For a query that joins on both space and time, DuckDB's planner picks the more selective predicate first based on column statistics. Typical plan:
+For a query that joins on both space and time, DuckDB's planner picks the more selective predicate first based on column statistics.
+Typical plan:
 
 1. Spatial join via R-tree (filters out 99%+ of pairs in most workloads).
 2. Apply temporal predicate as a post-filter.
 3. Compute `ST_Intersection` only for surviving pairs.
 
-You can verify with `EXPLAIN`. The win versus Phase 1 is **2–3 orders of magnitude on real-world catalog sizes**.
+You can verify with `EXPLAIN`.
+The win versus Phase 1 is **2–3 orders of magnitude on real-world catalog sizes**.
 
 ### 4.5 GeoParquet bbox column (1.1)
 
@@ -291,13 +332,16 @@ WHERE bbox.xmax >= $x0 AND bbox.xmin <= $x1
   AND ST_Intersects(geometry, ST_MakeEnvelope($x0,$y0,$x1,$y1))
 ```
 
-The first four conjuncts are pure double-comparison — no WKB parsing, fully vectorized. The exact `ST_Intersects` runs only on rows that pass the bbox filter. For very selective queries this is roughly 10× faster than calling `ST_Intersects` directly on every row.
+The first four conjuncts are pure double-comparison — no WKB parsing, fully vectorized.
+The exact `ST_Intersects` runs only on rows that pass the bbox filter.
+For very selective queries this is roughly 10× faster than calling `ST_Intersects` directly on every row.
 
 The catalog writer should always emit the bbox column.
 
 ### 4.6 Streaming build cost model
 
-Phase 1's `build_raster_catalog` materializes the whole gdf. For 10M files at ~1 KB/row, that's 10 GB plus Python overhead.
+Phase 1's `build_raster_catalog` materializes the whole gdf.
+For 10M files at ~1 KB/row, that's 10 GB plus Python overhead.
 
 The streaming variant batches `B` rows into Arrow record batches and appends to a Parquet writer:
 
@@ -305,13 +349,15 @@ $$
 \text{peak memory} \;\approx\; B \cdot \text{row\_size} \;+\; \text{open-file-handles} \cdot \text{rasterio overhead}
 $$
 
-For `B = 10 000` and ~1 KB/row, peak is ~10 MB plus rasterio's per-file overhead (tens of MB). Build time is dominated by `rasterio.open` calls, which can be parallelized with a `ThreadPoolExecutor` (GIL-friendly because rasterio releases the GIL during I/O).
+For `B = 10 000` and ~1 KB/row, peak is ~10 MB plus rasterio's per-file overhead (tens of MB).
+Build time is dominated by `rasterio.open` calls, which can be parallelized with a `ThreadPoolExecutor` (GIL-friendly because rasterio releases the GIL during I/O).
 
 ---
 
 ## 5. Coupling with Phase 1
 
-The whole point of the Phase 1 protocol design was to make Phase 2 transparent. Here's the seam:
+The whole point of the Phase 1 protocol design was to make Phase 2 transparent.
+Here's the seam:
 
 | Operation | `InMemoryGeoCatalog` (Phase 1) | `DuckDBGeoCatalog` (Phase 2) |
 | --- | --- | --- |
@@ -326,11 +372,13 @@ The whole point of the Phase 1 protocol design was to make Phase 2 transparent. 
 
 **Loaders unchanged.** `load_raster(catalog, slice, ...)` only needs `catalog.iter_rows()` (or a single `query` + `iter_rows`) — it never touches the underlying gdf or relation.
 
-**Samplers** need the smallest tweak: replace `catalog.gdf.iloc[i]` patterns with `catalog.iter_rows()` or `catalog.query(slice).iter_rows()`. Once that's done, samplers work identically against either backend.
+**Samplers** need the smallest tweak: replace `catalog.gdf.iloc[i]` patterns with `catalog.iter_rows()` or `catalog.query(slice).iter_rows()`.
+Once that's done, samplers work identically against either backend.
 
 **`stitch` unchanged.** It only consumes `GeoSlice` + `np.ndarray`, no catalog.
 
-The catalog is the only seam. Get the protocol right and Phase 2 is purely additive.
+The catalog is the only seam.
+Get the protocol right and Phase 2 is purely additive.
 
 ---
 
@@ -354,7 +402,8 @@ georeader/
 
 ### 6.2 Protocol additions
 
-The Phase 1 `GeoCatalog` protocol stays mostly intact. Phase 2 adds:
+The Phase 1 `GeoCatalog` protocol stays mostly intact.
+Phase 2 adds:
 
 ```python
 class GeoCatalog(Protocol):
@@ -391,7 +440,8 @@ class CatalogRow:
     extras: dict[str, Any]                         # backend-specific extras (data_vars, layer, ...)
 ```
 
-Loaders consume `CatalogRow`. Whether the row came from a gdf or a DuckDB cursor is invisible.
+Loaders consume `CatalogRow`.
+Whether the row came from a gdf or a DuckDB cursor is invisible.
 
 ### 6.4 `DuckDBGeoCatalog`
 
@@ -455,7 +505,9 @@ def build_raster_catalog(
 ) -> GeoCatalog: ...
 ```
 
-When `backend="duckdb"`, the builder streams metadata into an Arrow record-batch writer and lands directly in `out_path` as GeoParquet. The returned object is a `DuckDBGeoCatalog` opened on that file. Memory stays bounded regardless of file count.
+When `backend="duckdb"`, the builder streams metadata into an Arrow record-batch writer and lands directly in `out_path` as GeoParquet.
+The returned object is a `DuckDBGeoCatalog` opened on that file.
+Memory stays bounded regardless of file count.
 
 Same surface for `build_xarray_catalog` and `build_vector_catalog`.
 
@@ -510,25 +562,35 @@ The CLI is a thin wrapper around `DuckDBGeoCatalog`; everything it does is calla
 ### 6.8 What I'd *not* add in Phase 2
 
 - A query DSL that abstracts over pandas vs SQL. Just expose `.gdf` and `.relation` as escape hatches.
-- A persistent server (HTTP API). That's STAC's job.
-- Auto-conversion between CRSs at query time. Catalogs should be written in one CRS; `ST_Transform` is available but slow and a footgun.
-- Materialized R-tree indexes on Parquet. They don't exist; if you need persistent indexes, write to `.duckdb` (see [§7](#7-sharp-edges)).
+- A persistent server (HTTP API).
+  That's STAC's job.
+- Auto-conversion between CRSs at query time.
+  Catalogs should be written in one CRS; `ST_Transform` is available but slow and a footgun.
+- Materialized R-tree indexes on Parquet.
+  They don't exist; if you need persistent indexes, write to `.duckdb` (see [§7](#7-sharp-edges)).
 
 ---
 
 ## 7. Sharp edges
 
-1. **GeoParquet 1.0 vs 1.1.** 1.1 adds the per-row bbox column — order-of-magnitude speedup for spatial filters at scale. Default to writing 1.1; provide a `--geoparquet-version=1.0` opt-out for compatibility with older readers.
-2. **DuckDB spatial extension version pinning.** APIs are stable but evolving. Pin a minimum DuckDB version (e.g. ≥ 1.1) and document the install (`INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;`).
-3. **No persistent R-tree on Parquet.** Persistent R-tree indexes only exist in `.duckdb` table files. If a catalog will be queried thousands of times with the same predicate shapes, materialize to `.duckdb`:
+1. **GeoParquet 1.0 vs 1.1.** 1.1 adds the per-row bbox column — order-of-magnitude speedup for spatial filters at scale.
+   Default to writing 1.1; provide a `--geoparquet-version=1.0` opt-out for compatibility with older readers.
+2. **DuckDB spatial extension version pinning.** APIs are stable but evolving.
+   Pin a minimum DuckDB version (e.g. ≥ 1.1) and document the install (`INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;`).
+3. **No persistent R-tree on Parquet.** Persistent R-tree indexes only exist in `.duckdb` table files.
+   If a catalog will be queried thousands of times with the same predicate shapes, materialize to `.duckdb`:
    ```sql
    CREATE TABLE files AS SELECT * FROM 'cat.parquet';
    CREATE INDEX idx_geom ON files USING RTREE (geometry);
    ```
    Otherwise, rely on bbox + zone-map pushdown — usually fast enough.
-4. **Multi-CRS catalogs.** Same problem as Phase 1, more visible because SQL doesn't auto-reproject. Strong recommendation: **write all GeoParquet in EPSG:4326**, store the native CRS in a column, reproject on load. `ST_Transform` works but requires PROJ data and is slow per call.
-5. **NULL temporal sentinels.** Don't write `pd.Timestamp.min/.max` — they overflow `TIMESTAMP`. Write `NULL` and require explicit `OR tmin IS NULL` for queries that should include date-less files.
-6. **Cursor lifecycle on `iter_rows()`.** The DuckDB connection must outlive the iterator. Use a context manager:
+4. **Multi-CRS catalogs.** Same problem as Phase 1, more visible because SQL doesn't auto-reproject.
+   Strong recommendation: **write all GeoParquet in EPSG:4326**, store the native CRS in a column, reproject on load.
+   `ST_Transform` works but requires PROJ data and is slow per call.
+5. **NULL temporal sentinels.** Don't write `pd.Timestamp.min/.max` — they overflow `TIMESTAMP`.
+   Write `NULL` and require explicit `OR tmin IS NULL` for queries that should include date-less files.
+6. **Cursor lifecycle on `iter_rows()`.** The DuckDB connection must outlive the iterator.
+   Use a context manager:
    ```python
    with catalog.cursor() as rows:
        for row in rows:
@@ -536,17 +598,27 @@ The CLI is a thin wrapper around `DuckDBGeoCatalog`; everything it does is calla
    ```
    Document that storing the iterator beyond the `with` block is unsupported.
 7. **WKB → shapely deserialization cost.** Per-row `shapely.from_wkb` is fine at 10⁴ rows/s, painful at 10⁶. For tight inner loops, batch with `shapely.from_wkb(arr)` (vectorized, uses `pygeos` / shapely 2.x).
-8. **Sampler weighting on lazy catalogs.** Phase 1's area-weighted random sampler ([§4.5 of Phase 1 report](#45-random-sampler-weighting)) needs all candidate areas. With DuckDB, either (a) maintain a precomputed `area_m2` column at build time (recommended), (b) use `USING SAMPLE 10%` to estimate, or (c) stream the area column once and cache.
-9. **Parquet schema evolution.** Parquet is immutable. Add a column → rewrite the file. Mitigate by storing the catalog as a directory of dated shards with consistent schema; DuckDB reads them as one virtual table via `read_parquet('shards/*.parquet')`. Document the canonical schema and bump a version column.
-10. **Authentication for remote.** `httpfs` picks up env vars, `~/.aws/credentials`, GCS service accounts automatically. Document this and provide one-line recipes per provider. Surface clear errors when auth fails (DuckDB's default messages are cryptic).
-11. **Streaming builder + multiprocessing.** When `n_workers > 1`, the rasterio metadata extraction parallelizes well, but Arrow record-batch writes must serialize. Use a single writer thread fed by a queue. Don't try to parallelize the Parquet writer itself.
-12. **Connection-per-thread.** DuckDB connections are *not* thread-safe; use `con.cursor()` in worker threads or open a fresh connection per process. The `DuckDBGeoCatalog` should expose a `.cursor()` method, not pass `con` around.
+8. **Sampler weighting on lazy catalogs.** Phase 1's area-weighted random sampler ([§4.5 of Phase 1 report](#45-random-sampler-weighting)) needs all candidate areas.
+   With DuckDB, either (a) maintain a precomputed `area_m2` column at build time (recommended), (b) use `USING SAMPLE 10%` to estimate, or (c) stream the area column once and cache.
+9. **Parquet schema evolution.** Parquet is immutable.
+   Add a column → rewrite the file.
+   Mitigate by storing the catalog as a directory of dated shards with consistent schema; DuckDB reads them as one virtual table via `read_parquet('shards/*.parquet')`.
+   Document the canonical schema and bump a version column.
+10. **Authentication for remote.** `httpfs` picks up env vars, `~/.aws/credentials`, GCS service accounts automatically.
+    Document this and provide one-line recipes per provider.
+    Surface clear errors when auth fails (DuckDB's default messages are cryptic).
+11. **Streaming builder + multiprocessing.** When `n_workers > 1`, the rasterio metadata extraction parallelizes well, but Arrow record-batch writes must serialize.
+    Use a single writer thread fed by a queue.
+    Don't try to parallelize the Parquet writer itself.
+12. **Connection-per-thread.** DuckDB connections are *not* thread-safe; use `con.cursor()` in worker threads or open a fresh connection per process.
+    The `DuckDBGeoCatalog` should expose a `.cursor()` method, not pass `con` around.
 
 ---
 
 ## 8. End-to-end examples
 
-A varied gallery, organized by what's *new* in Phase 2 — persistence, analytics, scale, federation, and lazy ML pipelines. All examples assume the Phase 1 surface exists.
+A varied gallery, organized by what's *new* in Phase 2 — persistence, analytics, scale, federation, and lazy ML pipelines.
+All examples assume the Phase 1 surface exists.
 
 | § | Example | Pattern |
 | --- | --- | --- |
@@ -754,7 +826,8 @@ joint = catalog.sql("""
 """)
 ```
 
-Slower and PROJ-dependent. Document the cost.
+Slower and PROJ-dependent.
+Document the cost.
 
 ### 8.5 Sampler / inference patterns at scale
 
@@ -846,12 +919,14 @@ None require new dependencies; all are thin wrappers over DuckDB or geopandas.
 
 ## 9. Verdict
 
-Phase 2 is a **clean, additive upgrade** that costs almost nothing for users on the in-memory path and unlocks 2–3 orders of magnitude more catalog scale, plus a real sharing story, for users who need it. The Phase 1 protocol design pays off here: loaders, samplers, and stitchers are unchanged.
+Phase 2 is a **clean, additive upgrade** that costs almost nothing for users on the in-memory path and unlocks 2–3 orders of magnitude more catalog scale, plus a real sharing story, for users who need it.
+The Phase 1 protocol design pays off here: loaders, samplers, and stitchers are unchanged.
 
 What needs to happen to ship Phase 2:
 
 - [ ] Implement `DuckDBGeoCatalog` behind a `[duckdb]` extra, satisfying the `GeoCatalog` protocol from Phase 1.
-- [ ] Canonicalize the GeoParquet schema (§6.6) — types, NULL conventions, bbox column, sort order. Bump a `schema_version` column so future migrations are tractable.
+- [ ] Canonicalize the GeoParquet schema (§6.6) — types, NULL conventions, bbox column, sort order.
+  Bump a `schema_version` column so future migrations are tractable.
 - [ ] Add the streaming-write builders (`backend="duckdb"`) so multi-million-file ingest doesn't materialize a gdf.
 - [ ] Round-trip tests on every backend at three scales: 10², 10⁴, 10⁶ rows.
 - [ ] Cross-CRS smoke test (mixed-UTM-zone catalog harmonized to EPSG:4326 at write time).
@@ -875,15 +950,20 @@ The DuckDB-on-GeoParquet path is sound; concerns to manage actively.
 
 ### DuckDB `spatial` extension version pinning
 
-The `spatial` extension is pre-1.0 in DuckDB; behaviours change between versions. GeoParquet 1.1 bbox-column predicate pushdown specifically lands at **DuckDB ≥ 1.1**. **Mitigation:** pin `duckdb >= 1.1` (and a known-good spatial-extension pin) in package metadata; add a CI matrix that tests on the latest DuckDB once it crosses 1.0 final. Don't lower the pin even if a user asks — silent query-plan regressions are the worst kind of bug.
+The `spatial` extension is pre-1.0 in DuckDB; behaviours change between versions.
+GeoParquet 1.1 bbox-column predicate pushdown specifically lands at **DuckDB ≥ 1.1**.
+**Mitigation:** pin `duckdb >= 1.1` (and a known-good spatial-extension pin) in package metadata; add a CI matrix that tests on the latest DuckDB once it crosses 1.0 final. Don't lower the pin even if a user asks — silent query-plan regressions are the worst kind of bug.
 
 ### `httpfs` extension and credentials
 
-Reading S3 / GCS / Azure GeoParquet from cloud needs the `httpfs` extension configured with the right credentials. DuckDB's secret API differs from `obstore` / `fsspec` patterns. **Mitigation:** define the `Credential` ↔ DuckDB-secret bridge in the [`Credential`](../types/credentials.md) design (cross-link), so users don't configure auth twice (once for georeader readers, once for DuckDB).
+Reading S3 / GCS / Azure GeoParquet from cloud needs the `httpfs` extension configured with the right credentials.
+DuckDB's secret API differs from `obstore` / `fsspec` patterns.
+**Mitigation:** define the `Credential` ↔ DuckDB-secret bridge in the [`Credential`](../types/credentials.md) design (cross-link), so users don't configure auth twice (once for georeader readers, once for DuckDB).
 
 ### Concurrent reads/writes from multiple processes
 
-DuckDB on a single GeoParquet file is **read-safe** across processes. Write-safe only under specific patterns:
+DuckDB on a single GeoParquet file is **read-safe** across processes.
+Write-safe only under specific patterns:
 - **Append-only** (new row groups in new files, then a manifest concat) — safe.
 - **In-place mutation** (rewrite the file under existing reads) — not safe across concurrent writers; you need an external lock or a Delta-Lake-style manifest.
 
@@ -891,12 +971,18 @@ Phase 2 of `GeoCatalog` should default to the append-only pattern; document the 
 
 ### GeoParquet 1.1 writer support
 
-DuckDB's GeoParquet *write* path is newer than the read path. Round-trip test (write with DuckDB, read with `geopandas.read_parquet`, check bbox column survives + CRS metadata is preserved) before promising the writer in v0.1. Cross-link [`geocatalog.md` §10.2](geocatalog.md#102-geoparquet-11-writer-adoption-is-uneven).
+DuckDB's GeoParquet *write* path is newer than the read path.
+Round-trip test (write with DuckDB, read with `geopandas.read_parquet`, check bbox column survives + CRS metadata is preserved) before promising the writer in v0.1. Cross-link [`geocatalog.md` §10.2](geocatalog.md#102-geoparquet-11-writer-adoption-is-uneven).
 
 ### Bit-rot risk
 
-Most users will stay on Phase 1 (GeoPandas in-memory) for the 90% case; Phase 2 won't see organic exercise until someone hits 10⁶+ rows. **Risk:** the Phase 2 code paths regress without being noticed. **Mitigation:** maintain a multi-million-row CI fixture from v0.1; gate Phase 2 release behind one real Phase 2 user.
+Most users will stay on Phase 1 (GeoPandas in-memory) for the 90% case; Phase 2 won't see organic exercise until someone hits 10⁶+ rows.
+**Risk:** the Phase 2 code paths regress without being noticed.
+**Mitigation:** maintain a multi-million-row CI fixture from v0.1; gate Phase 2 release behind one real Phase 2 user.
 
 ### `ST_Transform` is slow per row
 
-DuckDB's `ST_Transform` requires PROJ data and is expensive when called per row. Hence the §4 design choice to write all GeoParquet in EPSG:4326 and store native CRS as a column for round-trip — reproject at write time, not at query time. **Footgun for users who skip this convention:** a multi-CRS catalog with `ST_Transform` in the WHERE clause will be 100× slower than a 4326-canonical catalog. Document loudly.
+DuckDB's `ST_Transform` requires PROJ data and is expensive when called per row.
+Hence the §4 design choice to write all GeoParquet in EPSG:4326 and store native CRS as a column for round-trip — reproject at write time, not at query time.
+**Footgun for users who skip this convention:** a multi-CRS catalog with `ST_Transform` in the WHERE clause will be 100× slower than a 4326-canonical catalog.
+Document loudly.

--- a/projects/geotoolz/plans/georeader/README.md
+++ b/projects/geotoolz/plans/georeader/README.md
@@ -15,17 +15,25 @@ license: CC-BY-4.0
 keywords: design, georeader, reader, protocol
 ---
 
-> **Status:** **revised 2026-05-09** — slimmed substantially. The earlier draft introduced a parallel `_ReaderMeta` / `SyncReader` / `AsyncReader` Protocol taxonomy, a custom `ByteStore` Protocol, and a from-scratch `_cog_helpers.py` async COG reader. On review, today's `GeoData` / `GeoDataBase` already covers the sync metadata + read surface; [`obspec`](https://github.com/developmentseed/obspec) already plays the role of `ByteStore`; and [`developmentseed/async-geotiff`](https://github.com/developmentseed/async-geotiff) already ships the async COG reader. So the design collapsed to: **add `AsyncGeoData` only, defer `ByteStore` to `obspec`, write `AsyncGeoTIFFReader` as a thin adapter over `async-geotiff`**.
-> **Scope:** the long-term shape of the reader layer in `georeader`. Adds an `AsyncGeoData` Protocol alongside today's `GeoData` / `GeoDataBase`; adds one new reader (`AsyncGeoTIFFReader`) as a thin adapter over `async-geotiff`; documents an additive widening of `RasterioReader`'s bytes-path knobs.
+> **Status:** **revised 2026-05-09** — slimmed substantially.
+> The earlier draft introduced a parallel `_ReaderMeta` / `SyncReader` / `AsyncReader` Protocol taxonomy, a custom `ByteStore` Protocol, and a from-scratch `_cog_helpers.py` async COG reader.
+> On review, today's `GeoData` / `GeoDataBase` already covers the sync metadata + read surface; [`obspec`](https://github.com/developmentseed/obspec) already plays the role of `ByteStore`; and [`developmentseed/async-geotiff`](https://github.com/developmentseed/async-geotiff) already ships the async COG reader.
+> So the design collapsed to: **add `AsyncGeoData` only, defer `ByteStore` to `obspec`, write `AsyncGeoTIFFReader` as a thin adapter over `async-geotiff`**.
+> **Scope:** the long-term shape of the reader layer in `georeader`.
+> Adds an `AsyncGeoData` Protocol alongside today's `GeoData` / `GeoDataBase`; adds one new reader (`AsyncGeoTIFFReader`) as a thin adapter over `async-geotiff`; documents an additive widening of `RasterioReader`'s bytes-path knobs.
 > **Audience:** anyone touching `georeader/abstract_reader.py`, `georeader/rasterio_reader.py`, or building downstream pipelines that need to swap readers without rewriting call sites.
 
 ---
 
 ## Summary
 
-Today, `georeader` ships one reader (`RasterioReader`) with a sync, GDAL-backed interface that's worked well for years. As the package's audience grows into cloud-native and async-first workloads, it needs to grow alongside — without breaking the call sites that already use it.
+Today, `georeader` ships one reader (`RasterioReader`) with a sync, GDAL-backed interface that's worked well for years.
+As the package's audience grows into cloud-native and async-first workloads, it needs to grow alongside — without breaking the call sites that already use it.
 
-This design adds a single new Protocol (`AsyncGeoData`) alongside today's `GeoData` / `GeoDataBase` so async-shaped readers slot into the existing surface. One concrete async reader is added (`AsyncGeoTIFFReader`), implemented as a thin adapter over [`developmentseed/async-geotiff`](https://github.com/developmentseed/async-geotiff). Cloud byte access is delegated to [`obspec`](https://github.com/developmentseed/obspec) — the upstream Protocol that `async-geotiff` already consumes — rather than wrapped in a parallel `ByteStore` Protocol of our own. Downstream code branches only on sync-vs-async, never on which concrete reader class is in use.
+This design adds a single new Protocol (`AsyncGeoData`) alongside today's `GeoData` / `GeoDataBase` so async-shaped readers slot into the existing surface.
+One concrete async reader is added (`AsyncGeoTIFFReader`), implemented as a thin adapter over [`developmentseed/async-geotiff`](https://github.com/developmentseed/async-geotiff).
+Cloud byte access is delegated to [`obspec`](https://github.com/developmentseed/obspec) — the upstream Protocol that `async-geotiff` already consumes — rather than wrapped in a parallel `ByteStore` Protocol of our own.
+Downstream code branches only on sync-vs-async, never on which concrete reader class is in use.
 
 The work splits into two small issues that can be reviewed independently.
 
@@ -35,37 +43,58 @@ The work splits into two small issues that can be reviewed independently.
 
 Three pressures make this worth doing now:
 
-1. **Cloud is the default substrate, not an exotic one.** New RS workflows assume reads from S3 / GCS / Azure; today's `RasterioReader` routes through GDAL VSI, which is excellent for the common case but offers no way to opt into competing transports — `obstore` (Rust core, HTTP/2, native parallel ranges) for hot-path throughput, or `fsspec` for niche backends and custom auth. The existing reader lacks the seam to plug them in.
+1. **Cloud is the default substrate, not an exotic one.** New RS workflows assume reads from S3 / GCS / Azure; today's `RasterioReader` routes through GDAL VSI, which is excellent for the common case but offers no way to opt into competing transports — `obstore` (Rust core, HTTP/2, native parallel ranges) for hot-path throughput, or `fsspec` for niche backends and custom auth.
+   The existing reader lacks the seam to plug them in.
 
-2. **Async I/O is now first-class.** Tile servers, web maps, ML inference services, and any code that fans out reads concurrently are increasingly written async-first. `RasterioReader` is sync-only. Users wanting an async reader either roll their own or pull in an external library with a different API shape — there is no shared interface to compose against.
+2. **Async I/O is now first-class.** Tile servers, web maps, ML inference services, and any code that fans out reads concurrently are increasingly written async-first.
+   `RasterioReader` is sync-only.
+   Users wanting an async reader either roll their own or pull in an external library with a different API shape — there is no shared interface to compose against.
 
-3. **COG-only readers can be substantially faster than full GDAL.** A pure-Rust COG reader (via `async-tiff`) can skip per-call GDAL state and PROJ initialisation, batch parallel range requests directly via `obstore`, and coalesce close-by ranges. For tile-server fan-out across thousands of small windows the overhead difference is meaningful. A reader specialised to COG (the dominant cloud-native format) deserves a place alongside the general-purpose `RasterioReader`, not as a separate ecosystem with an incompatible API. We don't have to *build* such a reader — `developmentseed/async-geotiff` exists, is actively maintained, and is the right thing to depend on. Our job is to expose it behind the same Protocol-shaped surface as `RasterioReader`.
+3. **COG-only readers can be substantially faster than full GDAL.** A pure-Rust COG reader (via `async-tiff`) can skip per-call GDAL state and PROJ initialisation, batch parallel range requests directly via `obstore`, and coalesce close-by ranges.
+   For tile-server fan-out across thousands of small windows the overhead difference is meaningful.
+   A reader specialised to COG (the dominant cloud-native format) deserves a place alongside the general-purpose `RasterioReader`, not as a separate ecosystem with an incompatible API. We don't have to *build* such a reader — `developmentseed/async-geotiff` exists, is actively maintained, and is the right thing to depend on.
+   Our job is to expose it behind the same Protocol-shaped surface as `RasterioReader`.
 
-The status quo can absorb each of these one at a time, but the shapes start to drift apart and downstream code accumulates branches. A reconciliation pass — `AsyncGeoData` Protocol + thin async-geotiff adapter — pays for itself the first time a user wants to swap GDAL VSI for `obstore` in a hot loop.
+The status quo can absorb each of these one at a time, but the shapes start to drift apart and downstream code accumulates branches.
+A reconciliation pass — `AsyncGeoData` Protocol + thin async-geotiff adapter — pays for itself the first time a user wants to swap GDAL VSI for `obstore` in a hot loop.
 
 ---
 
 ## Primer for newcomers
 
-A handful of advanced concepts run through this design. Quick primers below; deeper specs in the per-issue sub-designs.
+A handful of advanced concepts run through this design.
+Quick primers below; deeper specs in the per-issue sub-designs.
 
-> **ELI5.** Reading a satellite image from the cloud is like ordering one slice of pizza from a giant pie that lives in another city. You don't want the whole pie shipped — just your slice. This design is about *how to ask for slices*, *who actually fetches them*, and *how to wait efficiently when you want a thousand at once*.
+> **ELI5.** Reading a satellite image from the cloud is like ordering one slice of pizza from a giant pie that lives in another city.
+> You don't want the whole pie shipped — just your slice.
+> This design is about *how to ask for slices*, *who actually fetches them*, and *how to wait efficiently when you want a thousand at once*.
 
 ### What "reader" means in this package
 
-**What it is.** A *reader* is a Python class that turns a file path or URL (local disk, S3, GCS, Azure, HTTP) into a `GeoTensor` — a numpy array with georeferencing attached. Today's package has one (`RasterioReader`); this design adds two more.
+**What it is.** A *reader* is a Python class that turns a file path or URL (local disk, S3, GCS, Azure, HTTP) into a `GeoTensor` — a numpy array with georeferencing attached.
+Today's package has one (`RasterioReader`); this design adds two more.
 
-**How it works.** A reader has two phases. **Open** (cheap) reads only the file's header — enough to know the CRS, transform, shape, dtype. **Read** (expensive) actually fetches pixel bytes for a window and decodes them. The split lets you pass readers around as cheap handles and only pay I/O when you ask for data.
+**How it works.** A reader has two phases.
+**Open** (cheap) reads only the file's header — enough to know the CRS, transform, shape, dtype.
+**Read** (expensive) actually fetches pixel bytes for a window and decodes them.
+The split lets you pass readers around as cheap handles and only pay I/O when you ask for data.
 
-**What this means for us.** Code that takes a "reader" as input doesn't need the bytes — just the metadata. That's why georeader's existing Protocols split into two layers (`GeoDataBase` for metadata-only, `GeoData` for read-capable). Many georeader functions (window math, bounds queries, catalog construction) only need metadata and run instantly even on cloud-hosted files.
+**What this means for us.** Code that takes a "reader" as input doesn't need the bytes — just the metadata.
+That's why georeader's existing Protocols split into two layers (`GeoDataBase` for metadata-only, `GeoData` for read-capable).
+Many georeader functions (window math, bounds queries, catalog construction) only need metadata and run instantly even on cloud-hosted files.
 
 ### Sync vs async I/O
 
-**What it is.** *Sync* code blocks the calling thread until I/O completes (the standard Python flow). *Async* code uses `async def` / `await` so the thread can do other work while waiting. Two different control-flow models for the same fundamental operation.
+**What it is.** *Sync* code blocks the calling thread until I/O completes (the standard Python flow).
+*Async* code uses `async def` / `await` so the thread can do other work while waiting.
+Two different control-flow models for the same fundamental operation.
 
-**How it works.** Sync I/O is what you've used your whole life: `open(path).read()`. Async I/O uses `asyncio` (or `trio`); the runtime juggles many in-flight reads concurrently on one thread, which is dramatically more efficient for workloads where you'd otherwise spawn a thread-per-request (tile servers, 1000-window batch reads).
+**How it works.** Sync I/O is what you've used your whole life: `open(path).read()`.
+Async I/O uses `asyncio` (or `trio`); the runtime juggles many in-flight reads concurrently on one thread, which is dramatically more efficient for workloads where you'd otherwise spawn a thread-per-request (tile servers, 1000-window batch reads).
 
-**What this means for us.** `RasterioReader` is sync — fine for batch jobs, scripts, notebooks. `AsyncGeoTIFFReader` is async — needed when you want to fan out 1000 reads concurrently from one process. The Protocol surface (`GeoData` / `AsyncGeoData`) isolates the difference so user code only branches on `await` vs not, never on which concrete reader class is in use.
+**What this means for us.** `RasterioReader` is sync — fine for batch jobs, scripts, notebooks.
+`AsyncGeoTIFFReader` is async — needed when you want to fan out 1000 reads concurrently from one process.
+The Protocol surface (`GeoData` / `AsyncGeoData`) isolates the difference so user code only branches on `await` vs not, never on which concrete reader class is in use.
 
 ```{mermaid}
 gantt
@@ -84,11 +113,16 @@ gantt
 
 ### The "bytes path"
 
-**What it is.** When a reader fetches data from cloud storage (S3, GCS, Azure), *something* has to translate "give me bytes 0–4096 of `s3://bucket/scene.tif`" into actual HTTP traffic. The library that does this is the **bytes path**.
+**What it is.** When a reader fetches data from cloud storage (S3, GCS, Azure), *something* has to translate "give me bytes 0–4096 of `s3://bucket/scene.tif`" into actual HTTP traffic.
+The library that does this is the **bytes path**.
 
-**How it works.** Three options ship today: **GDAL VSI** (libcurl in C, default for `RasterioReader`), **obstore** (Rust core, fast for parallel ranges), and **fsspec** (Python, broadest backend coverage). They differ in throughput, async support, and which clouds they speak.
+**How it works.** Three options ship today: **GDAL VSI** (libcurl in C, default for `RasterioReader`), **obstore** (Rust core, fast for parallel ranges), and **fsspec** (Python, broadest backend coverage).
+They differ in throughput, async support, and which clouds they speak.
 
-**What this means for us.** A single reader class can run on different bytes paths. `RasterioReader` defaults to VSI but the optional widening in [Issue 1](reader_protocol.md) lets you swap to fsspec via `fs=` or to a custom callback via `opener=`. The new reader (`AsyncGeoTIFFReader`) skips GDAL entirely and accepts any [`obspec.AsyncStore`](https://github.com/developmentseed/obspec) (`obstore.S3Store` / `GCSStore` / `AzureStore` / etc.). Your call which trade-off matches the workload — see [`geostack.md` §"`obstore` vs `fsspec` compared"](../geostack.md#obstore-vs-fsspec-compared) for the comparison.
+**What this means for us.** A single reader class can run on different bytes paths.
+`RasterioReader` defaults to VSI but the optional widening in [Issue 1](reader_protocol.md) lets you swap to fsspec via `fs=` or to a custom callback via `opener=`.
+The new reader (`AsyncGeoTIFFReader`) skips GDAL entirely and accepts any [`obspec.AsyncStore`](https://github.com/developmentseed/obspec) (`obstore.S3Store` / `GCSStore` / `AzureStore` / etc.).
+Your call which trade-off matches the workload — see [`geostack.md` §"`obstore` vs `fsspec` compared"](../geostack.md#obstore-vs-fsspec-compared) for the comparison.
 
 ```{mermaid}
 flowchart TD
@@ -101,43 +135,64 @@ flowchart TD
 
 ### Python Protocols
 
-**What it is.** A `typing.Protocol` is a "structural type" — a class declaration that says *what methods/attributes a type must have* without requiring inheritance. Like duck typing with type-checker support.
+**What it is.** A `typing.Protocol` is a "structural type" — a class declaration that says *what methods/attributes a type must have* without requiring inheritance.
+Like duck typing with type-checker support.
 
-**How it works.** Define a `Protocol` with the surface you want; any class that has the right attributes satisfies it automatically (no `class MyReader(GeoData)` declaration required). With `@runtime_checkable`, `isinstance(x, Protocol)` works at runtime too.
+**How it works.** Define a `Protocol` with the surface you want; any class that has the right attributes satisfies it automatically (no `class MyReader(GeoData)` declaration required).
+With `@runtime_checkable`, `isinstance(x, Protocol)` works at runtime too.
 
-**What this means for us.** The reader Protocols (`GeoDataBase`, `GeoData`, `AsyncGeoData`) let `RasterioReader` and `AsyncGeoTIFFReader` (and any future sensor-specific or raw-byte reader) be passed to the same function with no shared base class — they just satisfy the Protocol structurally. Same shape; independent implementations; no inheritance hierarchy.
+**What this means for us.** The reader Protocols (`GeoDataBase`, `GeoData`, `AsyncGeoData`) let `RasterioReader` and `AsyncGeoTIFFReader` (and any future sensor-specific or raw-byte reader) be passed to the same function with no shared base class — they just satisfy the Protocol structurally.
+Same shape; independent implementations; no inheritance hierarchy.
 
 ---
 
 ## Goals
 
-- **Reuse today's metadata surface.** Every reader (current and future) keeps using the existing `crs` / `transform` / `bounds` / `shape` / `width` / `height` / `dtype` / `fill_value_default` / `res` properties from `GeoDataBase` and `GeoData`. No parallel `_ReaderMeta` Protocol.
+- **Reuse today's metadata surface.** Every reader (current and future) keeps using the existing `crs` / `transform` / `bounds` / `shape` / `width` / `height` / `dtype` / `fill_value_default` / `res` properties from `GeoDataBase` and `GeoData`.
+  No parallel `_ReaderMeta` Protocol.
 - **Add one new read interface.** `AsyncGeoData` mirrors `GeoData` with `async` read methods; user code typed `data: AsyncGeoData` accepts any conforming async reader.
 - **Add `AsyncGeoTIFFReader`** as a thin adapter over `developmentseed/async-geotiff` — async, COG-only, no GDAL — for high-concurrency fan-out. ~80 LOC.
-- **Defer cloud byte transport to `obspec`.** No custom `ByteStore` Protocol. We pass `obspec.AsyncStore` straight through to `async-geotiff`. We ship a small `geotoolz.io.open_store(url)` factory and nothing else.
-- **(Optional, additive)** widen `RasterioReader` with `opener=` / `fs=` / `rio_open_kwargs=` keyword-only knobs so users can route bytes through GDAL VSI / fsspec / a custom callback explicitly. Pure addition, no breaking changes.
+- **Defer cloud byte transport to `obspec`.** No custom `ByteStore` Protocol.
+  We pass `obspec.AsyncStore` straight through to `async-geotiff`.
+  We ship a small `geotoolz.io.open_store(url)` factory and nothing else.
+- **(Optional, additive)** widen `RasterioReader` with `opener=` / `fs=` / `rio_open_kwargs=` keyword-only knobs so users can route bytes through GDAL VSI / fsspec / a custom callback explicitly.
+  Pure addition, no breaking changes.
 
 ---
 
 ## Non-goals
 
-- **Replacing GDAL.** `RasterioReader` stays the default. The new reader is a specialisation, not a replacement.
-- **Reimplementing the COG reader.** `developmentseed/async-geotiff` already does IFD walk, tile-fetch math, decompression dispatch, range coalescing, and obspec transport. Our reader is a ~80-LOC adapter, not a peer reimplementation.
-- **Reprojection / warping / resampling in the async path.** `async-geotiff` explicitly disclaims warp; we follow suit. `AsyncGeoTIFFReader.read_bounds(target_crs=...)` raises `NotImplementedError` and points users at `georeader.read.read_reproject_like` (post-step) or `RasterioReader` (WarpedVRT). See [open question §4](#4-async-warp-resample-overview-pick-deferred) for revisit.
+- **Replacing GDAL.** `RasterioReader` stays the default.
+  The new reader is a specialisation, not a replacement.
+- **Reimplementing the COG reader.** `developmentseed/async-geotiff` already does IFD walk, tile-fetch math, decompression dispatch, range coalescing, and obspec transport.
+  Our reader is a ~80-LOC adapter, not a peer reimplementation.
+- **Reprojection / warping / resampling in the async path.** `async-geotiff` explicitly disclaims warp; we follow suit.
+  `AsyncGeoTIFFReader.read_bounds(target_crs=...)` raises `NotImplementedError` and points users at `georeader.read.read_reproject_like` (post-step) or `RasterioReader` (WarpedVRT).
+  See [open question §4](#4-async-warp-resample-overview-pick-deferred) for revisit.
 - **Async-by-default for the existing reader.** `RasterioReader` stays sync; users wanting async use `AsyncGeoTIFFReader`.
-- **Universal format support in the new reader.** `AsyncGeoTIFFReader` is TIFF/COG-only. JP2, NetCDF, HDF5, GRIB, ENVI continue to route through `RasterioReader`.
-- **A sync GDAL-free GeoTensor reader for v0.1.** Speculative, no clear customer; `RasterioReader` covers sync, `AsyncGeoTIFFReader` covers GDAL-free. If a real workload emerges later we'll add a sync sibling (or a sync facade over `AsyncGeoTIFFReader`); see [open question §3](#3-a-sync-gdal-free-geotensor-reader-deferred).
-- **A custom `ByteStore` Protocol.** [`obspec`](https://github.com/developmentseed/obspec) (DevSeed) already plays that role and is what `async-geotiff` consumes. We pass it through. See [`types/bytestore.md`](../types/bytestore.md) for the rationale.
-- **A parallel `_ReaderMeta` / `SyncReader` taxonomy.** Today's `GeoDataBase` and `GeoData` already cover the metadata + sync-read surface. Adding a parallel layer would force every concept to have two names forever. See [Issue 1 §"Why the rewrite"](reader_protocol.md#why-the-rewrite).
+- **Universal format support in the new reader.** `AsyncGeoTIFFReader` is TIFF/COG-only.
+  JP2, NetCDF, HDF5, GRIB, ENVI continue to route through `RasterioReader`.
+- **A sync GDAL-free GeoTensor reader for v0.1.** Speculative, no clear customer; `RasterioReader` covers sync, `AsyncGeoTIFFReader` covers GDAL-free.
+  If a real workload emerges later we'll add a sync sibling (or a sync facade over `AsyncGeoTIFFReader`); see [open question §3](#3-a-sync-gdal-free-geotensor-reader-deferred).
+- **A custom `ByteStore` Protocol.** [`obspec`](https://github.com/developmentseed/obspec) (DevSeed) already plays that role and is what `async-geotiff` consumes.
+  We pass it through.
+  See [`types/bytestore.md`](../types/bytestore.md) for the rationale.
+- **A parallel `_ReaderMeta` / `SyncReader` taxonomy.** Today's `GeoDataBase` and `GeoData` already cover the metadata + sync-read surface.
+  Adding a parallel layer would force every concept to have two names forever.
+  See [Issue 1 §"Why the rewrite"](reader_protocol.md#why-the-rewrite).
 
 ---
 
 ## Constraints
 
-- **Backward compatibility.** Existing `RasterioReader` callers — and the `GeoData` / `GeoDataBase` Protocols in `abstract_reader.py` — must keep working. The current `read_from_window(window, boundless=True)` and `load(boundless=True)` methods stay; new methods are added alongside, not in place of.
-- **`GeoTensor` already morally satisfies `GeoData`.** It exposes `crs`, `transform`, `bounds`, `shape`, `dtype`, `fill_value_default`, `res`. Confirming it formally is a typing-only change; no runtime behaviour change.
-- **Integer-pixel rounding behaviour can't change** silently. The `PIXEL_PRECISION = 3` tolerance in `window_utils` must be preserved across all readers.
-- **The `GeoTensor` class lives in `georeader/geotensor.py` on the `feature/geotensor_npapi` branch** — see [Ch. 1 of the tutorial](../../georeader_tutorial/01_geotensor.md). The protocol definitions assume that branch is merged.
+- **Backward compatibility.** Existing `RasterioReader` callers — and the `GeoData` / `GeoDataBase` Protocols in `abstract_reader.py` — must keep working.
+  The current `read_from_window(window, boundless=True)` and `load(boundless=True)` methods stay; new methods are added alongside, not in place of.
+- **`GeoTensor` already morally satisfies `GeoData`.** It exposes `crs`, `transform`, `bounds`, `shape`, `dtype`, `fill_value_default`, `res`.
+  Confirming it formally is a typing-only change; no runtime behaviour change.
+- **Integer-pixel rounding behaviour can't change** silently.
+  The `PIXEL_PRECISION = 3` tolerance in `window_utils` must be preserved across all readers.
+- **The `GeoTensor` class lives in `georeader/geotensor.py` on the `feature/geotensor_npapi` branch** — see [Ch. 1 of the tutorial](../../georeader_tutorial/01_geotensor.md).
+  The protocol definitions assume that branch is merged.
 
 ---
 
@@ -150,7 +205,8 @@ Two readers, one shared metadata surface, two read interfaces:
 | `RasterioReader` | `georeader` | sync | GDAL / VSI | every GDAL driver |
 | `AsyncGeoTIFFReader` | `georeader` | async | `obstore` / `fsspec` | TIFF / COG only |
 
-The metadata properties and the `read_window` / `read_bounds` / `read_geoslice` / `load` method names are identical across both. The only divergence is whether reads are sync or async.
+The metadata properties and the `read_window` / `read_bounds` / `read_geoslice` / `load` method names are identical across both.
+The only divergence is whether reads are sync or async.
 
 ```python
 # Sync path — RasterioReader satisfies GeoData
@@ -175,7 +231,9 @@ geotoolz.catalog_ops.CatalogPipeline(
 )
 ```
 
-Same metadata surface, same `read_*` method names, two different bytes paths underneath. The only tax on swapping is `await` — which is unavoidable as long as the cloud HTTP world is fundamentally async. For the side-by-side strategy comparison (open cost, read cost, concurrency, driver coverage), see the [stack-level overview in `geostack.md`](../geostack.md#the-two-readers-compared).
+Same metadata surface, same `read_*` method names, two different bytes paths underneath.
+The only tax on swapping is `await` — which is unavoidable as long as the cloud HTTP world is fundamentally async.
+For the side-by-side strategy comparison (open cost, read cost, concurrency, driver coverage), see the [stack-level overview in `geostack.md`](../geostack.md#the-two-readers-compared).
 
 ---
 
@@ -188,7 +246,8 @@ The work splits into two independently reviewable issues:
 | 1 | [`reader_protocol.md`](reader_protocol.md) | `AsyncGeoData` Protocol (single new Protocol); `GeoTensor` Protocol-conformance check; tutorial chapter updates (02). Optional bundle: `RasterioReader` constructor widening with `opener=`/`fs=`/`rio_open_kwargs=` knobs + three-bytes-paths writeup in tutorial Ch. 3. |
 | 2 | [`reader_async_geotiff.md`](reader_async_geotiff.md) | `AsyncGeoTIFFReader` class — thin (~80 LOC) adapter over `developmentseed/async-geotiff`; async `open(...)` classmethod; `Window`/`RasterArray` translators; passthrough of `obspec.AsyncStore` to `GeoTIFF.open`. |
 
-Cloud byte transport is delegated to `obspec` (see [`types/bytestore.md`](../types/bytestore.md)); we ship a small `geotoolz.io.open_store(url)` factory and nothing else. There is no `ByteStore` Protocol of our own.
+Cloud byte transport is delegated to `obspec` (see [`types/bytestore.md`](../types/bytestore.md)); we ship a small `geotoolz.io.open_store(url)` factory and nothing else.
+There is no `ByteStore` Protocol of our own.
 
 Each sub-design is sized to be a single PR with a focused review.
 
@@ -207,7 +266,8 @@ Issue 2 (AsyncGeoTIFFReader thin adapter over async-geotiff)
 ```
 
 - **Issue 1 lands first.** It defines `AsyncGeoData` so Issue 2 has a typed seam to satisfy.
-- **`types/bytestore.md`** is documentation, not code — it picks `obspec` as the transport surface and specifies `geotoolz.io.open_store(url)` (~30 LOC). Can land alongside Issue 1.
+- **`types/bytestore.md`** is documentation, not code — it picks `obspec` as the transport surface and specifies `geotoolz.io.open_store(url)` (~30 LOC).
+  Can land alongside Issue 1.
 - **Issue 2 is a single focused PR**: the ~80-LOC async adapter, two small `Window`/`RasterArray` translators, the `geotoolz.io.open_store` helper.
 - **No `_cog_helpers.py`, no semaphore policy, no decompression dispatch in our code.** All of that is in `async-geotiff` (and its Rust dep `async-tiff`); we depend on it.
 
@@ -219,51 +279,72 @@ These are unresolved and should be discussed before Issue 1 starts.
 
 ### 1. `RasterioReader` file-handle caching
 
-The current `RasterioReader` opens the file fresh on every `read()` call — see [Ch. 3 §1 of the tutorial](../../georeader_tutorial/03_rasterio_reader.md). That behaviour is **deliberate**: it makes the reader pickleable for `multiprocessing` / `joblib` / Dask workers, because a cached `rasterio.DatasetReader` cannot cross a process boundary.
+The current `RasterioReader` opens the file fresh on every `read()` call — see [Ch. 3 §1 of the tutorial](../../georeader_tutorial/03_rasterio_reader.md).
+That behaviour is **deliberate**: it makes the reader pickleable for `multiprocessing` / `joblib` / Dask workers, because a cached `rasterio.DatasetReader` cannot cross a process boundary.
 
-The proposal in this design implies caching the open handle for the lifetime of the reader (with explicit `__enter__` / `__exit__` and `close()`). That's a behaviour change and the trade-off is real:
+The proposal in this design implies caching the open handle for the lifetime of the reader (with explicit `__enter__` / `__exit__` and `close()`).
+That's a behaviour change and the trade-off is real:
 
-- **Cache the handle:** repeated reads in one process are faster (no per-call open cost). Pickling for multi-process work breaks; users would need to re-open in worker.
+- **Cache the handle:** repeated reads in one process are faster (no per-call open cost).
+  Pickling for multi-process work breaks; users would need to re-open in worker.
 - **Open fresh per read (status quo):** pickleable across processes for free; pays a small per-call open cost.
-- **Configurable:** add a `cache_handle: bool = False` kwarg. More API surface, but lets each call site pick.
+- **Configurable:** add a `cache_handle: bool = False` kwarg.
+  More API surface, but lets each call site pick.
 
 **Decision needed before Issue 1.**
 
 ### 2. Where COG IFD parsing + tile math + decompression lives
 
-In **`developmentseed/async-geotiff`** (and its Rust dep `async-tiff`). We don't host these primitives ourselves — `AsyncGeoTIFFReader` is a thin adapter over `GeoTIFF.open` and `overview.read(window=...)`. The earlier draft of this plan proposed a private `_cog_helpers.py` module; that scope was removed when the review showed `async-geotiff` already covers IFD walk, tile-fetch math, decompression dispatch, request coalescing, and decoding off the event loop. See [Issue 2 §"Why the rewrite"](reader_async_geotiff.md#why-the-rewrite).
+In **`developmentseed/async-geotiff`** (and its Rust dep `async-tiff`).
+We don't host these primitives ourselves — `AsyncGeoTIFFReader` is a thin adapter over `GeoTIFF.open` and `overview.read(window=...)`.
+The earlier draft of this plan proposed a private `_cog_helpers.py` module; that scope was removed when the review showed `async-geotiff` already covers IFD walk, tile-fetch math, decompression dispatch, request coalescing, and decoding off the event loop.
+See [Issue 2 §"Why the rewrite"](reader_async_geotiff.md#why-the-rewrite).
 
 If a future reader needs the same primitives (sync facade, sensor-specific COG variant), the right path is to call `async-geotiff` from sync code via `asyncio.run(...)` — not to fork the helpers.
 
 ### 3. A sync GDAL-free GeoTensor reader (deferred)
 
-Earlier drafts of this design proposed a `LazyCOGReader` — a sync, GDAL-free, COG-only `GeoTensor` reader. It was originally pitched as a wrapper around the [`developmentseed/lazycogs`](https://github.com/developmentseed/lazycogs) library, which turned out to return `xarray.DataArray` (not `GeoTensor`) and to be properly part of the `xrtoolz` / dense-cube stack — see the `geostack_notes.md` discussion for that re-routing.
+Earlier drafts of this design proposed a `LazyCOGReader` — a sync, GDAL-free, COG-only `GeoTensor` reader.
+It was originally pitched as a wrapper around the [`developmentseed/lazycogs`](https://github.com/developmentseed/lazycogs) library, which turned out to return `xarray.DataArray` (not `GeoTensor`) and to be properly part of the `xrtoolz` / dense-cube stack — see the `geostack_notes.md` discussion for that re-routing.
 
-The sync GDAL-free GeoTensor workload itself is plausible (notebooks, FastAPI sync handlers, batch scripts), but **doesn't yet have a clear customer** that `RasterioReader` (sync, GDAL) and `AsyncGeoTIFFReader` (async, GDAL-free) don't already cover between them. If a real workload emerges, the cheapest path is a sync facade that wraps `AsyncGeoTIFFReader` with `asyncio.run(...)` for one-call use cases; the more expensive path is a from-scratch sync IFD reader. **Decide if and when.**
+The sync GDAL-free GeoTensor workload itself is plausible (notebooks, FastAPI sync handlers, batch scripts), but **doesn't yet have a clear customer** that `RasterioReader` (sync, GDAL) and `AsyncGeoTIFFReader` (async, GDAL-free) don't already cover between them.
+If a real workload emerges, the cheapest path is a sync facade that wraps `AsyncGeoTIFFReader` with `asyncio.run(...)` for one-call use cases; the more expensive path is a from-scratch sync IFD reader.
+**Decide if and when.**
 
 ### 4. Async warp / resample / overview-pick (deferred)
 
-`async-geotiff` explicitly disclaims [warping, resampling, and automatic overview selection](https://github.com/developmentseed/async-geotiff#anti-features). Their guidance is "load with async-geotiff, then warp via `rasterio.MemoryFile` if needed". Our v1 plan adopts the same boundary: `AsyncGeoTIFFReader.read_bounds(target_crs=...)` raises `NotImplementedError` and points users at:
+`async-geotiff` explicitly disclaims [warping, resampling, and automatic overview selection](https://github.com/developmentseed/async-geotiff#anti-features).
+Their guidance is "load with async-geotiff, then warp via `rasterio.MemoryFile` if needed".
+Our v1 plan adopts the same boundary: `AsyncGeoTIFFReader.read_bounds(target_crs=...)` raises `NotImplementedError` and points users at:
 
-- **(a) Two-step pattern.** `gt = await reader.read_bounds(bounds)` (native CRS) → `gt = georeader.read.read_reproject_like(gt, target=...)` (sync warp post-step). User owns the post-step.
+- **(a) Two-step pattern.** `gt = await reader.read_bounds(bounds)` (native CRS) → `gt = georeader.read.read_reproject_like(gt, target=...)` (sync warp post-step).
+  User owns the post-step.
 - **(b) Use `RasterioReader` instead.** It has WarpedVRT integration on the sync path.
 
-This is fine for the workloads we know about (tile servers serving native-CRS overviews, fan-out batch reads in a single CRS). It will **not** fit a future tile server that needs Web-Mercator output from a UTM source without GDAL anywhere in the loop. When that customer materialises, the options are:
+This is fine for the workloads we know about (tile servers serving native-CRS overviews, fan-out batch reads in a single CRS).
+It will **not** fit a future tile server that needs Web-Mercator output from a UTM source without GDAL anywhere in the loop.
+When that customer materialises, the options are:
 
-- (i) Inline post-warp via `rasterio.warp` in `loop.run_in_executor`. Adds GDAL back into the async dependency cone (defeats part of the point).
-- (ii) `WarpedAsyncGeoTIFFReader` wrapper class that composes (i). Cleaner API, same dep cost.
+- (i) Inline post-warp via `rasterio.warp` in `loop.run_in_executor`.
+  Adds GDAL back into the async dependency cone (defeats part of the point).
+- (ii) `WarpedAsyncGeoTIFFReader` wrapper class that composes (i).
+  Cleaner API, same dep cost.
 - (iii) Pure-Python or pure-Rust warp (long-tail engineering; not on anyone's roadmap).
 
-Same logic applies to overview auto-selection (`request_resolution`-style helper) and to in-CRS resampling. **Deferred for a later discussion** — flagging here so we don't accidentally bake a no-warp assumption deep into downstream code that would later be hard to lift.
+Same logic applies to overview auto-selection (`request_resolution`-style helper) and to in-CRS resampling.
+**Deferred for a later discussion** — flagging here so we don't accidentally bake a no-warp assumption deep into downstream code that would later be hard to lift.
 
 ---
 
 ## Alternatives considered
 
-- **Don't unify; let `async-geotiff` stay an external library with a different shape.** Rejected: forces downstream code (`geotoolz`, ML pipelines) to special-case which library is in use, which is exactly the coordination tax the reconciliation removes. *(`lazycogs` was previously named here as a parallel external library; on closer inspection it's `xarray`-shaped, so it belongs in the `xrtoolz` discussion rather than this one — see [`geostack_notes.md`](../../geostack_notes.md).)*
+- **Don't unify; let `async-geotiff` stay an external library with a different shape.** Rejected: forces downstream code (`geotoolz`, ML pipelines) to special-case which library is in use, which is exactly the coordination tax the reconciliation removes.
+  *(`lazycogs` was previously named here as a parallel external library; on closer inspection it's `xarray`-shaped, so it belongs in the `xrtoolz` discussion rather than this one — see [`geostack_notes.md`](../../geostack_notes.md).)*
 - **Make the existing `RasterioReader` async-by-default with sync wrappers.** Rejected: too disruptive to existing callers, and the GDAL ecosystem isn't async-friendly underneath; the wrapper would be sync-pretending-to-be-async.
-- **Use `rio-tiler` / `terracotta` as the COG reader.** Rejected: those are higher-level — they bake in tile-server assumptions and color/visualisation logic. The COG reader proposed here is a substrate, not a tile server.
-- **Adopt `kerchunk` / `zarr`-shaped lazy access.** Rejected: incompatible with the rasterio-native `Window` and `Affine` API surface that the rest of `georeader` is built on. Could be added as a separate reader later.
+- **Use `rio-tiler` / `terracotta` as the COG reader.** Rejected: those are higher-level — they bake in tile-server assumptions and color/visualisation logic.
+  The COG reader proposed here is a substrate, not a tile server.
+- **Adopt `kerchunk` / `zarr`-shaped lazy access.** Rejected: incompatible with the rasterio-native `Window` and `Affine` API surface that the rest of `georeader` is built on.
+  Could be added as a separate reader later.
 
 ---
 
@@ -281,13 +362,29 @@ The tutorial today describes the **current** package state; updates land alongsi
 
 ## Open questions, gotchas, and warnings
 
-The reconciliation is mostly low-risk — pieces exist, the work is plumbing. A few things to manage actively:
+The reconciliation is mostly low-risk — pieces exist, the work is plumbing.
+A few things to manage actively:
 
-- **`feature/geotensor_npapi` merge timing is critical-path** for `geotoolz`. The ndarray-subclass `GeoTensor` with `__array_ufunc__` underpins `geotoolz`'s two-tier model. If the branch stalls upstream, downstream blocks. Track the upstream merge as a v0.1 release blocker; contingency is to vendor `GeoTensor` in `geotoolz` until upstream catches up.
-- **`__array_function__` (NEP-18) coverage.** `__array_ufunc__` covers ufuncs only; `np.fft.*`, `np.linalg.*`, `np.einsum`, `np.percentile` go through `__array_function__`. Verify `GeoTensor` implements both protocols, or document which numpy submodules strip the subclass. Add a CI test that round-trips metadata through every numpy submodule the readers and downstream operators touch.
-- **ndarray subclass survival across third-party libraries.** `GeoTensor` survives numpy + scipy + skimage + matplotlib. It does **not** survive PyTorch (`torch.from_numpy` strips), JAX (`jnp.asarray` strips), or Dask without explicit `meta=` plumbing. Document this boundary in the user docs so consumers don't assume the subclass flows everywhere.
-- **Async ↔ sync boundary.** `AsyncGeoData` returns awaitables; downstream sync code (Operators, batch loops) needs `asyncio.run()` per call, which costs an event loop per invocation. `geotoolz` will need to pick a strategy (`AsyncOperator` family, or restrict async to the `CatalogPipeline` boundary) — see [`geotoolz.md` §11.2](../geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci). Worth coordinating before v0.1.
-- **Sensor-reader scope reduction for v0.1.** [`readers/`](../readers/) lists ABI, SEVIRI Native, MTG-FCI, Himawari-AHI HSD, SEVIRI HRIT, MODIS, VIIRS. Each "hard" sensor (irregular file formats, bowtie distortion) is 1–2 weeks *with full product spec access*. **Recommendation:** ship MODIS + ABI as v0.1 sensor proofs; defer SEVIRI / MTG / Himawari to v0.5+ unless an active user has a concrete need.
-- **Credential per-reader isolation.** The `Credential` design (`apply()` returning a dict, no global env-var mutation) only works if every reader is updated to consume the per-call dict instead of reading from `os.environ`. Backwards-compat path: legacy `apply_to_os_environ()` is provided but discouraged. Audit each reader on the way through reconciliation.
-- **`async-geotiff` API stability.** `async-geotiff` is at v0.1+ and pre-1.0; the API may shift between minor releases. Pin a minor range in `pyproject.toml` (`async-geotiff>=0.1,<0.2`) and bump deliberately. Document the bump policy in `geotoolz`'s release notes when we cut v0.1.
-- **Per-sensor public bucket helpers** are user-friendly but couple `georeader` to specific cloud-bucket layouts that providers can change without notice (Sentinel-2 on AWS moved twice). Pin reader behaviour to a documented bucket convention; add a smoke test that fails loudly if a bucket layout changes.
+- **`feature/geotensor_npapi` merge timing is critical-path** for `geotoolz`.
+  The ndarray-subclass `GeoTensor` with `__array_ufunc__` underpins `geotoolz`'s two-tier model.
+  If the branch stalls upstream, downstream blocks.
+  Track the upstream merge as a v0.1 release blocker; contingency is to vendor `GeoTensor` in `geotoolz` until upstream catches up.
+- **`__array_function__` (NEP-18) coverage.** `__array_ufunc__` covers ufuncs only; `np.fft.*`, `np.linalg.*`, `np.einsum`, `np.percentile` go through `__array_function__`.
+  Verify `GeoTensor` implements both protocols, or document which numpy submodules strip the subclass.
+  Add a CI test that round-trips metadata through every numpy submodule the readers and downstream operators touch.
+- **ndarray subclass survival across third-party libraries.** `GeoTensor` survives numpy + scipy + skimage + matplotlib.
+  It does **not** survive PyTorch (`torch.from_numpy` strips), JAX (`jnp.asarray` strips), or Dask without explicit `meta=` plumbing.
+  Document this boundary in the user docs so consumers don't assume the subclass flows everywhere.
+- **Async ↔ sync boundary.** `AsyncGeoData` returns awaitables; downstream sync code (Operators, batch loops) needs `asyncio.run()` per call, which costs an event loop per invocation.
+  `geotoolz` will need to pick a strategy (`AsyncOperator` family, or restrict async to the `CatalogPipeline` boundary) — see [`geotoolz.md` §11.2](../geotoolz/geotoolz.md#112-implementation-gotchas-test-these-in-ci).
+  Worth coordinating before v0.1.
+- **Sensor-reader scope reduction for v0.1.** [`readers/`](../readers/) lists ABI, SEVIRI Native, MTG-FCI, Himawari-AHI HSD, SEVIRI HRIT, MODIS, VIIRS. Each "hard" sensor (irregular file formats, bowtie distortion) is 1–2 weeks *with full product spec access*.
+  **Recommendation:** ship MODIS + ABI as v0.1 sensor proofs; defer SEVIRI / MTG / Himawari to v0.5+ unless an active user has a concrete need.
+- **Credential per-reader isolation.** The `Credential` design (`apply()` returning a dict, no global env-var mutation) only works if every reader is updated to consume the per-call dict instead of reading from `os.environ`.
+  Backwards-compat path: legacy `apply_to_os_environ()` is provided but discouraged.
+  Audit each reader on the way through reconciliation.
+- **`async-geotiff` API stability.** `async-geotiff` is at v0.1+ and pre-1.0; the API may shift between minor releases.
+  Pin a minor range in `pyproject.toml` (`async-geotiff>=0.1,<0.2`) and bump deliberately.
+  Document the bump policy in `geotoolz`'s release notes when we cut v0.1.
+- **Per-sensor public bucket helpers** are user-friendly but couple `georeader` to specific cloud-bucket layouts that providers can change without notice (Sentinel-2 on AWS moved twice).
+  Pin reader behaviour to a documented bucket convention; add a smoke test that fails loudly if a bucket layout changes.

--- a/projects/geotoolz/plans/georeader/reader_async_geotiff.md
+++ b/projects/geotoolz/plans/georeader/reader_async_geotiff.md
@@ -15,20 +15,24 @@ license: CC-BY-4.0
 keywords: design, georeader, async, cog, async-geotiff
 ---
 
-> **Parent:** [README.md](README.md)
-> **Depends on:** [Issue 1](reader_protocol.md) — adds an `AsyncGeoData` Protocol that mirrors today's `GeoData` with `async` read methods.
-> **Status:** **revised 2026-05-09** — collapsed from a "build a COG reader from scratch" design (~400 LOC, private `_cog_helpers.py`, semaphore policy) into a thin adapter (~80 LOC) over [`developmentseed/async-geotiff`](https://github.com/developmentseed/async-geotiff). See §"Why the rewrite" below.
-> **Scope:** an async, COG-only reader for high-concurrency fan-out workloads — tile servers, web maps, async ML inference services. Wraps `async_geotiff.GeoTIFF`; translates async-geotiff's `Window` / `RasterArray` into our `Window` / `GeoTensor`.
+> **Parent:** [README.md](README.md) **Depends on:** [Issue 1](reader_protocol.md) — adds an `AsyncGeoData` Protocol that mirrors today's `GeoData` with `async` read methods.
+> **Status:** **revised 2026-05-09** — collapsed from a "build a COG reader from scratch" design (~400 LOC, private `_cog_helpers.py`, semaphore policy) into a thin adapter (~80 LOC) over [`developmentseed/async-geotiff`](https://github.com/developmentseed/async-geotiff).
+> See §"Why the rewrite" below.
+> **Scope:** an async, COG-only reader for high-concurrency fan-out workloads — tile servers, web maps, async ML inference services.
+> Wraps `async_geotiff.GeoTIFF`; translates async-geotiff's `Window` / `RasterArray` into our `Window` / `GeoTensor`.
 
 ---
 
 ## Why this issue exists
 
-Sync I/O is fine when you have one read at a time. For workloads where many reads happen concurrently (a tile server fielding 1000 simultaneous tile requests, an async ML service that fans out across hundreds of windows from one process), async-native fetching is the right shape — `asyncio.gather(*[reader.read_window(w) for w in windows])` becomes a one-line concurrency primitive.
+Sync I/O is fine when you have one read at a time.
+For workloads where many reads happen concurrently (a tile server fielding 1000 simultaneous tile requests, an async ML service that fans out across hundreds of windows from one process), async-native fetching is the right shape — `asyncio.gather(*[reader.read_window(w) for w in windows])` becomes a one-line concurrency primitive.
 
-Today, `georeader` has no async story. Users wanting async reads either roll their own or pull in an external library with a different API. This issue adds `AsyncGeoTIFFReader` — same metadata surface as `RasterioReader`, async read methods.
+Today, `georeader` has no async story.
+Users wanting async reads either roll their own or pull in an external library with a different API. This issue adds `AsyncGeoTIFFReader` — same metadata surface as `RasterioReader`, async read methods.
 
-We do **not** rebuild any of the COG plumbing. [`async-geotiff`](https://github.com/developmentseed/async-geotiff) (DevSeed, ~50★, last updated 2026-05-09) already ships:
+We do **not** rebuild any of the COG plumbing.
+[`async-geotiff`](https://github.com/developmentseed/async-geotiff) (DevSeed, ~50★, last updated 2026-05-09) already ships:
 
 - `await GeoTIFF.open(path, store=...)` — async constructor, fetches and parses the IFD chain.
 - `geotiff.transform`, `geotiff.crs`, `geotiff.overviews[i]`, `overview.read(window=...)`.
@@ -39,7 +43,8 @@ We do **not** rebuild any of the COG plumbing. [`async-geotiff`](https://github.
 - Decompressors: Deflate, JPEG, JPEG2000, LERC, LERC_DEFLATE, LERC_ZSTD, LZMA, LZW, WebP, ZSTD.
 - Cloud transport: accepts any [`obspec.AsyncStore`](https://github.com/developmentseed/obspec) — including `obstore.S3Store`, `GCSStore`, `AzureStore`, `HTTPStore`, `LocalStore`.
 
-Our reader is therefore a **thin adapter**: instantiate `GeoTIFF.open`, expose its metadata behind our `GeoDataBase`-shaped property surface, translate windows on the way in and `RasterArray → GeoTensor` on the way out. Roughly 80 LOC.
+Our reader is therefore a **thin adapter**: instantiate `GeoTIFF.open`, expose its metadata behind our `GeoDataBase`-shaped property surface, translate windows on the way in and `RasterArray → GeoTensor` on the way out.
+Roughly 80 LOC.
 
 ---
 
@@ -65,31 +70,43 @@ On review (2026-05-09), every one of those concerns is already solved upstream:
 | Concurrency / fan-out control | Rust thread pool + obspec backend's connection pool |
 | Decompressor coverage | Deflate, JPEG, JPEG2000, LERC*, LZMA, LZW, WebP, ZSTD |
 
-A pure-Python reimplementation would be slower, less correct (decompression dispatch is fiddly), and would drift from upstream. The right call is to depend on `async-geotiff` and write the smallest possible adapter on top of it.
+A pure-Python reimplementation would be slower, less correct (decompression dispatch is fiddly), and would drift from upstream.
+The right call is to depend on `async-geotiff` and write the smallest possible adapter on top of it.
 
-The custom `ByteStore` Protocol also evaporated in the same rewrite — see [`types/bytestore.md`](../types/bytestore.md). We pass `obspec.AsyncStore` straight through.
+The custom `ByteStore` Protocol also evaporated in the same rewrite — see [`types/bytestore.md`](../types/bytestore.md).
+We pass `obspec.AsyncStore` straight through.
 
 ---
 
 ## Primer for newcomers
 
-> **ELI5.** Sync code is like **waiting in line at one cashier** — you can't do anything else until your turn finishes. Async code is like **leaving your order at 25 different counters** and collecting the results as they're ready. Same hardware; far more food per unit time when each order is mostly waiting.
+> **ELI5.** Sync code is like **waiting in line at one cashier** — you can't do anything else until your turn finishes.
+> Async code is like **leaving your order at 25 different counters** and collecting the results as they're ready.
+> Same hardware; far more food per unit time when each order is mostly waiting.
 
 ### `async` / `await` basics
 
-**What it is.** Python's `async def` defines a *coroutine* — a function that can pause itself with `await` and let other coroutines run on the same thread until the awaited operation completes. It's not threading; it's cooperative multitasking inside one event loop.
+**What it is.** Python's `async def` defines a *coroutine* — a function that can pause itself with `await` and let other coroutines run on the same thread until the awaited operation completes.
+It's not threading; it's cooperative multitasking inside one event loop.
 
-**How it works.** When you call `result = await some_async_function()`, the runtime suspends the current coroutine until `some_async_function()` finishes, then resumes with the result. While suspended, the event loop runs other ready coroutines. Async only helps when the work is I/O-bound — waiting on network, disk, etc. — because that's when there's idle time to fill.
+**How it works.** When you call `result = await some_async_function()`, the runtime suspends the current coroutine until `some_async_function()` finishes, then resumes with the result.
+While suspended, the event loop runs other ready coroutines.
+Async only helps when the work is I/O-bound — waiting on network, disk, etc. — because that's when there's idle time to fill.
 
-**What this means for us.** Cloud raster reads are dominated by network round-trips. With `async`, one process can have hundreds of `read_window(...)` calls in flight concurrently, all sharing one OS thread. The CPython GIL doesn't get in the way because nobody's computing — they're all waiting on HTTP. Same hardware; far more throughput; far simpler than thread pools.
+**What this means for us.** Cloud raster reads are dominated by network round-trips.
+With `async`, one process can have hundreds of `read_window(...)` calls in flight concurrently, all sharing one OS thread.
+The CPython GIL doesn't get in the way because nobody's computing — they're all waiting on HTTP. Same hardware; far more throughput; far simpler than thread pools.
 
 ### `asyncio.gather` and parallel awaits
 
-**What it is.** `asyncio.gather(coro1, coro2, coro3, ...)` runs multiple coroutines concurrently and returns when all finish (or one raises). It's the canonical way to issue many parallel I/O operations in one call.
+**What it is.** `asyncio.gather(coro1, coro2, coro3, ...)` runs multiple coroutines concurrently and returns when all finish (or one raises).
+It's the canonical way to issue many parallel I/O operations in one call.
 
-**How it works.** Each argument is a coroutine that hasn't started yet. `gather(...)` schedules them all on the event loop, lets them run interleaved, and collects their results into a list in input order.
+**How it works.** Each argument is a coroutine that hasn't started yet.
+`gather(...)` schedules them all on the event loop, lets them run interleaved, and collects their results into a list in input order.
 
-**What this means for us.** A *single* `read_window(...)` is just one `await` on async-geotiff (the parallelism inside it is in the Rust core). The interesting `gather(...)` is at the *outer* layer — `await asyncio.gather(*[reader.read_window(w) for w in 1000_windows])` for tile-server-shaped workloads.
+**What this means for us.** A *single* `read_window(...)` is just one `await` on async-geotiff (the parallelism inside it is in the Rust core).
+The interesting `gather(...)` is at the *outer* layer — `await asyncio.gather(*[reader.read_window(w) for w in 1000_windows])` for tile-server-shaped workloads.
 
 ```{mermaid}
 gantt
@@ -112,11 +129,17 @@ gantt
 
 ### Async classmethod for construction
 
-**What it is.** Python's `__init__` *can't* be an `async def`. There's no `__ainit__` magic method. So when initialisation requires async work (fetching the COG IFD over HTTP), the convention is a classmethod `open(...)` that's `async`.
+**What it is.** Python's `__init__` *can't* be an `async def`.
+There's no `__ainit__` magic method.
+So when initialisation requires async work (fetching the COG IFD over HTTP), the convention is a classmethod `open(...)` that's `async`.
 
-**How it works.** `__init__` does cheap synchronous setup (store the URL, the credential, allocate state). The user calls `await Cls.open(url)`, which constructs an instance via `__init__` and then runs the async setup before returning the fully-initialised reader. Same pattern used by `aiohttp.ClientSession`, `asyncpg.connect`, and `async_geotiff.GeoTIFF` itself.
+**How it works.** `__init__` does cheap synchronous setup (store the URL, the credential, allocate state).
+The user calls `await Cls.open(url)`, which constructs an instance via `__init__` and then runs the async setup before returning the fully-initialised reader.
+Same pattern used by `aiohttp.ClientSession`, `asyncpg.connect`, and `async_geotiff.GeoTIFF` itself.
 
-**What this means for us.** Users write `reader = await AsyncGeoTIFFReader.open("s3://bucket/scene.tif")`. The reader's `crs` / `transform` / etc. don't work until `open()` has been awaited — accessing them earlier raises `RuntimeError("Reader not opened")`. Slight cost in clarity; major win in not faking sync APIs over async work.
+**What this means for us.** Users write `reader = await AsyncGeoTIFFReader.open("s3://bucket/scene.tif")`.
+The reader's `crs` / `transform` / etc. don't work until `open()` has been awaited — accessing them earlier raises `RuntimeError("Reader not opened")`.
+Slight cost in clarity; major win in not faking sync APIs over async work.
 
 ```{mermaid}
 sequenceDiagram
@@ -145,16 +168,21 @@ sequenceDiagram
 
 ## Deliverables
 
-1. **`AsyncGeoData` Protocol** in `georeader/abstract_reader.py` — mirrors today's `GeoData` with async read methods. Defined in [Issue 1](reader_protocol.md).
+1. **`AsyncGeoData` Protocol** in `georeader/abstract_reader.py` — mirrors today's `GeoData` with async read methods.
+   Defined in [Issue 1](reader_protocol.md).
 2. **`AsyncGeoTIFFReader` class** in `georeader/async_geotiff_reader.py` (~80 LOC).
 3. **`async open(...)` classmethod** — wraps `await async_geotiff.GeoTIFF.open(path, store=...)`.
-4. **Async read methods** — `read_window`, `read_bounds`, `read_geoslice`, `load`. Each is one or two lines of adapter code over `async-geotiff`.
+4. **Async read methods** — `read_window`, `read_bounds`, `read_geoslice`, `load`.
+   Each is one or two lines of adapter code over `async-geotiff`.
 5. **Two small translators** — `Window ↔ async_geotiff.Window` and `RasterArray → GeoTensor`.
-6. **Optional `geotoolz.io.open_store(url)`** — see [`types/bytestore.md`](../types/bytestore.md). Builds an `obstore` backend from the URL scheme; if the user passes their own `obspec.AsyncStore` we use it as-is.
-7. **Async context-manager** — `__aenter__` / `__aexit__`. `aclose` is a no-op (obstore pools its own connections; async-geotiff has no resource to release).
+6. **Optional `geotoolz.io.open_store(url)`** — see [`types/bytestore.md`](../types/bytestore.md).
+   Builds an `obstore` backend from the URL scheme; if the user passes their own `obspec.AsyncStore` we use it as-is.
+7. **Async context-manager** — `__aenter__` / `__aexit__`.
+   `aclose` is a no-op (obstore pools its own connections; async-geotiff has no resource to release).
 8. **Tests** — open + read a real COG asynchronously; concurrent fan-out across N windows; numerical equivalence vs `RasterioReader.read_window` for the same file/window within rounding.
 
-This issue does **not** ship: a custom byte-store Protocol, a `_cog_helpers.py` module, a semaphore-based concurrency cap, decompression dispatch, IFD parsing, or tile-fetch math. All of that is in `async-geotiff`.
+This issue does **not** ship: a custom byte-store Protocol, a `_cog_helpers.py` module, a semaphore-based concurrency cap, decompression dispatch, IFD parsing, or tile-fetch math.
+All of that is in `async-geotiff`.
 
 ---
 
@@ -340,7 +368,9 @@ def _rasterarray_to_geotensor(
     )
 ```
 
-That's the whole reader. Roughly 80 LOC counting blank lines and helpers. The interesting work is two adapters; the rest is property passthrough.
+That's the whole reader.
+Roughly 80 LOC counting blank lines and helpers.
+The interesting work is two adapters; the rest is property passthrough.
 
 ---
 
@@ -348,11 +378,15 @@ That's the whole reader. Roughly 80 LOC counting blank lines and helpers. The in
 
 These are explicitly out of scope — pulling them in would either reinvent async-geotiff functionality or rebuild the GDAL warping layer in a context where rasterio already exists.
 
-- **Reprojection / warping in `read_bounds(target_crs=...)`.** async-geotiff has the same non-goal. Users wanting cross-CRS reads either (a) read native + post-process via `georeader.read.read_reproject_like`, or (b) use `RasterioReader` (which has WarpedVRT integration). The async-reader path raises on `target_crs!=None` for v1; revisit per [open question §1](#1-async-warp-revisit-later).
+- **Reprojection / warping in `read_bounds(target_crs=...)`.** async-geotiff has the same non-goal. Users wanting cross-CRS reads either (a) read native + post-process via `georeader.read.read_reproject_like`, or (b) use `RasterioReader` (which has WarpedVRT integration).
+  The async-reader path raises on `target_crs!=None` for v1; revisit per [open question §1](#1-async-warp-revisit-later).
 - **Resampling in `read_bounds(target_resolution=...)`.** Same reasoning. async-geotiff's overview ladder is what we expose; downsampling between overview levels happens in a sync post-step via existing `georeader` functions.
-- **Auto overview selection.** Caller picks `overview_level` (default 0 = full-res). `geotoolz` can layer "pick the smallest overview ≥ requested resolution" on top later — this is a one-screen helper, not reader plumbing.
+- **Auto overview selection.** Caller picks `overview_level` (default 0 = full-res).
+  `geotoolz` can layer "pick the smallest overview ≥ requested resolution" on top later — this is a one-screen helper, not reader plumbing.
 - **A custom byte-store Protocol.** See [`types/bytestore.md`](../types/bytestore.md).
-- **A semaphore for `max_concurrent_tiles`.** async-tiff's Rust core handles intra-call coalescing; obstore's connection pool bounds outer concurrency. Adding our own semaphore competes with both. If a benchmark shows us getting hammered, revisit.
+- **A semaphore for `max_concurrent_tiles`.** async-tiff's Rust core handles intra-call coalescing; obstore's connection pool bounds outer concurrency.
+  Adding our own semaphore competes with both.
+  If a benchmark shows us getting hammered, revisit.
 - **Decompression dispatch.** async-tiff already covers Deflate, JPEG, JPEG2000, LERC, LERC_DEFLATE, LERC_ZSTD, LZMA, LZW, WebP, ZSTD. If a sensor we care about uses something exotic, that's a per-issue workaround, not a reason to fork.
 
 ---
@@ -369,7 +403,8 @@ These are explicitly out of scope — pulling them in would either reinvent asyn
 | `AsyncGeoTIFFReader` adapter | `georeader/async_geotiff_reader.py` (~80 LOC) |
 | `_to_agt_window` / `_rasterarray_to_geotensor` | colocated with the reader (small private helpers) |
 
-The original code in this issue is the ~80-LOC adapter and its two helpers. Everything else is dependencies.
+The original code in this issue is the ~80-LOC adapter and its two helpers.
+Everything else is dependencies.
 
 ---
 
@@ -391,26 +426,40 @@ In addition to the [parent design's open questions](README.md#open-questions):
 
 ### 1. Async warp — revisit later
 
-[`async-geotiff` explicitly says no warp / resample / overview-pick.](https://github.com/developmentseed/async-geotiff#anti-features) Their guidance is "load with async-geotiff, then warp via `rasterio.MemoryFile`". For v1 we raise on `target_crs!=None`. If a real customer materialises (e.g. an async tile server that needs Web-Mercator output from a UTM source), the options are:
+[`async-geotiff` explicitly says no warp / resample / overview-pick.](https://github.com/developmentseed/async-geotiff#anti-features) Their guidance is "load with async-geotiff, then warp via `rasterio.MemoryFile`".
+For v1 we raise on `target_crs!=None`.
+If a real customer materialises (e.g. an async tile server that needs Web-Mercator output from a UTM source), the options are:
 
-- (a) post-process inside `read_bounds`: fetch native, then warp via `rasterio.warp` in a thread (`loop.run_in_executor`). Adds GDAL back into the async dependency cone, which partly defeats the point.
+- (a) post-process inside `read_bounds`: fetch native, then warp via `rasterio.warp` in a thread (`loop.run_in_executor`).
+  Adds GDAL back into the async dependency cone, which partly defeats the point.
 - (b) document the two-step pattern (`reader.read_bounds(...)` → `georeader.read.read_reproject_like(...)`) and let the user own the post-step.
-- (c) build a `WarpedAsyncGeoTIFFReader` wrapper that composes (a). Keeps the surface clean but ships the GDAL dep regardless.
+- (c) build a `WarpedAsyncGeoTIFFReader` wrapper that composes (a).
+  Keeps the surface clean but ships the GDAL dep regardless.
 
-Tentative pick: stay at "raise" for v1, document (b) in the error message, revisit when a customer asks. **Tagged for later discussion** (per the 2026-05-09 review).
+Tentative pick: stay at "raise" for v1, document (b) in the error message, revisit when a customer asks.
+**Tagged for later discussion** (per the 2026-05-09 review).
 
 ### 2. Overview selection
 
-`overview_level: int = 0` is a constructor arg today (full-res by default). Adding a `request_resolution` shortcut that picks the smallest overview ≥ that resolution is a 10-line helper; could live on the reader or as a free function in `geotoolz`. Not blocking.
+`overview_level: int = 0` is a constructor arg today (full-res by default).
+Adding a `request_resolution` shortcut that picks the smallest overview ≥ that resolution is a 10-line helper; could live on the reader or as a free function in `geotoolz`.
+Not blocking.
 
 ### 3. Async iteration over many readers (one per file)
 
-Tile-server workloads often have one COG per scene and N concurrent client requests. The natural shape is `await asyncio.gather(*[AsyncGeoTIFFReader.open(p) for p in paths])` for setup, then per-request reads against a cached pool of opened readers. Caching strategy (LRU? per-process? shared across workers?) is **not** in this issue — it's an application-level concern. Just calling out so we don't accidentally bake in a single-reader-per-call assumption.
+Tile-server workloads often have one COG per scene and N concurrent client requests.
+The natural shape is `await asyncio.gather(*[AsyncGeoTIFFReader.open(p) for p in paths])` for setup, then per-request reads against a cached pool of opened readers.
+Caching strategy (LRU? per-process? shared across workers?) is **not** in this issue — it's an application-level concern.
+Just calling out so we don't accidentally bake in a single-reader-per-call assumption.
 
 ### 4. `path_or_url` typing on the Protocol
 
-`AsyncGeoData` (defined in Issue 1) inherits from `GeoData`, which doesn't currently mandate `path_or_url`. We only need it on the concrete reader for diagnostics / repr. Don't lift it onto the Protocol.
+`AsyncGeoData` (defined in Issue 1) inherits from `GeoData`, which doesn't currently mandate `path_or_url`.
+We only need it on the concrete reader for diagnostics / repr.
+Don't lift it onto the Protocol.
 
 ### 5. Pinned vs floating `async-geotiff` version
 
-`async-geotiff` is at v0.1+ and pre-1.0; the API may shift. Pin a minor range in `pyproject.toml` (`async-geotiff>=0.1,<0.2`) and bump deliberately. Document the bump policy in `geotoolz`'s release notes when we cut v0.1.
+`async-geotiff` is at v0.1+ and pre-1.0; the API may shift.
+Pin a minor range in `pyproject.toml` (`async-geotiff>=0.1,<0.2`) and bump deliberately.
+Document the bump policy in `geotoolz`'s release notes when we cut v0.1.

--- a/projects/geotoolz/plans/georeader/reader_protocol.md
+++ b/projects/geotoolz/plans/georeader/reader_protocol.md
@@ -15,19 +15,25 @@ license: CC-BY-4.0
 keywords: design, georeader, protocol, refactor
 ---
 
-> **Parent:** [README.md](README.md)
-> **Status:** **revised 2026-05-09** — collapsed from a "build a parallel `_ReaderMeta` / `SyncReader` / `AsyncReader` taxonomy" design into "keep today's `GeoData` / `GeoDataBase`; add only `AsyncGeoData`". See §"Why the rewrite" below.
-> **Scope:** add a single new Protocol (`AsyncGeoData`) so [`AsyncGeoTIFFReader`](reader_async_geotiff.md) has a typed seam to slot into. Optionally widen [`RasterioReader`](reader_rasterio.md) with `opener=` / `fs=` / `rio_open_kwargs=` knobs to expose its three bytes paths. Don't redefine the metadata surface; today's `GeoDataBase` and `GeoData` already do that.
+> **Parent:** [README.md](README.md) **Status:** **revised 2026-05-09** — collapsed from a "build a parallel `_ReaderMeta` / `SyncReader` / `AsyncReader` taxonomy" design into "keep today's `GeoData` / `GeoDataBase`; add only `AsyncGeoData`".
+> See §"Why the rewrite" below.
+> **Scope:** add a single new Protocol (`AsyncGeoData`) so [`AsyncGeoTIFFReader`](reader_async_geotiff.md) has a typed seam to slot into.
+> Optionally widen [`RasterioReader`](reader_rasterio.md) with `opener=` / `fs=` / `rio_open_kwargs=` knobs to expose its three bytes paths.
+> Don't redefine the metadata surface; today's `GeoDataBase` and `GeoData` already do that.
 
 ---
 
 ## Why this issue exists
 
-`AsyncGeoTIFFReader` (the new async COG reader; see [Issue 2](reader_async_geotiff.md)) needs a typed Protocol to satisfy. Today's `GeoData` / `GeoDataBase` Protocols cover the *sync* surface — properties + sync `load(boundless=True)` + sync `read_from_window(window, boundless)`. We need an async mirror for the new reader.
+`AsyncGeoTIFFReader` (the new async COG reader; see [Issue 2](reader_async_geotiff.md)) needs a typed Protocol to satisfy.
+Today's `GeoData` / `GeoDataBase` Protocols cover the *sync* surface — properties + sync `load(boundless=True)` + sync `read_from_window(window, boundless)`.
+We need an async mirror for the new reader.
 
-That's the entire ambition of this issue: add `AsyncGeoData`. The earlier draft also proposed adding `_ReaderMeta` and `SyncReader` Protocols *alongside* `GeoData` / `GeoDataBase` and renaming the surface — that scope has been removed (see §"Why the rewrite").
+That's the entire ambition of this issue: add `AsyncGeoData`.
+The earlier draft also proposed adding `_ReaderMeta` and `SyncReader` Protocols *alongside* `GeoData` / `GeoDataBase` and renaming the surface — that scope has been removed (see §"Why the rewrite").
 
-A second, smaller scope item is widening `RasterioReader`'s constructor with `opener=` / `fs=` / `rio_open_kwargs=` knobs so users can route bytes through GDAL VSI / fsspec / a custom callback explicitly. This is genuinely additive — no method renames, no Protocol churn — and lets `RasterioReader` remain the canonical sync reader without forcing users to monkey-patch `rasterio.Env` to reach niche backends.
+A second, smaller scope item is widening `RasterioReader`'s constructor with `opener=` / `fs=` / `rio_open_kwargs=` knobs so users can route bytes through GDAL VSI / fsspec / a custom callback explicitly.
+This is genuinely additive — no method renames, no Protocol churn — and lets `RasterioReader` remain the canonical sync reader without forcing users to monkey-patch `rasterio.Env` to reach niche backends.
 
 ---
 
@@ -42,27 +48,43 @@ The earlier draft of this doc proposed a parallel taxonomy:
 
 On review (2026-05-09), three problems:
 
-1. **Two names for every concept.** Every property would have a `GeoDataBase`-shaped name and a `_ReaderMeta`-shaped name. We'd explain back-compat in every doc forever.
-2. **Most of `_ReaderMeta` is already in `GeoData` / `GeoDataBase`.** `crs`, `transform`, `shape`, `width`, `height` are in `GeoDataBase`; `bounds`, `res`, `dtype`, `fill_value_default` are in `GeoData` (with default implementations on top of the required three). The only genuinely new fields proposed (`path_or_url`, `indexes`) are *reader-construction details* that leak file-backed-reader concerns onto an abstract surface — `GeoTensor` shouldn't have to fake them.
-3. **Async is the only real gap.** Today's Protocols have no async surface. That's the actual problem.
+1. **Two names for every concept.** Every property would have a `GeoDataBase`-shaped name and a `_ReaderMeta`-shaped name.
+   We'd explain back-compat in every doc forever.
+2. **Most of `_ReaderMeta` is already in `GeoData` / `GeoDataBase`.** `crs`, `transform`, `shape`, `width`, `height` are in `GeoDataBase`; `bounds`, `res`, `dtype`, `fill_value_default` are in `GeoData` (with default implementations on top of the required three).
+   The only genuinely new fields proposed (`path_or_url`, `indexes`) are *reader-construction details* that leak file-backed-reader concerns onto an abstract surface — `GeoTensor` shouldn't have to fake them.
+3. **Async is the only real gap.** Today's Protocols have no async surface.
+   That's the actual problem.
 
-So: drop `_ReaderMeta` and `SyncReader` from the plan. Add `AsyncGeoData` (mirror of `GeoData` with `async` read methods). Document the `opener=` / `fs=` constructor widening for `RasterioReader` separately as an additive change.
+So: drop `_ReaderMeta` and `SyncReader` from the plan.
+Add `AsyncGeoData` (mirror of `GeoData` with `async` read methods).
+Document the `opener=` / `fs=` constructor widening for `RasterioReader` separately as an additive change.
 
-If we want a clean rename later (`GeoData` → `SyncReader`, `GeoDataBase` → `ReaderMeta`), that's a one-line deprecation alias upstream in `spaceml-org/georeader` proper — *not* a parallel layer in our plan. Out of scope for this issue.
+If we want a clean rename later (`GeoData` → `SyncReader`, `GeoDataBase` → `ReaderMeta`), that's a one-line deprecation alias upstream in `spaceml-org/georeader` proper — *not* a parallel layer in our plan.
+Out of scope for this issue.
 
 ---
 
 ## Primer for newcomers
 
-> **ELI5.** A Python Protocol is like a **job description**: if you can do the listed tasks, you're qualified — regardless of which company you trained at. Today, `GeoData` is the sync-reader job description. We're adding `AsyncGeoData` as the async-reader job description. `RasterioReader` keeps doing the sync job; `AsyncGeoTIFFReader` shows up to do the async one.
+> **ELI5.** A Python Protocol is like a **job description**: if you can do the listed tasks, you're qualified — regardless of which company you trained at.
+> Today, `GeoData` is the sync-reader job description.
+> We're adding `AsyncGeoData` as the async-reader job description.
+> `RasterioReader` keeps doing the sync job; `AsyncGeoTIFFReader` shows up to do the async one.
 
 ### Python Protocols (the typing kind)
 
-**What it is.** A `typing.Protocol` is a class that lists method signatures and attributes — and any other class with the same shape satisfies it, without needing to inherit. It's how Python expresses "if it walks like a duck and quacks like a duck, it's a duck" with type-checker support.
+**What it is.** A `typing.Protocol` is a class that lists method signatures and attributes — and any other class with the same shape satisfies it, without needing to inherit.
+It's how Python expresses "if it walks like a duck and quacks like a duck, it's a duck" with type-checker support.
 
-**How it works.** Define `class Foo(Protocol): def bar(self) -> int: ...`. Any class with a `bar() -> int` method is now a `Foo`, no `class MyClass(Foo)` declaration required. Add `@runtime_checkable` to make `isinstance(x, Foo)` work at runtime too. The static type-checker (`mypy` / `ty`) verifies conformance at the call site.
+**How it works.** Define `class Foo(Protocol): def bar(self) -> int: ...`.
+Any class with a `bar() -> int` method is now a `Foo`, no `class MyClass(Foo)` declaration required.
+Add `@runtime_checkable` to make `isinstance(x, Foo)` work at runtime too.
+The static type-checker (`mypy` / `ty`) verifies conformance at the call site.
 
-**What this means for us.** `RasterioReader` (sync, GDAL-backed) satisfies `GeoData` today. `AsyncGeoTIFFReader` (async, GDAL-free) satisfies `AsyncGeoData` after this issue. User code typed `def f(reader: AsyncGeoData)` accepts any conforming async reader — no isinstance checks, no shared base class. This is the seam that makes the two readers swappable per workload.
+**What this means for us.** `RasterioReader` (sync, GDAL-backed) satisfies `GeoData` today.
+`AsyncGeoTIFFReader` (async, GDAL-free) satisfies `AsyncGeoData` after this issue.
+User code typed `def f(reader: AsyncGeoData)` accepts any conforming async reader — no isinstance checks, no shared base class.
+This is the seam that makes the two readers swappable per workload.
 
 ```{mermaid}
 classDiagram
@@ -101,21 +123,29 @@ classDiagram
 
 ### The metadata-vs-read split
 
-**What it is.** Every reader has cheap metadata (CRS, transform, shape, dtype) and expensive bytes (the actual pixel data). The Protocol design splits these into two layers: `GeoDataBase` (metadata only) and `GeoData` / `AsyncGeoData` (`GeoDataBase` + read methods).
+**What it is.** Every reader has cheap metadata (CRS, transform, shape, dtype) and expensive bytes (the actual pixel data).
+The Protocol design splits these into two layers: `GeoDataBase` (metadata only) and `GeoData` / `AsyncGeoData` (`GeoDataBase` + read methods).
 
-**How it works.** A reader's `__init__` (or `await open(...)` for async) reads only the file header — enough to populate `crs` / `transform` / `shape` / etc. That's the `GeoDataBase` surface. Calling `read_from_window(window)` or `await read_window(window)` fetches actual pixel bytes; that's the `GeoData` / `AsyncGeoData` layer on top. The split exists because many functions (window math, bounds queries, intersection checks) only need metadata and shouldn't pay I/O cost.
+**How it works.** A reader's `__init__` (or `await open(...)` for async) reads only the file header — enough to populate `crs` / `transform` / `shape` / etc. That's the `GeoDataBase` surface.
+Calling `read_from_window(window)` or `await read_window(window)` fetches actual pixel bytes; that's the `GeoData` / `AsyncGeoData` layer on top.
+The split exists because many functions (window math, bounds queries, intersection checks) only need metadata and shouldn't pay I/O cost.
 
-**What this means for us.** `FakeGeoData` (an existing dataclass in `abstract_reader.py`) is a `GeoDataBase`-only object — it carries metadata for window calculations without owning data. Functions typed `data: GeoDataBase` are guaranteed I/O-free; functions typed `data: GeoData` may issue sync reads; functions typed `data: AsyncGeoData` may issue async reads.
+**What this means for us.** `FakeGeoData` (an existing dataclass in `abstract_reader.py`) is a `GeoDataBase`-only object — it carries metadata for window calculations without owning data.
+Functions typed `data: GeoDataBase` are guaranteed I/O-free; functions typed `data: GeoData` may issue sync reads; functions typed `data: AsyncGeoData` may issue async reads.
 
 ### The three bytes paths in `RasterioReader`
 
-**What it is.** `RasterioReader` wraps `rasterio.open(...)`, which delegates to GDAL. Underneath GDAL is some library that fetches the actual bytes. The optional widening exposes three options.
+**What it is.** `RasterioReader` wraps `rasterio.open(...)`, which delegates to GDAL. Underneath GDAL is some library that fetches the actual bytes.
+The optional widening exposes three options.
 
 **How it works.** Three constructor knobs:
 
-- **`opener=None`, `fs=None`** (default): GDAL VSI uses libcurl in C. Fastest sync option, no Python in the byte-fetching loop. Works for `s3://`, `gs://`, `az://`, `https://`.
-- **`fs=fsspec_filesystem`**: GDAL calls back into a Python file-like object via fsspec for each byte range. Slower (Python ↔ C trip per range) but covers backends GDAL doesn't speak natively (FTP, SFTP, GitHub).
-- **`opener=callable`**: same shape as fsspec but with a user-supplied callback. Lets advanced users wire in custom HTTP clients.
+- **`opener=None`, `fs=None`** (default): GDAL VSI uses libcurl in C. Fastest sync option, no Python in the byte-fetching loop.
+  Works for `s3://`, `gs://`, `az://`, `https://`.
+- **`fs=fsspec_filesystem`**: GDAL calls back into a Python file-like object via fsspec for each byte range.
+  Slower (Python ↔ C trip per range) but covers backends GDAL doesn't speak natively (FTP, SFTP, GitHub).
+- **`opener=callable`**: same shape as fsspec but with a user-supplied callback.
+  Lets advanced users wire in custom HTTP clients.
 
 A small helper, `_resolve_open_kwargs`, is the only Python code that knows which path is active.
 
@@ -131,7 +161,9 @@ flowchart TD
     Custom --> Cloud
 ```
 
-**What this means for us.** Most users land on the default and never think about it. Users who need a niche backend (custom auth, MinIO endpoint, GitHub-hosted fixtures) flip `fs=` and keep the rest of their pipeline unchanged. Users who want maximum cloud throughput skip `RasterioReader` entirely and use [`AsyncGeoTIFFReader`](reader_async_geotiff.md), which routes through `obstore` (no GDAL).
+**What this means for us.** Most users land on the default and never think about it.
+Users who need a niche backend (custom auth, MinIO endpoint, GitHub-hosted fixtures) flip `fs=` and keep the rest of their pipeline unchanged.
+Users who want maximum cloud throughput skip `RasterioReader` entirely and use [`AsyncGeoTIFFReader`](reader_async_geotiff.md), which routes through `obstore` (no GDAL).
 
 ---
 
@@ -139,21 +171,29 @@ flowchart TD
 
 ### Required
 
-1. **`AsyncGeoData` Protocol** — added to `georeader/abstract_reader.py`. Mirrors `GeoData`'s sync surface with `async` read methods. ~30 LOC.
-2. **`GeoTensor` Protocol conformance check** — `GeoTensor` already satisfies `GeoData` morally; add a static-type-check confirming this so the type-checker agrees. (No code change to `GeoTensor` expected.)
+1. **`AsyncGeoData` Protocol** — added to `georeader/abstract_reader.py`.
+   Mirrors `GeoData`'s sync surface with `async` read methods. ~30 LOC.
+2. **`GeoTensor` Protocol conformance check** — `GeoTensor` already satisfies `GeoData` morally; add a static-type-check confirming this so the type-checker agrees.
+   (No code change to `GeoTensor` expected.)
 3. **Tutorial update** — [Ch. 2](../../georeader_tutorial/02_abstract_reader.md) gains a small section describing `AsyncGeoData` alongside the existing `GeoData` / `GeoDataBase` writeup.
 
 ### Optional (additive — bundle if convenient, otherwise defer)
 
-4. **`RasterioReader` constructor widening** — add `opener=`, `fs=`, `rio_open_kwargs=` keyword-only knobs. No breaking changes; defaults reproduce today's behaviour. See §"`RasterioReader` widening" below.
+4. **`RasterioReader` constructor widening** — add `opener=`, `fs=`, `rio_open_kwargs=` keyword-only knobs.
+   No breaking changes; defaults reproduce today's behaviour.
+   See §"`RasterioReader` widening" below.
 5. **Tutorial update for the bytes-path triage** — [Ch. 3](../../georeader_tutorial/03_rasterio_reader.md) gains a section on the three bytes paths if (4) lands.
 
 What this issue does **not** ship:
 
-- A `_ReaderMeta` Protocol. Today's `GeoDataBase` already plays this role.
-- A `SyncReader` Protocol. Today's `GeoData` already plays this role.
-- A rename of `GeoData` / `GeoDataBase`. If we want one, do it upstream in `spaceml-org/georeader` proper as a separate PR with deprecation aliases — not as a parallel layer in our plan.
-- New `path_or_url` / `indexes` fields on the abstract surface. Those are reader-construction details; they live on the concrete reader classes only.
+- A `_ReaderMeta` Protocol.
+  Today's `GeoDataBase` already plays this role.
+- A `SyncReader` Protocol.
+  Today's `GeoData` already plays this role.
+- A rename of `GeoData` / `GeoDataBase`.
+  If we want one, do it upstream in `spaceml-org/georeader` proper as a separate PR with deprecation aliases — not as a parallel layer in our plan.
+- New `path_or_url` / `indexes` fields on the abstract surface.
+  Those are reader-construction details; they live on the concrete reader classes only.
 
 ---
 
@@ -233,9 +273,13 @@ class AsyncGeoData(GeoDataBase, Protocol):
         return window_utils.polygon_to_crs(pol, self.crs, crs)
 ```
 
-Note that `AsyncGeoData.values` is **not** present (unlike `GeoData.values`, which materialises sync via `self.load()`). An async-equivalent would have to be a coroutine, but properties can't be async. Callers that want the array call `await reader.load()` explicitly. Documenting this in the Protocol docstring is enough.
+Note that `AsyncGeoData.values` is **not** present (unlike `GeoData.values`, which materialises sync via `self.load()`).
+An async-equivalent would have to be a coroutine, but properties can't be async.
+Callers that want the array call `await reader.load()` explicitly.
+Documenting this in the Protocol docstring is enough.
 
-The `footprint`, `res`, `bounds` properties are duplicated from `GeoData` because Python Protocols don't compose default implementations cleanly through inheritance. Concrete readers can override; the defaults match `GeoData`'s behaviour.
+The `footprint`, `res`, `bounds` properties are duplicated from `GeoData` because Python Protocols don't compose default implementations cleanly through inheritance.
+Concrete readers can override; the defaults match `GeoData`'s behaviour.
 
 ---
 
@@ -249,7 +293,8 @@ RasterioReader(paths, allow_different_shape=False, window_focus=None,
                overview_level=None, check=True, rio_env_options=None)
 ```
 
-It stays. New keyword-only knobs are added:
+It stays.
+New keyword-only knobs are added:
 
 ```python
 class RasterioReader(GeoData):
@@ -294,7 +339,9 @@ class RasterioReader(GeoData):
 
 ### The three bytes paths
 
-The `opener=` / `fs=` knobs route bytes through one of three paths: GDAL VSI (default, fastest), fsspec (for niche backends), or a custom obstore-aware callback. The diagram and per-path comparison table live in [`geostack.md` §"What's actually inside `RasterioReader`"](../geostack.md#whats-actually-inside-rasterioreader). `_resolve_open_kwargs` (above) is the only Python code that knows which path is active; after it returns, GDAL takes over.
+The `opener=` / `fs=` knobs route bytes through one of three paths: GDAL VSI (default, fastest), fsspec (for niche backends), or a custom obstore-aware callback.
+The diagram and per-path comparison table live in [`geostack.md` §"What's actually inside `RasterioReader`"](../geostack.md#whats-actually-inside-rasterioreader).
+`_resolve_open_kwargs` (above) is the only Python code that knows which path is active; after it returns, GDAL takes over.
 
 ### Usage examples
 
@@ -322,7 +369,9 @@ reader = await AsyncGeoTIFFReader.open("s3://bucket/scene.tif")
 
 ### Credential handling across the three paths
 
-The widening doesn't change the existing GDAL-VSI credential pattern. It does add two paths where credentials can live in user objects rather than process env vars — useful for tests, multi-account isolation in one process, and refreshable tokens. Where credentials live in each path:
+The widening doesn't change the existing GDAL-VSI credential pattern.
+It does add two paths where credentials can live in user objects rather than process env vars — useful for tests, multi-account isolation in one process, and refreshable tokens.
+Where credentials live in each path:
 
 | Path | Credential locus |
 |---|---|
@@ -330,7 +379,9 @@ The widening doesn't change the existing GDAL-VSI credential pattern. It does ad
 | **fsspec** (`fs=fsspec_fs`) | The `fs` object's construction — `fsspec.filesystem("s3", key=..., secret=...)`. Per-reader, no env vars needed. Multi-account isolation comes free: two readers with two `fs` instances see two credential sets. |
 | **opener=callable** | Whatever the callable closes over. Most flexible, most user-managed; this is where refreshable-token implementations would live until the package ships a typed credential surface. |
 
-A typed `Credential` Protocol that unifies these three paths is proposed separately in [`plans/types/credentials.md`](../types/credentials.md). The wiring on `RasterioReader` (`credential=` kwarg, refresh-on-401, auto-rewrite for SAS fallback) is in [`reader_rasterio.md`](reader_rasterio.md). Both designs are downstream of this issue — Issue 1 just needs to not paint into a corner that prevents them.
+A typed `Credential` Protocol that unifies these three paths is proposed separately in [`plans/types/credentials.md`](../types/credentials.md).
+The wiring on `RasterioReader` (`credential=` kwarg, refresh-on-401, auto-rewrite for SAS fallback) is in [`reader_rasterio.md`](reader_rasterio.md).
+Both designs are downstream of this issue — Issue 1 just needs to not paint into a corner that prevents them.
 
 ---
 
@@ -343,7 +394,8 @@ A typed `Credential` Protocol that unifies these three paths is proposed separat
 - `width`, `height` — as derived properties.
 - `read_from_window`, `load` — already implemented (Tutorial Ch. 1 §10).
 
-Declaring `GeoTensor` as `GeoData`-conformant is a typing-only change. May need a small alignment if the type-checker objects to one signature; otherwise no code change.
+Declaring `GeoTensor` as `GeoData`-conformant is a typing-only change.
+May need a small alignment if the type-checker objects to one signature; otherwise no code change.
 
 ---
 
@@ -364,16 +416,25 @@ In addition to the [parent design's open questions](README.md#open-questions), t
 
 ### 1. Should `AsyncGeoData` add a `values_async()` method?
 
-`GeoData.values` is a sync property that materialises via `self.load()`. Properties can't be async, so the natural async equivalent would be `await reader.values_async()`. Tentative: don't add it — `await reader.load()` is fine and `.values` on the *returned* `GeoTensor` works the way users expect.
+`GeoData.values` is a sync property that materialises via `self.load()`.
+Properties can't be async, so the natural async equivalent would be `await reader.values_async()`.
+Tentative: don't add it — `await reader.load()` is fine and `.values` on the *returned* `GeoTensor` works the way users expect.
 
 ### 2. Upstream rename of `GeoData` / `GeoDataBase`?
 
-If we wanted `GeoData` → `SyncReader` and `GeoDataBase` → `ReaderMeta` for naming consistency with `AsyncReader`-shaped names, that should happen in `spaceml-org/georeader` proper as a one-line deprecation alias, not as a parallel layer here. Out of scope for this issue. Flagging because the original design tried to do it, and we should be intentional about *not* doing it here.
+If we wanted `GeoData` → `SyncReader` and `GeoDataBase` → `ReaderMeta` for naming consistency with `AsyncReader`-shaped names, that should happen in `spaceml-org/georeader` proper as a one-line deprecation alias, not as a parallel layer here.
+Out of scope for this issue.
+Flagging because the original design tried to do it, and we should be intentional about *not* doing it here.
 
 ### 3. Are `path_or_url` / `indexes` ever lifted onto a Protocol?
 
-No. They're reader-construction details. `GeoTensor` shouldn't have to fake them. `FakeGeoData` shouldn't have to declare them. They stay on the concrete reader classes only.
+No. They're reader-construction details.
+`GeoTensor` shouldn't have to fake them.
+`FakeGeoData` shouldn't have to declare them.
+They stay on the concrete reader classes only.
 
 ### 4. Should `AsyncGeoData` be `@runtime_checkable`?
 
-`GeoDataBase` and `GeoData` are not currently runtime-checkable (see [Tutorial Ch. 2 §8](../../georeader_tutorial/02_abstract_reader.md)). Tentative: keep `AsyncGeoData` non-runtime-checkable too for symmetry. If we ever flip them, do it together upstream.
+`GeoDataBase` and `GeoData` are not currently runtime-checkable (see [Tutorial Ch. 2 §8](../../georeader_tutorial/02_abstract_reader.md)).
+Tentative: keep `AsyncGeoData` non-runtime-checkable too for symmetry.
+If we ever flip them, do it together upstream.

--- a/projects/geotoolz/plans/georeader/reader_rasterio.md
+++ b/projects/geotoolz/plans/georeader/reader_rasterio.md
@@ -24,9 +24,11 @@ keywords: design, georeader, rasterio, credentials
 
 ## Why this issue exists
 
-[`reader_protocol.md`](reader_protocol.md) optionally widens `RasterioReader`'s constructor with `opener=` / `fs=` / `rio_open_kwargs=` knobs (additive — `RasterioReader` already conforms to `GeoData`). That widening is about *bytes-path triage*; it doesn't try to fix the awkward parts of the today-API.
+[`reader_protocol.md`](reader_protocol.md) optionally widens `RasterioReader`'s constructor with `opener=` / `fs=` / `rio_open_kwargs=` knobs (additive — `RasterioReader` already conforms to `GeoData`).
+That widening is about *bytes-path triage*; it doesn't try to fix the awkward parts of the today-API.
 
-This document is about the awkward parts. It builds on:
+This document is about the awkward parts.
+It builds on:
 
 - The credential-plumbing snippets in [Tutorial Ch. 3 §9](../../georeader_tutorial/03_rasterio_reader.md) — env-var-first auth, manual managed-identity token fetching, HTTPS-embedded-SAS fallback.
 - The typed `Credential` Protocol proposed in [`types/credentials.md`](../types/credentials.md) — wraps the env-var setup and adds refresh.
@@ -38,23 +40,34 @@ Four concrete proposals, each scoped to a single PR. None are blocking on the ot
 
 ## Primer for newcomers
 
-> **ELI5.** Today, cloud credentials are like a **sticky note on the office fridge** — anyone in the room can read them, and there's only one note. The proposed change is each person carrying their own credential card, so two people working on different cloud accounts don't keep replacing each other's sticky notes.
+> **ELI5.** Today, cloud credentials are like a **sticky note on the office fridge** — anyone in the room can read them, and there's only one note.
+> The proposed change is each person carrying their own credential card, so two people working on different cloud accounts don't keep replacing each other's sticky notes.
 
 ### Env-var-based auth (the GDAL pattern)
 
-**What it is.** GDAL — the C library underneath `rasterio` — reads cloud credentials from process environment variables: `AWS_ACCESS_KEY_ID`, `GOOGLE_APPLICATION_CREDENTIALS`, `AZURE_STORAGE_*`. There's no per-call credential argument; GDAL just looks at `os.environ` when it opens a file.
+**What it is.** GDAL — the C library underneath `rasterio` — reads cloud credentials from process environment variables: `AWS_ACCESS_KEY_ID`, `GOOGLE_APPLICATION_CREDENTIALS`, `AZURE_STORAGE_*`.
+There's no per-call credential argument; GDAL just looks at `os.environ` when it opens a file.
 
-**How it works.** Your app sets the env vars once at startup (`os.environ['AZURE_STORAGE_SAS_TOKEN'] = '...'`). Every subsequent `RasterioReader(...)` constructor implicitly inherits those values via `rasterio.Env(**rio_env_options)`, which copies the GDAL env into a context-managed scope. The credentials flow through the C layer; Python never touches them per-call.
+**How it works.** Your app sets the env vars once at startup (`os.environ['AZURE_STORAGE_SAS_TOKEN'] = '...'`).
+Every subsequent `RasterioReader(...)` constructor implicitly inherits those values via `rasterio.Env(**rio_env_options)`, which copies the GDAL env into a context-managed scope.
+The credentials flow through the C layer; Python never touches them per-call.
 
-**What this means for us.** It's *easy* — set vars once, ignore credentials in pipeline code. But it's *global* — two readers in one process can't use different credentials without clobbering each other. The proposed `credential=` kwarg on `RasterioReader` (Proposal 1) merges credentials into `rio_env_options` *per call*, giving per-reader isolation without abandoning the GDAL contract.
+**What this means for us.** It's *easy* — set vars once, ignore credentials in pipeline code.
+But it's *global* — two readers in one process can't use different credentials without clobbering each other.
+The proposed `credential=` kwarg on `RasterioReader` (Proposal 1) merges credentials into `rio_env_options` *per call*, giving per-reader isolation without abandoning the GDAL contract.
 
 ### Managed identity and refreshable tokens
 
-**What it is.** When code runs inside cloud compute (Azure VM, AKS pod, AWS EC2 with an IAM role), the platform mints a short-lived bearer token via a metadata-service endpoint instead of using static credentials. Common in production; basically never in laptops.
+**What it is.** When code runs inside cloud compute (Azure VM, AKS pod, AWS EC2 with an IAM role), the platform mints a short-lived bearer token via a metadata-service endpoint instead of using static credentials.
+Common in production; basically never in laptops.
 
-**How it works.** Code calls `azure.identity.DefaultAzureCredential().get_token(...)` (or `boto3.Session().get_credentials()` for AWS) — under the hood that hits the cloud's IMDS / IAM endpoint and returns a JWT bearer token. The token typically expires in 1 hour. GDAL accepts the token as `AZURE_STORAGE_ACCESS_TOKEN` (or for AWS, the credential gets converted to standard `AWS_*` env vars).
+**How it works.** Code calls `azure.identity.DefaultAzureCredential().get_token(...)` (or `boto3.Session().get_credentials()` for AWS) — under the hood that hits the cloud's IMDS / IAM endpoint and returns a JWT bearer token.
+The token typically expires in 1 hour.
+GDAL accepts the token as `AZURE_STORAGE_ACCESS_TOKEN` (or for AWS, the credential gets converted to standard `AWS_*` env vars).
 
-**What this means for us.** Long-running pipelines (overnight batches, async services) silently start failing at the 1-hour mark with 401 Unauthorized. Today's pattern fetches the token once at startup and never refreshes. Proposal 2 (refresh-aware tokens) makes the typed `Credential` know how to refresh and the reader retry once on 401 — turning a silent failure into transparent recovery.
+**What this means for us.** Long-running pipelines (overnight batches, async services) silently start failing at the 1-hour mark with 401 Unauthorized.
+Today's pattern fetches the token once at startup and never refreshes.
+Proposal 2 (refresh-aware tokens) makes the typed `Credential` know how to refresh and the reader retry once on 401 — turning a silent failure into transparent recovery.
 
 ```{mermaid}
 sequenceDiagram
@@ -84,9 +97,13 @@ sequenceDiagram
 
 **What it is.** A single process needs to read from two different cloud accounts at the same time — e.g., source data in one S3 bucket, destination in another with different credentials.
 
-**How it works (today, awkward).** Set env vars for account A → construct reader A → swap env vars for account B → construct reader B. Then if you ever call `reader_a.read_window()` after the swap, you read with account B's credentials. The HTTPS-embedded-SAS workaround is one fix (the credential travels in the URL, not the env), but it only works for SAS tokens.
+**How it works (today, awkward).** Set env vars for account A → construct reader A → swap env vars for account B → construct reader B. Then if you ever call `reader_a.read_window()` after the swap, you read with account B's credentials.
+The HTTPS-embedded-SAS workaround is one fix (the credential travels in the URL, not the env), but it only works for SAS tokens.
 
-**What this means for us.** Proposal 1 fixes this directly: `credential=` is per-reader, applied inside the `rasterio.Env(...)` scope of just that reader. Two readers with two `Credential` instances see two different credential sets. No global env-var clobbering. (Caveat: GDAL's underlying HTTP client uses libcurl, which has process-global SSL state; the isolation is at the credential layer, not the connection-pool layer.)
+**What this means for us.** Proposal 1 fixes this directly: `credential=` is per-reader, applied inside the `rasterio.Env(...)` scope of just that reader.
+Two readers with two `Credential` instances see two different credential sets.
+No global env-var clobbering.
+(Caveat: GDAL's underlying HTTP client uses libcurl, which has process-global SSL state; the isolation is at the credential layer, not the connection-pool layer.)
 
 ```{mermaid}
 flowchart TD
@@ -106,7 +123,8 @@ flowchart TD
 
 ### Today
 
-Credentials are global process state. Two `RasterioReader` instances reading from two Azure accounts in one process collide at the env-var layer:
+Credentials are global process state.
+Two `RasterioReader` instances reading from two Azure accounts in one process collide at the env-var layer:
 
 ```python
 # Account A
@@ -126,7 +144,8 @@ The HTTPS-embedded-SAS workaround is the standard answer — but it requires the
 
 ### Proposed
 
-`RasterioReader` accepts a `credential=` kwarg (typed against the [`Credential`](../types/credentials.md) Protocol). The credential's env vars are merged into `rio_env_options` *per call*, not into `os.environ` globally:
+`RasterioReader` accepts a `credential=` kwarg (typed against the [`Credential`](../types/credentials.md) Protocol).
+The credential's env vars are merged into `rio_env_options` *per call*, not into `os.environ` globally:
 
 ```python
 from georeader.credentials import AzureSASCredential
@@ -162,12 +181,14 @@ class RasterioReader(GeoData):
         return get_rio_options_path(opts, path)
 ```
 
-The credential's `apply(env)` returns the env dict with credential keys merged. `rasterio.Env(**opts)` then sees the per-reader credential without touching global `os.environ`.
+The credential's `apply(env)` returns the env dict with credential keys merged.
+`rasterio.Env(**opts)` then sees the per-reader credential without touching global `os.environ`.
 
 ### What this preserves
 
 - **The today-pattern still works.** Construct `RasterioReader` without `credential=`, and the existing env-var inheritance from `os.environ` is unchanged.
-- **The fsspec / opener paths are unaffected.** Those paths carry their own credential locus (the `fs` object's construction or the opener's closure). When both `credential=` and `fs=` are given, the `credential=` is ignored with a warning.
+- **The fsspec / opener paths are unaffected.** Those paths carry their own credential locus (the `fs` object's construction or the opener's closure).
+  When both `credential=` and `fs=` are given, the `credential=` is ignored with a warning.
 
 ### Acceptance criteria
 
@@ -181,7 +202,9 @@ The credential's `apply(env)` returns the env dict with credential keys merged. 
 
 ### Today
 
-The managed-identity snippet calls `credential.get_token(...).token` once at startup and writes the result to `AZURE_STORAGE_ACCESS_TOKEN`. Tokens typically expire in 1 hour. Long-running pipelines silently start failing with 401 once the token expires:
+The managed-identity snippet calls `credential.get_token(...).token` once at startup and writes the result to `AZURE_STORAGE_ACCESS_TOKEN`.
+Tokens typically expire in 1 hour.
+Long-running pipelines silently start failing with 401 once the token expires:
 
 ```python
 # At startup
@@ -194,7 +217,8 @@ gt = RasterioReader('az://...').read_window(window)
 # rasterio.RasterioIOError: HTTP 401 Unauthorized
 ```
 
-The user's only recourse today: catch the error, refresh the token, set the env var, retry. Every project does it differently.
+The user's only recourse today: catch the error, refresh the token, set the env var, retry.
+Every project does it differently.
 
 ### Proposed
 
@@ -215,7 +239,8 @@ The `Credential` Protocol's `refresh()` method is implemented as a no-op for sta
 
 The refresh policy:
 
-- **One refresh + one retry on 401.** No backoff (refresh is fast). Second 401 propagates.
+- **One refresh + one retry on 401.** No backoff (refresh is fast).
+  Second 401 propagates.
 - **Auto-refresh on `apply()` if token expired.** Avoids the 401 round-trip when the credential knows its TTL. The `AzureManagedIdentityCredential` snippet in `types/credentials.md` does this with a 60-second safety margin.
 - **No refresh for non-401 errors.** A 403 (permission denied) or 404 (not found) is not a credential issue and should propagate immediately.
 
@@ -237,7 +262,8 @@ The refresh policy:
 
 ### Today
 
-GDAL sometimes ignores `AZURE_STORAGE_SAS_TOKEN` for paths that don't go through the canonical `az://` form — typically `https://account.blob.core.windows.net/container/blob` paths fail with 401 even though the SAS token is set. The workaround in `mars_data_ops/utils/filesystem.py:336-358`:
+GDAL sometimes ignores `AZURE_STORAGE_SAS_TOKEN` for paths that don't go through the canonical `az://` form — typically `https://account.blob.core.windows.net/container/blob` paths fail with 401 even though the SAS token is set.
+The workaround in `mars_data_ops/utils/filesystem.py:336-358`:
 
 ```python
 def pathasroothttps(self, path: str) -> str:
@@ -248,7 +274,8 @@ def pathasroothttps(self, path: str) -> str:
     return path_https
 ```
 
-User has to know to call `pathasroothttps(path)` before constructing the reader. Easy to forget; debugging the resulting 401 is annoying.
+User has to know to call `pathasroothttps(path)` before constructing the reader.
+Easy to forget; debugging the resulting 401 is annoying.
 
 ### Proposed
 
@@ -313,7 +340,10 @@ RasterioReader(
 )
 ```
 
-Discoverability is poor. The env-var names aren't memorable. Casing matters. String-typed integer values are fragile.
+Discoverability is poor.
+The env-var names aren't memorable.
+Casing matters.
+String-typed integer values are fragile.
 
 ### Proposed
 
@@ -361,7 +391,8 @@ Initial set of kwargs (open for discussion):
 
 Out of scope for this design (each is its own potential follow-up):
 
-- **Async retry / async credentials.** Async support lives in [`reader_async_geotiff.md`](reader_async_geotiff.md). Whether `AsyncGeoData`-conformant readers accept the same `credential=` Protocol is a question for that design.
+- **Async retry / async credentials.** Async support lives in [`reader_async_geotiff.md`](reader_async_geotiff.md).
+  Whether `AsyncGeoData`-conformant readers accept the same `credential=` Protocol is a question for that design.
 - **Per-reader cache isolation.** Today's `GDAL_CACHEMAX` is process-global. Per-reader caches would require a much deeper change (custom block manager).
 - **Connection pool configuration.** GDAL's HTTP client doesn't expose pool tuning to PROJ-aware code; if needed, the answer is to switch to `AsyncGeoTIFFReader`, which uses obstore directly.
 - **Vault / secrets-manager integration.** That's the user's responsibility upstream of constructing the `Credential`.
@@ -377,7 +408,8 @@ Out of scope for this design (each is its own potential follow-up):
 | Proposal 3 (SAS path rewrite) | Proposal 1. |
 | Proposal 4 (typed GDAL kwargs) | [`reader_protocol.md`](reader_protocol.md). Independent of Proposals 1–3. |
 
-Proposal 4 can ship first since it's purely about ergonomics. Proposals 1–3 are coupled and should land together (or at least 1 first, then 2 and 3 in parallel).
+Proposal 4 can ship first since it's purely about ergonomics.
+Proposals 1–3 are coupled and should land together (or at least 1 first, then 2 and 3 in parallel).
 
 ---
 
@@ -385,18 +417,27 @@ Proposal 4 can ship first since it's purely about ergonomics. Proposals 1–3 ar
 
 ### 1. Should `credential=` be on `RasterioReader` only, or on the abstract `GeoData` / `AsyncGeoData` Protocols?
 
-If we want `AsyncGeoTIFFReader` (or any future reader) to accept the same kwarg, it has to be in the Protocol. But those readers have their own credential locus (the `obspec.AsyncStore` they're constructed with), so adding `credential=` to the Protocol creates a question: which path wins when both `credential=` and a credential-bearing store are given?
+If we want `AsyncGeoTIFFReader` (or any future reader) to accept the same kwarg, it has to be in the Protocol.
+But those readers have their own credential locus (the `obspec.AsyncStore` they're constructed with), so adding `credential=` to the Protocol creates a question: which path wins when both `credential=` and a credential-bearing store are given?
 
-**Tentative pick:** keep `credential=` on `RasterioReader` only for now. Other readers route credentials through `Credential.to_obstore_*_store(...)` and pass the resulting store via `store=`. Promote to the Protocol later if the duplication becomes painful.
+**Tentative pick:** keep `credential=` on `RasterioReader` only for now.
+Other readers route credentials through `Credential.to_obstore_*_store(...)` and pass the resulting store via `store=`.
+Promote to the Protocol later if the duplication becomes painful.
 
 ### 2. Should the SAS path-rewrite be opt-in (kwarg) or always-on?
 
-Always-on with `AzureSASCredential` is the proposal here. Opt-out via `auto_rewrite_paths=False` if false-positive rewrites turn out to be a problem in practice. **Tentative pick: always-on.**
+Always-on with `AzureSASCredential` is the proposal here.
+Opt-out via `auto_rewrite_paths=False` if false-positive rewrites turn out to be a problem in practice.
+**Tentative pick: always-on.**
 
 ### 3. Should typed kwargs (Proposal 4) include sensor-specific knobs?
 
-E.g., `read_subdatasets=True` for HDF5 / NetCDF. These are GDAL-driver-specific and the kwargs proliferate quickly. **Tentative pick: keep typed kwargs to the http- and cache-tier knobs.** Driver-specific options stay in `rio_open_kwargs=` per the existing pattern.
+E.g., `read_subdatasets=True` for HDF5 / NetCDF. These are GDAL-driver-specific and the kwargs proliferate quickly.
+**Tentative pick: keep typed kwargs to the http- and cache-tier knobs.** Driver-specific options stay in `rio_open_kwargs=` per the existing pattern.
 
 ### 4. Multi-credential single-reader
 
-A reader pointed at two paths in two clouds (`stack=True` with mixed S3 and Azure) doesn't have a clean answer in this design — `credential=` is a single object. Options: reject mixed-cloud stacks at construction time, or accept `credential=Sequence[Credential]` aligned to `paths`. **Tentative pick: reject at construction time** (with a clear error). Mixed-cloud is rare enough that the user can build two readers and stack themselves.
+A reader pointed at two paths in two clouds (`stack=True` with mixed S3 and Azure) doesn't have a clean answer in this design — `credential=` is a single object.
+Options: reject mixed-cloud stacks at construction time, or accept `credential=Sequence[Credential]` aligned to `paths`.
+**Tentative pick: reject at construction time** (with a clear error).
+Mixed-cloud is rare enough that the user can build two readers and stack themselves.

--- a/projects/geotoolz/plans/geostack.md
+++ b/projects/geotoolz/plans/geostack.md
@@ -15,13 +15,13 @@ license: CC-BY-4.0
 keywords: reference, ecosystem, stack
 ---
 
-> **Scope:** a rundown of `obstore`, `RasterioReader`, `async-geotiff`, `georeader`, `geotoolz`, `titiler`, and `lonboard` — what each is for, how they depend on one another, and which combinations match common workflows. *(The `lazycogs` library ships an `xarray.DataArray` carrier and is part of the dense / cube stack; see [`../geostack_notes.md`](../geostack_notes.md) Stack B for that discussion.)*
->
-> **Status:** reference document, not a design proposal. Companion to the per-design documents in [`georeader/`](georeader/), [`geotoolz/`](geotoolz/), [`geodatabase/`](geodatabase/), [`readers/`](readers/), and [`types/`](types/) — read this first to orient on the ecosystem, then dive into a specific design when you want the full spec.
+> **Scope:** a rundown of `obstore`, `RasterioReader`, `async-geotiff`, `georeader`, `geotoolz`, `titiler`, and `lonboard` — what each is for, how they depend on one another, and which combinations match common workflows.
+> *(The `lazycogs` library ships an `xarray.DataArray` carrier and is part of the dense / cube stack; see [`../geostack_notes.md`](../geostack_notes.md) Stack B for that discussion.)*  **Status:** reference document, not a design proposal. Companion to the per-design documents in [`georeader/`](georeader/), [`geotoolz/`](geotoolz/), [`geodatabase/`](geodatabase/), [`readers/`](readers/), and [`types/`](types/) — read this first to orient on the ecosystem, then dive into a specific design when you want the full spec.
 
 ## Where each topic is fully specified
 
-This file owns the visual ecosystem map (the layered diagram, the strategy-comparison tables, the bytes-paths triage diagram, the end-to-end flows). For the deep design of any one tool, follow the pointer:
+This file owns the visual ecosystem map (the layered diagram, the strategy-comparison tables, the bytes-paths triage diagram, the end-to-end flows).
+For the deep design of any one tool, follow the pointer:
 
 | Topic | Full design |
 |---|---|
@@ -80,9 +80,16 @@ There's a clean six-layer stack across this set, much of which is shipped by Dev
                          └─────────────────┘
 ```
 
-Bottom-up dependency direction. Anything above can call anything below; nothing reaches up. The substrate box (`georeader`) carries only the *types* — `GeoTensor`, `GeoSlice`, `GeoData`, `GeoCatalog`. The reader implementations sit one layer down. `RasterioReader` is in `georeader`'s own source tree but functionally peers with `async-geotiff`. (georeader also ships sensor-specific readers — `S2_SAFE_reader`, EMIT, EnMAP, etc. — those live alongside `RasterioReader` and produce `GeoTensor` the same way.)
+Bottom-up dependency direction.
+Anything above can call anything below; nothing reaches up.
+The substrate box (`georeader`) carries only the *types* — `GeoTensor`, `GeoSlice`, `GeoData`, `GeoCatalog`.
+The reader implementations sit one layer down.
+`RasterioReader` is in `georeader`'s own source tree but functionally peers with `async-geotiff`.
+(georeader also ships sensor-specific readers — `S2_SAFE_reader`, EMIT, EnMAP, etc. — those live alongside `RasterioReader` and produce `GeoTensor` the same way.)
 
-> **Note on `RasterioReader`'s bytes path.** The diagram shows `RasterioReader` going through GDAL VSI by default. That's the common path, but `RasterioReader` can also delegate to `obstore` or `fsspec` via rasterio's `opener=` parameter — so it isn't strictly bound to the GDAL/VSI lane. See [§ "What's actually inside `RasterioReader`"](#whats-actually-inside-rasterioreader) below.
+> **Note on `RasterioReader`'s bytes path.** The diagram shows `RasterioReader` going through GDAL VSI by default.
+> That's the common path, but `RasterioReader` can also delegate to `obstore` or `fsspec` via rasterio's `opener=` parameter — so it isn't strictly bound to the GDAL/VSI lane.
+> See [§ "What's actually inside `RasterioReader`"](#whats-actually-inside-rasterioreader) below.
 
 ---
 
@@ -90,9 +97,11 @@ Bottom-up dependency direction. Anything above can call anything below; nothing 
 
 ### 1. `obstore` (transport)
 
-**What it is.** Python bindings to the Rust `object_store` crate. A unified async API for S3, GCS, Azure Blob, and local filesystems — plus HTTP. Made by DevSeed.
+**What it is.** Python bindings to the Rust `object_store` crate.
+A unified async API for S3, GCS, Azure Blob, and local filesystems — plus HTTP. Made by DevSeed.
 
-**Why it matters.** It's roughly 10× faster than `fsspec` + `aiobotocore` for parallel cloud reads, because the Rust runtime handles HTTP/2, connection pooling, and range coalescing properly. Drop-in for anywhere you'd reach for `s3fs` or `fsspec`.
+**Why it matters.** It's roughly 10× faster than `fsspec` + `aiobotocore` for parallel cloud reads, because the Rust runtime handles HTTP/2, connection pooling, and range coalescing properly.
+Drop-in for anywhere you'd reach for `s3fs` or `fsspec`.
 
 **Deps.** `pyo3` runtime; nothing in Python land.
 
@@ -102,17 +111,23 @@ Bottom-up dependency direction. Anything above can call anything below; nothing 
 - Range-request-driven COG reads (the layer above this one).
 - Catalog hosting — when `georeader.GeoCatalog` opens a remote `.parquet`, `obstore` is the path your bytes travel.
 
-**Talks to.** Everything above it that does cloud I/O. `async-geotiff` builds on it directly. `georeader.RasterioReader` historically uses GDAL's VSI for cloud, but moving its remote path onto `obstore` is on the table.
+**Talks to.** Everything above it that does cloud I/O. `async-geotiff` builds on it directly.
+`georeader.RasterioReader` historically uses GDAL's VSI for cloud, but moving its remote path onto `obstore` is on the table.
 
 ### 2. `RasterioReader` (file reading — sync, in `georeader`)
 
-**What it is.** The default sync reader in `georeader`. Wraps `rasterio.open` with lazy-but-windowed semantics. Universal driver coverage (every GDAL format), GDAL/VSI for cloud paths by default, fresh-per-read for process-safety. The right answer ~90% of the time.
+**What it is.** The default sync reader in `georeader`.
+Wraps `rasterio.open` with lazy-but-windowed semantics.
+Universal driver coverage (every GDAL format), GDAL/VSI for cloud paths by default, fresh-per-read for process-safety.
+The right answer ~90% of the time.
 
 **See:** [`georeader/reader_protocol.md`](georeader/reader_protocol.md) for the full design (Protocol surface, `opener=`/`fs=` knobs, three-bytes-paths triage); [Tutorial Ch. 3](../georeader_tutorial/03_rasterio_reader.md) for the current implementation.
 
 ### 3. `async-geotiff` (file reading — async, external)
 
-**What it is.** An async GeoTIFF / COG reader. Tiles fetched via HTTP range requests through `obstore`; TIFF IFDs parsed concurrently; no GDAL. By DevSeed. The basis for georeader's planned `AsyncGeoTIFFReader`.
+**What it is.** An async GeoTIFF / COG reader.
+Tiles fetched via HTTP range requests through `obstore`; TIFF IFDs parsed concurrently; no GDAL. By DevSeed.
+The basis for georeader's planned `AsyncGeoTIFFReader`.
 
 **Why it matters.** Lights up workloads where many tile reads happen simultaneously (tile servers, hyper-parallel batch inference) — `asyncio.gather(*[read_window(w) for w in 1000_windows])` avoids thread-per-request overhead and exploits HTTP/2 multiplexing.
 
@@ -130,29 +145,40 @@ Bottom-up dependency direction. Anything above can call anything below; nothing 
 | `RasterioReader` | Sync, rasterio-backed reader. Lazy-but-windowed: open a file once, read sub-windows on demand. The default I/O path. |
 | `GeoCatalog` | Catalog of files / scenes. Wraps a GeoDataFrame with `IntervalIndex` + geometry; query / intersect / union live here. |
 
-**Why it matters.** This is the API surface RS users hold. Everything above (`geotoolz`, `titiler` indirectly, `lonboard` indirectly) consumes `GeoTensor`. Everything below (`async-geotiff`, `obstore`) is plumbing that produces them.
+**Why it matters.** This is the API surface RS users hold.
+Everything above (`geotoolz`, `titiler` indirectly, `lonboard` indirectly) consumes `GeoTensor`.
+Everything below (`async-geotiff`, `obstore`) is plumbing that produces them.
 
-**Deps.** Hard: `numpy`, `rasterio`, `shapely`, `geopandas`, `pyproj`. Optional: `obstore` / `async-geotiff` if/when remote-async paths are wired in.
+**Deps.** Hard: `numpy`, `rasterio`, `shapely`, `geopandas`, `pyproj`.
+Optional: `obstore` / `async-geotiff` if/when remote-async paths are wired in.
 
-**Use cases.** All RS workflows. Loading a Sentinel-2 scene, reading a bbox from a Landsat archive, building a catalog over 1M files, sampling chips for ML, saving COGs.
+**Use cases.** All RS workflows.
+Loading a Sentinel-2 scene, reading a bbox from a Landsat archive, building a catalog over 1M files, sampling chips for ML, saving COGs.
 
-**Talks to.** Below: rasterio (sync), `obstore` / `async-geotiff` (async paths). Above: `geotoolz` for transformations, `titiler` and `lonboard` for serving / viz.
+**Talks to.** Below: rasterio (sync), `obstore` / `async-geotiff` (async paths).
+Above: `geotoolz` for transformations, `titiler` and `lonboard` for serving / viz.
 
 ### 5. `geotoolz` (computation)
 
-**What it is.** The composable Operator library on top of `GeoTensor`. `Operator`, `Sequential`, `Graph`, plus the curated RS modules (`indices`, `radiometry`, `cloud`, `compositing`, `pansharpen`, `sar`, `hyperspectral`, `sampling`, `inference`, `catalog_ops`, `presets`).
+**What it is.** The composable Operator library on top of `GeoTensor`.
+`Operator`, `Sequential`, `Graph`, plus the curated RS modules (`indices`, `radiometry`, `cloud`, `compositing`, `pansharpen`, `sar`, `hyperspectral`, `sampling`, `inference`, `catalog_ops`, `presets`).
 
-**Why it matters.** Without it, every RS pipeline is bespoke glue code. With it, `Sequential([MaskClouds(...), TOAToBOA(...), NDVI(...)])` — declared in YAML or Python.
+**Why it matters.** Without it, every RS pipeline is bespoke glue code.
+With it, `Sequential([MaskClouds(...), TOAToBOA(...), NDVI(...)])` — declared in YAML or Python.
 
 **See:** [`geotoolz/README.md`](geotoolz/README.md) for the navigation entry; [`geotoolz/geotoolz.md`](geotoolz/geotoolz.md) for the full design report (architecture, 12-module surface, end-to-end examples, `xr_toolz` coexistence).
 
 ### 6. `titiler` (serving)
 
-**What it is.** A dynamic tile server built on FastAPI + `rio-tiler`. Serves XYZ / WMTS / OGC tiles from COGs, STAC items, or MosaicJSON. Comes with a viewer UI and OGC-compliant endpoints. By DevSeed.
+**What it is.** A dynamic tile server built on FastAPI + `rio-tiler`.
+Serves XYZ / WMTS / OGC tiles from COGs, STAC items, or MosaicJSON. Comes with a viewer UI and OGC-compliant endpoints.
+By DevSeed.
 
-**Why it matters.** Once you've produced a COG (NDVI, classification map, segmentation result), you want to look at it on a web map. `titiler` does on-the-fly tiling: a request for tile `z/x/y` triggers a `rio-tiler` read of just that COG window, color-mapped, returned as PNG/JPEG. No pre-rendering, no tile cache management.
+**Why it matters.** Once you've produced a COG (NDVI, classification map, segmentation result), you want to look at it on a web map.
+`titiler` does on-the-fly tiling: a request for tile `z/x/y` triggers a `rio-tiler` read of just that COG window, color-mapped, returned as PNG/JPEG. No pre-rendering, no tile cache management.
 
-**Deps.** `fastapi`, `uvicorn`, `rio-tiler`, `morecantile`. Doesn't depend on `georeader` or `geotoolz` directly — it consumes COGs (or STAC), which the lower stack produced.
+**Deps.** `fastapi`, `uvicorn`, `rio-tiler`, `morecantile`.
+Doesn't depend on `georeader` or `geotoolz` directly — it consumes COGs (or STAC), which the lower stack produced.
 
 **Use cases.**
 
@@ -160,15 +186,21 @@ Bottom-up dependency direction. Anything above can call anything below; nothing 
 - A research server that lets collaborators inspect intermediate results without downloading.
 - Backend for `lonboard` raster layers (lonboard can pull tiles from titiler URLs).
 
-**Talks to.** Below: reads COGs from object storage (potentially via `obstore` / `async-geotiff` if you wire `rio-tiler` that way; default is GDAL/VSI). Above: HTTP clients, `lonboard`, web maps, leafmap.
+**Talks to.** Below: reads COGs from object storage (potentially via `obstore` / `async-geotiff` if you wire `rio-tiler` that way; default is GDAL/VSI).
+Above: HTTP clients, `lonboard`, web maps, leafmap.
 
 ### 7. `lonboard` (visualization)
 
-**What it is.** Geospatial visualization in Jupyter using deck.gl. Renders huge vector data (millions of features) and raster tiles efficiently by binary-streaming GeoArrow to the browser. Recently added raster (XYZ tile-layer) support. Also by DevSeed.
+**What it is.** Geospatial visualization in Jupyter using deck.gl.
+Renders huge vector data (millions of features) and raster tiles efficiently by binary-streaming GeoArrow to the browser.
+Recently added raster (XYZ tile-layer) support.
+Also by DevSeed.
 
-**Why it matters.** Folium / ipyleaflet choke on 100k+ features. `lonboard` ships GeoArrow over the kernel-frontend boundary as a typed buffer and lets deck.gl's WebGL render it; the result is hundreds of millions of points / lines / polygons interactive in a notebook.
+**Why it matters.** Folium / ipyleaflet choke on 100k+ features.
+`lonboard` ships GeoArrow over the kernel-frontend boundary as a typed buffer and lets deck.gl's WebGL render it; the result is hundreds of millions of points / lines / polygons interactive in a notebook.
 
-**Deps.** `pyarrow`, `geopandas`, `anywidget`, `deck.gl-py-bindings`. Doesn't depend on `georeader` or `geotoolz` directly — accepts geopandas / GeoArrow / image arrays.
+**Deps.** `pyarrow`, `geopandas`, `anywidget`, `deck.gl-py-bindings`.
+Doesn't depend on `georeader` or `geotoolz` directly — accepts geopandas / GeoArrow / image arrays.
 
 **Use cases.**
 
@@ -218,15 +250,20 @@ A practical rule:
                          all formats, sync)
 ```
 
-Both are interchangeable behind one Protocol surface — pipelines accept a `reader_class=` argument and the rest of the code is unchanged. See [`georeader/README.md`](georeader/README.md) for the protocol surface that makes them swappable, and [`georeader/reader_protocol.md`](georeader/reader_protocol.md) for the refactor that locks it in.
+Both are interchangeable behind one Protocol surface — pipelines accept a `reader_class=` argument and the rest of the code is unchanged.
+See [`georeader/README.md`](georeader/README.md) for the protocol surface that makes them swappable, and [`georeader/reader_protocol.md`](georeader/reader_protocol.md) for the refactor that locks it in.
 
-> **What about `lazy-cogs`?** The [`developmentseed/lazycogs`](https://github.com/developmentseed/lazycogs) library is a STAC-driven lazy loader that returns `xarray.DataArray`, not `GeoTensor`. It's a peer of `stackstac` / `odc-stac` for the dense-cube / `xarray` stack rather than a `georeader` reader option. See [`../geostack_notes.md`](../geostack_notes.md) Stack B for that discussion.
+> **What about `lazy-cogs`?** The [`developmentseed/lazycogs`](https://github.com/developmentseed/lazycogs) library is a STAC-driven lazy loader that returns `xarray.DataArray`, not `GeoTensor`.
+> It's a peer of `stackstac` / `odc-stac` for the dense-cube / `xarray` stack rather than a `georeader` reader option.
+> See [`../geostack_notes.md`](../geostack_notes.md) Stack B for that discussion.
 
 ---
 
 ## `obstore` vs `fsspec` compared
 
-Once you're below the reader layer, you're choosing how the bytes themselves move. The two real options are `obstore` and `fsspec`. They overlap in scope but differ in shape, language backbone, and ecosystem fit.
+Once you're below the reader layer, you're choosing how the bytes themselves move.
+The two real options are `obstore` and `fsspec`.
+They overlap in scope but differ in shape, language backbone, and ecosystem fit.
 
 | Property | `obstore` | `fsspec` |
 | --- | --- | --- |
@@ -264,15 +301,23 @@ A practical rule:
               (5–10× faster on parallel COG reads)
 ```
 
-The two coexist comfortably. New code paths in `async-geotiff` and `lazycogs` default to `obstore`; older code paths in `geopandas`, `pandas`, `xarray`, and `zarr ≤ 2` go through `fsspec`. `georeader.GeoCatalog` uses `obstore` for its parquet round-trip when reading remote catalogs because that's the hot path; but it can fall back to `fsspec` for niche storage.
+The two coexist comfortably.
+New code paths in `async-geotiff` and `lazycogs` default to `obstore`; older code paths in `geopandas`, `pandas`, `xarray`, and `zarr ≤ 2` go through `fsspec`.
+`georeader.GeoCatalog` uses `obstore` for its parquet round-trip when reading remote catalogs because that's the hot path; but it can fall back to `fsspec` for niche storage.
 
-For our async path: `AsyncGeoTIFFReader` accepts any [`obspec.AsyncStore`](https://github.com/developmentseed/obspec) (`obstore.S3Store` / `GCSStore` / `AzureStore`, etc.) via `store=`. We don't ship a `ByteStore` Protocol of our own — `obspec` is the upstream Protocol and `obstore` is the reference implementation. Sync reads with niche backends still go through `RasterioReader(fs=fsspec_fs)`. See [`types/bytestore.md`](types/bytestore.md) for the (one-page) rationale and the small `geotoolz.io.open_store(url)` factory.
+For our async path: `AsyncGeoTIFFReader` accepts any [`obspec.AsyncStore`](https://github.com/developmentseed/obspec) (`obstore.S3Store` / `GCSStore` / `AzureStore`, etc.) via `store=`.
+We don't ship a `ByteStore` Protocol of our own — `obspec` is the upstream Protocol and `obstore` is the reference implementation.
+Sync reads with niche backends still go through `RasterioReader(fs=fsspec_fs)`.
+See [`types/bytestore.md`](types/bytestore.md) for the (one-page) rationale and the small `geotoolz.io.open_store(url)` factory.
 
 ---
 
 ## What's actually inside `RasterioReader`
 
-The main diagram shows `RasterioReader` going through `GDAL / VSI`. That's the *default*, but it isn't the only option. `rasterio.open(...)` accepts an `opener=` callable (added in rasterio 1.4) that GDAL uses for byte-level reads, which means `RasterioReader` can route bytes through `fsspec` or `obstore` instead of GDAL's built-in HTTP client. Three paths, all sync, all sitting under the same Python class:
+The main diagram shows `RasterioReader` going through `GDAL / VSI`.
+That's the *default*, but it isn't the only option.
+`rasterio.open(...)` accepts an `opener=` callable (added in rasterio 1.4) that GDAL uses for byte-level reads, which means `RasterioReader` can route bytes through `fsspec` or `obstore` instead of GDAL's built-in HTTP client.
+Three paths, all sync, all sitting under the same Python class:
 
 ```text
               ┌──────────────────────┐
@@ -305,7 +350,8 @@ The main diagram shows `RasterioReader` going through `GDAL / VSI`. That's the *
 
 Two takeaways from the diagram:
 
-- **`RasterioReader` can fetch cloud bytes without fsspec or obstore.** GDAL's vsicurl (libcurl in C) is the default and is faster than the Python-ish alternatives for general use. Use the `opener=` escape hatch only for niche backends or shared-auth scenarios.
+- **`RasterioReader` can fetch cloud bytes without fsspec or obstore.** GDAL's vsicurl (libcurl in C) is the default and is faster than the Python-ish alternatives for general use.
+  Use the `opener=` escape hatch only for niche backends or shared-auth scenarios.
 - **For thousands of parallel reads or millions of small chip fetches, a different reader is the right answer** — that's where `async-geotiff` shines, skipping GDAL entirely.
 
 For the `opener=` / `fs=` constructor knobs and the refactor that wires them in, see [`georeader/reader_protocol.md`](georeader/reader_protocol.md) §"`RasterioReader` refactor".
@@ -333,7 +379,9 @@ lonboard.Map(layers=[lonboard.BitmapTileLayer(
 )])
 ```
 
-Stack used: `rasterio` → `georeader.RasterioReader` → `georeader.GeoTensor` → `geotoolz` → COG → `titiler` → `lonboard`. No async needed, no catalog. **`RasterioReader` is the right reader here** — single scene, GDAL-friendly, no concurrency need.
+Stack used: `rasterio` → `georeader.RasterioReader` → `georeader.GeoTensor` → `geotoolz` → COG → `titiler` → `lonboard`.
+No async needed, no catalog.
+**`RasterioReader` is the right reader here** — single scene, GDAL-friendly, no concurrency need.
 
 ### Flow B — catalog-driven async batch processing
 
@@ -357,7 +405,8 @@ geotoolz.catalog_ops.CatalogPipeline(
 ).run()
 ```
 
-Stack used: `obstore` → `async-geotiff` → `georeader.GeoTensor` → `geotoolz.Sequential` → `georeader.save_cog` → S3. The async path lights up because the workload is I/O-bound across thousands of small reads. **`RasterioReader` would also work here** — just sequentially over a threadpool — but `async-geotiff` will be 5–10× faster for cloud-COG-heavy workloads.
+Stack used: `obstore` → `async-geotiff` → `georeader.GeoTensor` → `geotoolz.Sequential` → `georeader.save_cog` → S3. The async path lights up because the workload is I/O-bound across thousands of small reads.
+**`RasterioReader` would also work here** — just sequentially over a threadpool — but `async-geotiff` will be 5–10× faster for cloud-COG-heavy workloads.
 
 ### Flow C — ML dataloader with async COG fan-out + chip sampler
 
@@ -378,7 +427,8 @@ for batch in loader:
     # ...
 ```
 
-Stack used: `obstore` → `async-geotiff` → `georeader.GeoSlice` → `geotoolz.sampling` → torch. The win is that 100k random chips across 50k COGs costs only the bytes in 100k tiny range requests, not 50k full files. **`RasterioReader` would technically work** but you'd pay GDAL's VSI overhead on every chip — `async-geotiff`'s pure-Rust HTTP path is a meaningful speedup at this fan-out.
+Stack used: `obstore` → `async-geotiff` → `georeader.GeoSlice` → `geotoolz.sampling` → torch. The win is that 100k random chips across 50k COGs costs only the bytes in 100k tiny range requests, not 50k full files.
+**`RasterioReader` would technically work** but you'd pay GDAL's VSI overhead on every chip — `async-geotiff`'s pure-Rust HTTP path is a meaningful speedup at this fan-out.
 
 ---
 
@@ -386,10 +436,16 @@ Stack used: `obstore` → `async-geotiff` → `georeader.GeoSlice` → `geotoolz
 
 A few places where two tools could do the same job and you have to pick:
 
-- **`RasterioReader` vs `async-geotiff`.** See the comparison table above. Short version: `RasterioReader` is the safe default and the only choice for non-TIFF data; `async-geotiff` wins on parallel cloud-COG throughput and on "many files, small slice each."
-- **`titiler` vs direct `lonboard` raster.** `titiler` is the right choice when you want a real HTTP API for many viewers. `lonboard`'s direct array input is the right choice when you're in one notebook and just want to look. Same picture, different audiences.
-- **`obstore` vs `fsspec` / `s3fs`.** `obstore` is faster and async-native; `fsspec` has wider integration (zarr, parquet readers, etc. all speak fsspec). In practice `obstore` is the cloud transport for the new tools, and `fsspec` is what older libraries (including parts of geopandas/rasterio) still use. Coexist for now; new code prefers `obstore`.
-- **`georeader.RasterioReader` vs `async-geotiff`.** Sync vs async; full GDAL coverage vs TIFF-only. `RasterioReader` is fine for batch jobs, notebooks, and any non-TIFF source; `async-geotiff` shines when you're either serving tiles or running thousands of parallel reads.
+- **`RasterioReader` vs `async-geotiff`.** See the comparison table above.
+  Short version: `RasterioReader` is the safe default and the only choice for non-TIFF data; `async-geotiff` wins on parallel cloud-COG throughput and on "many files, small slice each."
+- **`titiler` vs direct `lonboard` raster.** `titiler` is the right choice when you want a real HTTP API for many viewers.
+  `lonboard`'s direct array input is the right choice when you're in one notebook and just want to look.
+  Same picture, different audiences.
+- **`obstore` vs `fsspec` / `s3fs`.** `obstore` is faster and async-native; `fsspec` has wider integration (zarr, parquet readers, etc. all speak fsspec).
+  In practice `obstore` is the cloud transport for the new tools, and `fsspec` is what older libraries (including parts of geopandas/rasterio) still use.
+  Coexist for now; new code prefers `obstore`.
+- **`georeader.RasterioReader` vs `async-geotiff`.** Sync vs async; full GDAL coverage vs TIFF-only.
+  `RasterioReader` is fine for batch jobs, notebooks, and any non-TIFF source; `async-geotiff` shines when you're either serving tiles or running thousands of parallel reads.
 
 ---
 

--- a/projects/geotoolz/plans/geotoolz/README.md
+++ b/projects/geotoolz/plans/geotoolz/README.md
@@ -16,22 +16,26 @@ keywords: design, geotoolz, operators, remote-sensing
 ---
 
 > **Status:** design proposal — full report in [`geotoolz.md`](geotoolz.md).
-> **Scope:** a composable Operator library for remote sensing, sitting on top of `georeader.GeoTensor`. Sibling to `xr_toolz`, targeted at a different community and a different substrate.
+> **Scope:** a composable Operator library for remote sensing, sitting on top of `georeader.GeoTensor`.
+> Sibling to `xr_toolz`, targeted at a different community and a different substrate.
 > **Audience:** anyone building RS pipelines that compose preprocessing, inference, and evaluation steps; anyone consuming a `georeader` `GeoCatalog` and wanting to apply per-tile operators at scale.
 
 ---
 
 ## Summary
 
-`geotoolz` is the **operator-composition layer** above `georeader`. Where `georeader` reads bytes and produces `GeoTensor`s, `geotoolz` lets users *compose* those reads with classification heads, spectral-index calculations, masking, mosaicking, sampling, inference, and writing — declared as a `Sequential` of operators or a `Graph` of named ops, executed eagerly or driven by a Hydra config.
+`geotoolz` is the **operator-composition layer** above `georeader`.
+Where `georeader` reads bytes and produces `GeoTensor`s, `geotoolz` lets users *compose* those reads with classification heads, spectral-index calculations, masking, mosaicking, sampling, inference, and writing — declared as a `Sequential` of operators or a `Graph` of named ops, executed eagerly or driven by a Hydra config.
 
-It's the RS-shaped sibling to `xr_toolz` (the climate-side composition library): same architectural patterns, separate codebase, different substrate. `GeoTensor` is the shared currency at the bottom; the operator surface is built fresh for each library's audience.
+It's the RS-shaped sibling to `xr_toolz` (the climate-side composition library): same architectural patterns, separate codebase, different substrate.
+`GeoTensor` is the shared currency at the bottom; the operator surface is built fresh for each library's audience.
 
 ---
 
 ## What's in the design
 
-The full design report is [`geotoolz.md`](geotoolz.md). It runs through the architecture in 10 numbered sections; the high-level outline:
+The full design report is [`geotoolz.md`](geotoolz.md).
+It runs through the architecture in 10 numbered sections; the high-level outline:
 
 | § | Topic |
 |---|---|
@@ -58,13 +62,29 @@ Two companion docs sit alongside the main report, both MyST-rendered and listed 
 | [`examples/usecases.md`](examples/usecases.md) | A 13-case gallery of where the Operator algebra fits in a deployment — notebook exploration, ETL, ML training/inference, LitServe API, FastAPI multi-pipeline service, user-uploaded YAML viz, tile server, QC as operators, regulatory artifacts, active learning, cross-sensor fusion `Graph`, workflow orchestrator units, A/B regression. Each case names the driver (notebook user vs. HTTP request vs. scheduler), the calling code, an implementation sketch, and an honest tradeoffs note. |
 | [`examples/tips_n_tricks.md`](examples/tips_n_tricks.md) | A reference of small composable Operators that punch above their weight — `Tap`/`Snapshot`/`Profile`/`Histogram`/`ShapeTrace`/`Diff` (observers), `Branch`/`Switch`/`Try`/`Coalesce`/`Retry` (control flow), `Fanout`/`ApplyToBands`/`Cache` (composition), context-managed `Mode` and `Spy` (stateful), `AssertX`/`Quarantine` (QC), and small building blocks like `Identity`/`Const`/`Lambda`/`Sink`. Includes the **scoped-by-default** API design for `Mode` (a `with pipe.mode("train"):` context manager) and `Spy` (a `with Spy.scoped() as s: ...` block) — the explicit-scoping alternative to PyTorch's sticky `train()`/`eval()` footgun. |
 
-Both files are deliberate companions, not duplicates: `usecases.md` is "*who drives the pipeline*" (a tour of deployment shapes); `tips_n_tricks.md` is "*what primitives let those shapes work*" (the v0.1 stdlib of idioms). New readers can start with either — use cases first if you want to know *whether* the abstraction fits your problem, tricks first if you already know it does and want the building blocks.
+Both files are deliberate companions, not duplicates: `usecases.md` is "*who drives the pipeline*" (a tour of deployment shapes); `tips_n_tricks.md` is "*what primitives let those shapes work*" (the v0.1 stdlib of idioms).
+New readers can start with either — use cases first if you want to know *whether* the abstraction fits your problem, tricks first if you already know it does and want the building blocks.
+
+---
+
+## Ecosystem bridges
+
+Two sub-designs spec how `geotoolz` reaches into the long-tail of the SciPy stack without re-implementing it.
+Each sub-design ships as a (design, examples) pair under its own subdirectory and is listed under the site TOC's *Plans → geotoolz* entry.
+
+| Bridge | Design | Examples | What it does |
+|---|---|---|---|
+| **scikit-image** | [`skimage/design_skimage.md`](skimage/design_skimage.md) | [`skimage/examples_skimage.md`](skimage/examples_skimage.md) | A small family of wrapping Operators (`PerBand`, `MultiBand`, `Func`) that adapt skimage's calling conventions to `GeoTensor` — axis-aware `HWC`/`CHW` adapters, dtype-range safety (`float [0,1]` ↔ `uint8 [0,255]`), and NaN masking/restoration. Brings filtering, morphology, segmentation, restoration, edge detection, feature extraction, and registration into the operator graph with no per-function glue. |
+| **scikit-learn** | [`sklearn/design_sklearn.md`](sklearn/design_sklearn.md) | [`sklearn/examples_sklearn.md`](sklearn/examples_sklearn.md) | One bridging type (`PixelTable`) for sklearn's `(n_samples, n_features)` shape, plus shape adapters (spatial-pixelwise, spatiotemporal-pixelwise, chipwise) and four estimator wrappers (Classifier / Regressor / Transformer / Clusterer). First-class NaN strategy taxonomy. Fitting stays out of the operator graph; pre-fitted estimators are the artifact that flows into pipelines. Works for any `BaseEstimator`-protocol library (sklearn proper, `xgboost`, `lightgbm`, `catboost`, `imbalanced-learn`, custom estimators). |
+
+Both bridges share the same shape: the design doc specs the wrapping Operators, type adapters, and gotchas; the examples doc walks through 10+ end-to-end recipes (SAR speckle reduction, cloud-mask post-processing, CLAHE, edge detection, superpixel segmentation, inpainting, GLCM textures, blob detection, image registration on the skimage side; crop classification, chipwise inference, biomass regression, pixel-wise PCA, full sklearn `Pipeline` composition, per-tile classifier, time-series classification, spatial CV, unsupervised clustering, incremental fitting on the sklearn side).
 
 ---
 
 ## Connections to other designs
 
-`geotoolz` sits on top of the rest of the plan tree. The cross-design touchpoints:
+`geotoolz` sits on top of the rest of the plan tree.
+The cross-design touchpoints:
 
 | Design | What `geotoolz` consumes / produces |
 |---|---|
@@ -79,15 +99,25 @@ Both files are deliberate companions, not duplicates: `usecases.md` is "*who dri
 
 The full design report flags twelve sharp edges in §7, architectural questions in §3 and §10, and a comprehensive risks/gotchas section in §11. The ones most worth surfacing here:
 
-1. **`Operator` base class — shared with `xr_toolz` or re-implemented?** The current decision (§0) is to re-implement (~300 LOC, freedom to specialise). Worth revisiting if a third sibling library appears.
-2. **Hydra-zen as a hard dep or extra?** §6 currently scopes it to an optional `[hydra]` extra. Some users want it as a baseline.
-3. **`presets/legacy/` for SPOT VGT and Proba-V?** §1.2 doesn't list them. [Tutorial Ch. 17](../../georeader_tutorial/17_legacy_sensors.md) suggests they'd live there if added.
-4. **Async operator support.** The current `Operator` base class is sync. An `AsyncOperator` for use with [`AsyncGeoTIFFReader`](../georeader/reader_async_geotiff.md) is plausible but not designed. **Pick a design before v0.1** — see §11.2.
-5. **`coordax` stability for the JAX path.** The future-work JAX bridge depends on `coordax` (NeuralGCM, research-grade). Spike before committing the v0.5 work; have a fallback (equinox + jaxtyping directly).
-6. **`georeader 2.0` (`feature/geotensor_npapi`) merge timing.** The two-tier model assumes the ndarray-subclass GeoTensor lands. If it stalls, geotoolz blocks.
-7. **`_src` privacy decision.** Primitives are currently "semi-public" — likely a footgun for non-ufunc primitives passed `GeoTensor` inputs. Decide truly-private vs deliberately-public namespace (§11.3 recommends truly-private for v0.1).
-8. **Sensor preset scope reduction for v0.1.** 80 operators in 4 months is tight. Recommendation: cut Himawari-AHI HSD, MTG-FCI, SEVIRI-HRIT to v0.5+; ship MODIS + ABI as v0.1 sensor proofs.
-9. **Array-API compliance from day one or as a retrofit?** If JAX path matters, factoring primitives through the array-API standard at v0.1 is cheap; v0.5 retrofit is expensive. See §11.3.
+1. **`Operator` base class — shared with `xr_toolz` or re-implemented?** The current decision (§0) is to re-implement (~300 LOC, freedom to specialise).
+   Worth revisiting if a third sibling library appears.
+2. **Hydra-zen as a hard dep or extra?** §6 currently scopes it to an optional `[hydra]` extra.
+   Some users want it as a baseline.
+3. **`presets/legacy/` for SPOT VGT and Proba-V?** §1.2 doesn't list them.
+   [Tutorial Ch. 17](../../georeader_tutorial/17_legacy_sensors.md) suggests they'd live there if added.
+4. **Async operator support.** The current `Operator` base class is sync.
+   An `AsyncOperator` for use with [`AsyncGeoTIFFReader`](../georeader/reader_async_geotiff.md) is plausible but not designed.
+   **Pick a design before v0.1** — see §11.2.
+5. **`coordax` stability for the JAX path.** The future-work JAX bridge depends on `coordax` (NeuralGCM, research-grade).
+   Spike before committing the v0.5 work; have a fallback (equinox + jaxtyping directly).
+6. **`georeader 2.0` (`feature/geotensor_npapi`) merge timing.** The two-tier model assumes the ndarray-subclass GeoTensor lands.
+   If it stalls, geotoolz blocks.
+7. **`_src` privacy decision.** Primitives are currently "semi-public" — likely a footgun for non-ufunc primitives passed `GeoTensor` inputs.
+   Decide truly-private vs deliberately-public namespace (§11.3 recommends truly-private for v0.1).
+8. **Sensor preset scope reduction for v0.1.** 80 operators in 4 months is tight.
+   Recommendation: cut Himawari-AHI HSD, MTG-FCI, SEVIRI-HRIT to v0.5+; ship MODIS + ABI as v0.1 sensor proofs.
+9. **Array-API compliance from day one or as a retrofit?** If JAX path matters, factoring primitives through the array-API standard at v0.1 is cheap; v0.5 retrofit is expensive.
+   See §11.3.
 
 The full risks/gotchas list lives in [`geotoolz.md` §11](geotoolz.md#11-open-questions-gotchas-and-risks) — covers strategic risks, implementation gotchas to test in CI, and scope honesty.
 
@@ -95,6 +125,7 @@ The full risks/gotchas list lives in [`geotoolz.md` §11](geotoolz.md#11-open-qu
 
 ## Why this README is a thin wrapper
 
-The detailed design lives in [`geotoolz.md`](geotoolz.md) — 800+ lines covering everything from architecture decisions to per-operator math to a 15-example use-case gallery. That file is the source of truth; this README is a navigation entry point that other designs link to.
+The detailed design lives in [`geotoolz.md`](geotoolz.md) — 800+ lines covering everything from architecture decisions to per-operator math to a 15-example use-case gallery.
+That file is the source of truth; this README is a navigation entry point that other designs link to.
 
 If you're cross-referencing `geotoolz` from another plan, prefer linking to a specific section of [`geotoolz.md`](geotoolz.md) where possible (`#1-2-module-surface`, `#5-2-numpy-scipy-scikit-image-scikit-learn-compute`, etc.) rather than to this README — readers want to land on the section that's relevant to their question, not navigate two levels down.

--- a/projects/geotoolz/plans/geotoolz/examples/tips_n_tricks.md
+++ b/projects/geotoolz/plans/geotoolz/examples/tips_n_tricks.md
@@ -26,12 +26,18 @@ They follow the same config-round-trip rules, plug into Hydra-zen YAML, and resp
 
 ## Contents
 
-- [Inspection / introspection (Tap family)](#inspection--introspection-tap-family) - [Tap](#tap) · [Snapshot](#snapshot) · [TimeIt / Profile](#timeit--profile) · [Histogram](#histogram) · [ShapeTrace](#shapetrace) · [Spy / Hook](#spy--hook) · [Diff](#diff)
-- [Control flow](#control-flow) - [Branch](#branch) · [Switch](#switch) · [Try / Fallback](#try--fallback) · [Coalesce](#coalesce) · [Retry](#retry)
-- [Composition](#composition) - [Fanout](#fanout) · [ApplyToBands](#applytobands) · [Cache / Memoize](#cache--memoize)
-- [Stateful / ML](#stateful--ml) - [Mode](#mode) · [Provenance / Watermark](#provenance--watermark)
-- [Validation / QC (assertion family)](#validation--qc-assertion-family) - [AssertX](#assertx-recap) · [Quarantine](#quarantine)
-- [Small but load-bearing building blocks](#small-but-load-bearing-building-blocks) - [Identity](#identity) · [Const](#const) · [Lambda](#lambda) · [Sink](#sink) · [Subsample](#subsample)
+- [Inspection / introspection (Tap family)](#inspection--introspection-tap-family)
+  - [Tap](#tap) · [Snapshot](#snapshot) · [TimeIt / Profile](#timeit--profile) · [Histogram](#histogram) · [ShapeTrace](#shapetrace) · [Spy / Hook](#spy--hook) · [Diff](#diff)
+- [Control flow](#control-flow)
+  - [Branch](#branch) · [Switch](#switch) · [Try / Fallback](#try--fallback) · [Coalesce](#coalesce) · [Retry](#retry)
+- [Composition](#composition)
+  - [Fanout](#fanout) · [ApplyToBands](#applytobands) · [Cache / Memoize](#cache--memoize)
+- [Stateful / ML](#stateful--ml)
+  - [Mode](#mode) · [Provenance / Watermark](#provenance--watermark)
+- [Validation / QC (assertion family)](#validation--qc-assertion-family)
+  - [AssertX](#assertx-recap) · [Quarantine](#quarantine)
+- [Small but load-bearing building blocks](#small-but-load-bearing-building-blocks)
+  - [Identity](#identity) · [Const](#const) · [Lambda](#lambda) · [Sink](#sink) · [Subsample](#subsample)
 - [Two design rules](#two-design-rules)
 
 -----

--- a/projects/geotoolz/plans/geotoolz/examples/tips_n_tricks.md
+++ b/projects/geotoolz/plans/geotoolz/examples/tips_n_tricks.md
@@ -18,44 +18,34 @@ keywords: design, geotoolz, operators, examples, remote-sensing
 > **Status:** companion to [`geotoolz.md`](../geotoolz.md) — codifies the v0.1 idiom library of observers, control flow, assertions, and small building blocks.
 > **Audience:** anyone composing `geotoolz` pipelines beyond the canned operator surface; anyone deciding which speculative tricks belong in v0.1 vs later.
 
-A reference of small composable Operators that punch above their weight. The
-meta-pattern across all of them: **the `Operator` interface is general enough
-to express things that aren’t just transforms** — side effects, assertions,
-profiling, control flow, error handling, caching, and metadata propagation all
-become first-class composable units.
+A reference of small composable Operators that punch above their weight.
+The meta-pattern across all of them: **the `Operator` interface is general enough to express things that aren’t just transforms** — side effects, assertions, profiling, control flow, error handling, caching, and metadata propagation all become first-class composable units.
 
-Drop them into a `Sequential` like any other op. They follow the same
-config-round-trip rules, plug into Hydra-zen YAML, and respect the carrier
-contract (`GeoTensor → GeoTensor`, even when they don’t transform).
+Drop them into a `Sequential` like any other op.
+They follow the same config-round-trip rules, plug into Hydra-zen YAML, and respect the carrier contract (`GeoTensor → GeoTensor`, even when they don’t transform).
 
 ## Contents
 
-- [Inspection / introspection (Tap family)](#inspection--introspection-tap-family)
-  - [Tap](#tap) · [Snapshot](#snapshot) · [TimeIt / Profile](#timeit--profile) · [Histogram](#histogram) · [ShapeTrace](#shapetrace) · [Spy / Hook](#spy--hook) · [Diff](#diff)
-- [Control flow](#control-flow)
-  - [Branch](#branch) · [Switch](#switch) · [Try / Fallback](#try--fallback) · [Coalesce](#coalesce) · [Retry](#retry)
-- [Composition](#composition)
-  - [Fanout](#fanout) · [ApplyToBands](#applytobands) · [Cache / Memoize](#cache--memoize)
-- [Stateful / ML](#stateful--ml)
-  - [Mode](#mode) · [Provenance / Watermark](#provenance--watermark)
-- [Validation / QC (assertion family)](#validation--qc-assertion-family)
-  - [AssertX](#assertx-recap) · [Quarantine](#quarantine)
-- [Small but load-bearing building blocks](#small-but-load-bearing-building-blocks)
-  - [Identity](#identity) · [Const](#const) · [Lambda](#lambda) · [Sink](#sink) · [Subsample](#subsample)
+- [Inspection / introspection (Tap family)](#inspection--introspection-tap-family) - [Tap](#tap) · [Snapshot](#snapshot) · [TimeIt / Profile](#timeit--profile) · [Histogram](#histogram) · [ShapeTrace](#shapetrace) · [Spy / Hook](#spy--hook) · [Diff](#diff)
+- [Control flow](#control-flow) - [Branch](#branch) · [Switch](#switch) · [Try / Fallback](#try--fallback) · [Coalesce](#coalesce) · [Retry](#retry)
+- [Composition](#composition) - [Fanout](#fanout) · [ApplyToBands](#applytobands) · [Cache / Memoize](#cache--memoize)
+- [Stateful / ML](#stateful--ml) - [Mode](#mode) · [Provenance / Watermark](#provenance--watermark)
+- [Validation / QC (assertion family)](#validation--qc-assertion-family) - [AssertX](#assertx-recap) · [Quarantine](#quarantine)
+- [Small but load-bearing building blocks](#small-but-load-bearing-building-blocks) - [Identity](#identity) · [Const](#const) · [Lambda](#lambda) · [Sink](#sink) · [Subsample](#subsample)
 - [Two design rules](#two-design-rules)
 
 -----
 
 ## Inspection / introspection (Tap family)
 
-The simplest, most powerful family: identity Operators with side effects. They
-let users observe a pipeline without breaking the chain.
+The simplest, most powerful family: identity Operators with side effects.
+They let users observe a pipeline without breaking the chain.
 
 ### Tap
 
-The seed pattern. An identity Operator with a side effect — the `fn` runs, the
-GeoTensor flows through unchanged. Already in the core surface; included here
-because the rest of this section builds on it.
+The seed pattern.
+An identity Operator with a side effect — the `fn` runs, the GeoTensor flows through unchanged.
+Already in the core surface; included here because the rest of this section builds on it.
 
 ```python
 gz.Sequential([
@@ -67,8 +57,8 @@ gz.Sequential([
 
 ### Snapshot
 
-`Tap` that **stores** instead of prints. After the pipeline runs, every named
-intermediate is available for plotting, debugging, or comparison.
+`Tap` that **stores** instead of prints.
+After the pipeline runs, every named intermediate is available for plotting, debugging, or comparison.
 
 ```python
 snap = gz.core.Snapshot()
@@ -99,9 +89,8 @@ class _SnapshotTap(Operator):
     def _apply(self, gt): self.store[self.key] = gt; return gt
 ```
 
-**Tradeoff.** Stores *references*, not copies — if an in-place op downstream
-mutates the array, your snapshot sees it too. Add `copy=True` for safety in
-exploratory work; leave default `False` for hot loops.
+**Tradeoff.** Stores *references*, not copies — if an in-place op downstream mutates the array, your snapshot sees it too.
+Add `copy=True` for safety in exploratory work; leave default `False` for hot loops.
 
 ### TimeIt / Profile
 
@@ -141,15 +130,13 @@ class _TimedOp(Operator):
         return out
 ```
 
-**Tradeoff.** `wrap()` adds one Python frame per op — negligible compared to
-GeoTensor work but visible in microbenchmark territory. For tile-server hot
-paths, profile during development and remove before deploying.
+**Tradeoff.** `wrap()` adds one Python frame per op — negligible compared to GeoTensor work but visible in microbenchmark territory.
+For tile-server hot paths, profile during development and remove before deploying.
 
 ### Histogram
 
-`Tap` that captures **distributions**, not point summaries. Useful for “is
-this band shifted from last week?” or “did my correction blow out the bright
-end?”
+`Tap` that captures **distributions**, not point summaries.
+Useful for “is this band shifted from last week?” or “did my correction blow out the bright end?”
 
 ```python
 hist = gz.core.Histogram(bins=50)
@@ -162,14 +149,13 @@ hist.plot(overlay=True)               # both distributions on one axis
 hist.compare("post_correction", reference="/data/ref_dist.npz")  # vs golden
 ```
 
-**Tradeoff.** Cheap *per call* (one `np.histogram`), expensive in *aggregate*
-if you bin every chip in a 10k-tile run. For ETL monitoring, sample 1% of tiles
-rather than all of them.
+**Tradeoff.** Cheap *per call* (one `np.histogram`), expensive in *aggregate* if you bin every chip in a 10k-tile run.
+For ETL monitoring, sample 1% of tiles rather than all of them.
 
 ### ShapeTrace
 
-Logs shape, dtype, CRS, transform, and bands at every step. Invaluable when an
-op silently strips a band or changes a transform.
+Logs shape, dtype, CRS, transform, and bands at every step.
+Invaluable when an op silently strips a band or changes a transform.
 
 ```python
 gz.Sequential([
@@ -184,8 +170,7 @@ gz.Sequential([
 # step 2: (1, 256, 256) float32 EPSG:32630 res=10  bands=ndvi   ← collapsed
 ```
 
-A diff-mode is the killer feature — only logs *changes* between steps, so a
-20-op pipeline doesn’t drown you in 20 identical lines.
+A diff-mode is the killer feature — only logs *changes* between steps, so a 20-op pipeline doesn’t drown you in 20 identical lines.
 
 ```python
 gz.core.ShapeTrace(mode="diff_only")
@@ -193,14 +178,11 @@ gz.core.ShapeTrace(mode="diff_only")
 
 ### Spy / Hook
 
-Register a callback that fires whenever an op of a specific *type* runs
-anywhere in the graph. Same idea as PyTorch forward hooks, but for operator
-graphs — cross-cutting instrumentation without modifying every Sequential.
+Register a callback that fires whenever an op of a specific *type* runs anywhere in the graph.
+Same idea as PyTorch forward hooks, but for operator graphs — cross-cutting instrumentation without modifying every Sequential.
 
-**Hooks are scoped, never global.** A naive global registry — hooks registered
-in one module firing in another — is a footgun the size of a barn (debug
-output appearing in production, tests leaking hooks into other tests). The
-primary API is a `with` block:
+**Hooks are scoped, never global.** A naive global registry — hooks registered in one module firing in another — is a footgun the size of a barn (debug output appearing in production, tests leaking hooks into other tests).
+The primary API is a `with` block:
 
 ```python
 # Debug: "why is MatchedFilter being called 47 times?"
@@ -248,23 +230,17 @@ class Spy:
                 fn(op, input_gt, output_gt)
 ```
 
-`Operator.__call__` invokes `Spy.fire(self, args, output)` after `_apply`. When
-no `Spy.scoped()` block is active, `_active_spies.get()` returns `()` and the
-firing path is a single empty-tuple iteration.
+`Operator.__call__` invokes `Spy.fire(self, args, output)` after `_apply`.
+When no `Spy.scoped()` block is active, `_active_spies.get()` returns `()` and the firing path is a single empty-tuple iteration.
 
-**Tradeoff.** Scoping is the safe default but it doesn't help when the
-behaviour you want to debug is *deep inside a worker process*. For that case,
-the worker can enter its own `Spy.scoped()` at startup — the contextvar
-behaves correctly under `concurrent.futures` workers. Avoid promoting a
-"global / sticky" `Spy.on` to a public API; if a test or a notebook needs the
-global feel, wrap the whole session in `with Spy.scoped() as s: ...` and
-register at the top.
+**Tradeoff.** Scoping is the safe default but it doesn't help when the behaviour you want to debug is *deep inside a worker process*.
+For that case, the worker can enter its own `Spy.scoped()` at startup — the contextvar behaves correctly under `concurrent.futures` workers.
+Avoid promoting a "global / sticky" `Spy.on` to a public API; if a test or a notebook needs the global feel, wrap the whole session in `with Spy.scoped() as s: ...` and register at the top.
 
 ### Diff
 
-Compares output to a stored reference; raises on drift beyond a tolerance. The
-**pytest of operator pipelines** — drop inline during refactoring to catch
-silent regressions.
+Compares output to a stored reference; raises on drift beyond a tolerance.
+The **pytest of operator pipelines** — drop inline during refactoring to catch silent regressions.
 
 ```python
 gz.Sequential([
@@ -275,10 +251,8 @@ gz.Sequential([
 # raises DiffError("max abs diff 0.0023 exceeds atol=1e-4 at index (0, 142, 89)")
 ```
 
-Workflow: bless a reference once you trust the pipeline output, then `Diff`
-catches any subsequent change. Particularly useful when refactoring a
-`Sequential` into a `Graph` or swapping a primitive — the numbers should
-match, and `Diff` proves it.
+Workflow: bless a reference once you trust the pipeline output, then `Diff` catches any subsequent change.
+Particularly useful when refactoring a `Sequential` into a `Graph` or swapping a primitive — the numbers should match, and `Diff` proves it.
 
 ```python
 # bless mode (run once when you know the pipeline is correct)
@@ -286,20 +260,19 @@ gz.core.Diff.bless("/refs/post_correction.tif")(gt)
 ```
 
 **Tradeoff.** Reference files drift over time as legitimate improvements ship.
-Pair with version pinning: `Diff.against("/refs/v3/...", atol=...)` per
-pipeline version, never overwrite a blessed reference in place.
+Pair with version pinning: `Diff.against("/refs/v3/...", atol=...)` per pipeline version, never overwrite a blessed reference in place.
 
 -----
 
 ## Control flow
 
-The Operator interface is general enough to express conditional execution,
-fallbacks, and retries. Same composition primitives, more interesting graphs.
+The Operator interface is general enough to express conditional execution, fallbacks, and retries.
+Same composition primitives, more interesting graphs.
 
 ### Branch
 
-Conditional execution based on a predicate over the GeoTensor. Apply correction
-only if the input warrants it; otherwise pass through.
+Conditional execution based on a predicate over the GeoTensor.
+Apply correction only if the input warrants it; otherwise pass through.
 
 ```python
 gz.Sequential([
@@ -312,9 +285,8 @@ gz.Sequential([
 ])
 ```
 
-The predicate is a callable rather than an Operator because it’s a *boolean
-decision* about an input, not a transform of it. The two arms are Operators
-because they perform the work.
+The predicate is a callable rather than an Operator because it’s a *boolean decision* about an input, not a transform of it.
+The two arms are Operators because they perform the work.
 
 ### Switch
 
@@ -332,19 +304,16 @@ gz.core.Switch(
 )
 ```
 
-Use this for cross-sensor pipelines where the *same downstream analysis* needs
-sensor-specific preprocessing. The downstream op stays one Sequential; the
-sensor branching lives in one place.
+Use this for cross-sensor pipelines where the *same downstream analysis* needs sensor-specific preprocessing.
+The downstream op stays one Sequential; the sensor branching lives in one place.
 
-**Tradeoff.** A `Switch` with five branches whose bodies share 80% of their
-operators is a code smell — refactor into `Sequential([common_prefix, Switch(...) for the divergent step])`. Don’t let `Switch` become a
-copy-paste vehicle.
+**Tradeoff.** A `Switch` with five branches whose bodies share 80% of their operators is a code smell — refactor into `Sequential([common_prefix, Switch(...) for the divergent step])`.
+Don’t let `Switch` become a copy-paste vehicle.
 
 ### Try / Fallback
 
-Robust to upstream flakiness — if the first op fails, try the fallback. Useful
-for ML inference where a remote model is occasionally unavailable, or for
-batch jobs that should survive transient errors.
+Robust to upstream flakiness — if the first op fails, try the fallback.
+Useful for ML inference where a remote model is occasionally unavailable, or for batch jobs that should survive transient errors.
 
 ```python
 gz.core.Try(
@@ -354,18 +323,14 @@ gz.core.Try(
 )
 ```
 
-Always specify the exception types in `on=`. Catching bare `Exception` masks
-real bugs.
+Always specify the exception types in `on=`.
+Catching bare `Exception` masks real bugs.
 
-**Tradeoff.** Silent fallback can hide deteriorating production conditions —
-“the v2 model has been OOMing for two weeks but Try kept covering it up.” Pair
-with metrics: log every fallback as a counter, alert when the rate exceeds a
-threshold.
+**Tradeoff.** Silent fallback can hide deteriorating production conditions — “the v2 model has been OOMing for two weeks but Try kept covering it up.” Pair with metrics: log every fallback as a counter, alert when the rate exceeds a threshold.
 
 ### Coalesce
 
-First-non-empty across sources — the “S2 first, fall back to Landsat if S2 is
-too cloudy, fall back to MODIS if Landsat is also unavailable” pattern.
+First-non-empty across sources — the “S2 first, fall back to Landsat if S2 is too cloudy, fall back to MODIS if Landsat is also unavailable” pattern.
 
 ```python
 gz.core.Coalesce([
@@ -375,9 +340,8 @@ gz.core.Coalesce([
 ], is_empty=lambda gt: np.isnan(gt).mean() > 0.7)
 ```
 
-Distinct from `Try` — `Coalesce` cascades on a *quality predicate* (the output
-is bad), `Try` cascades on an *exception* (the operator failed). They compose
-naturally:
+Distinct from `Try` — `Coalesce` cascades on a *quality predicate* (the output is bad), `Try` cascades on an *exception* (the operator failed).
+They compose naturally:
 
 ```python
 gz.core.Coalesce([
@@ -388,8 +352,8 @@ gz.core.Coalesce([
 
 ### Retry
 
-Wraps an op with retry + backoff. Most useful for `ModelOp` over a remote API
-or any op touching the network.
+Wraps an op with retry + backoff.
+Most useful for `ModelOp` over a remote API or any op touching the network.
 
 ```python
 gz.core.Retry(
@@ -400,10 +364,8 @@ gz.core.Retry(
 )
 ```
 
-**Tradeoff.** Retries hide latency from upstream callers — a tile server
-request that nominally takes 200ms can spike to 7 seconds because of two
-retries. For latency-sensitive paths, prefer `Try` with a fast fallback over
-`Retry` with backoff.
+**Tradeoff.** Retries hide latency from upstream callers — a tile server request that nominally takes 200ms can spike to 7 seconds because of two retries.
+For latency-sensitive paths, prefer `Try` with a fast fallback over `Retry` with backoff.
 
 -----
 
@@ -413,8 +375,7 @@ Building blocks for graphs that aren’t pure linear chains.
 
 ### Fanout
 
-One input, multiple outputs — useful when you want N derived products from one
-read instead of re-reading the source N times.
+One input, multiple outputs — useful when you want N derived products from one read instead of re-reading the source N times.
 
 ```python
 products = gz.core.Fanout({
@@ -425,37 +386,31 @@ products = gz.core.Fanout({
 # {"ndvi": GeoTensor, "ndwi": GeoTensor, "rgb": GeoTensor}
 ```
 
-For computing many indices on one scene, Fanout reads once and computes once
-per index. Compared to running three separate Sequentials, it’s both faster
-(one read) and more honest (the input GeoTensor is genuinely shared).
+For computing many indices on one scene, Fanout reads once and computes once per index.
+Compared to running three separate Sequentials, it’s both faster (one read) and more honest (the input GeoTensor is genuinely shared).
 
-A `Graph` with a single input and N outputs expresses the same thing more
-formally. `Fanout` is the sugar for the common case.
+A `Graph` with a single input and N outputs expresses the same thing more formally.
+`Fanout` is the sugar for the common case.
 
 ### ApplyToBands
 
-Split-apply-combine over the band axis — applies the inner op to each band
-independently, recombines. Mirrors xarray’s `.groupby()` shape but for bare
-arrays.
+Split-apply-combine over the band axis — applies the inner op to each band independently, recombines.
+Mirrors xarray’s `.groupby()` shape but for bare arrays.
 
 ```python
 # Apply Lee speckle filter independently to each polarisation channel
 gz.core.ApplyToBands(gz.sar.LeeSpeckle(window=7), axis=0)(sar_gt)
 ```
 
-Composable with everything: drop into a Sequential, wrap in Cache, profile
-with TimeIt. The inner op becomes a regular Operator that just happens to run
-N times.
+Composable with everything: drop into a Sequential, wrap in Cache, profile with TimeIt.
+The inner op becomes a regular Operator that just happens to run N times.
 
-**Tradeoff.** Naive implementation is a Python-level for-loop over bands —
-fine for ~10 bands, painful for hyperspectral with ~200. For hyperspectral,
-the inner op should ideally be vectorisable across the band axis directly;
-`ApplyToBands` is the fallback when it isn’t.
+**Tradeoff.** Naive implementation is a Python-level for-loop over bands — fine for ~10 bands, painful for hyperspectral with ~200. For hyperspectral, the inner op should ideally be vectorisable across the band axis directly; `ApplyToBands` is the fallback when it isn’t.
 
 ### Cache / Memoize
 
-Hashes input + operator config, caches the result. Saves hours during
-iterative analysis where you keep re-running the same expensive prefix.
+Hashes input + operator config, caches the result.
+Saves hours during iterative analysis where you keep re-running the same expensive prefix.
 
 ```python
 expensive_prefix = gz.core.Cache(
@@ -491,15 +446,11 @@ class Cache(Operator):
         ).hexdigest()
 ```
 
-The cache key is `(input_hash, inner.config_hash())`. Both must be stable —
-the input hash is on `GeoTensor` content (or a checksum of the source bytes),
-the config hash is what `get_config()` returns canonicalised.
+The cache key is `(input_hash, inner.config_hash())`.
+Both must be stable — the input hash is on `GeoTensor` content (or a checksum of the source bytes), the config hash is what `get_config()` returns canonicalised.
 
-**Tradeoff.** Memory backend is fast but unbounded — wrap with an LRU. Disk
-backend is restart-friendly but you need to garbage-collect old entries. Cache
-must opt-in (`Cache(...)` wraps explicitly), never silent — if `Cache` ever
-becomes a default, debugging “why does my pipeline produce stale output”
-becomes a nightmare.
+**Tradeoff.** Memory backend is fast but unbounded — wrap with an LRU. Disk backend is restart-friendly but you need to garbage-collect old entries.
+Cache must opt-in (`Cache(...)` wraps explicitly), never silent — if `Cache` ever becomes a default, debugging “why does my pipeline produce stale output” becomes a nightmare.
 
 -----
 
@@ -509,12 +460,9 @@ Operators that hold state across calls or interact with the broader runtime.
 
 ### Mode
 
-Train / eval switching for pipelines that mix deterministic preprocessing with
-train-only operators (augmentation, dropout-like ops). The lesson from PyTorch
-is that *implicit, instance-level, sticky* `train()` / `eval()` is a footgun —
-"I forgot to call `.eval()` on the batchnorm" is the well-known bug. `geotoolz`
-takes the **scoped, explicit** path: mode is a context manager on a Sequential,
-not a sticky attribute on the operator graph.
+Train / eval switching for pipelines that mix deterministic preprocessing with train-only operators (augmentation, dropout-like ops).
+The lesson from PyTorch is that *implicit, instance-level, sticky* `train()` / `eval()` is a footgun — "I forgot to call `.eval()` on the batchnorm" is the well-known bug.
+`geotoolz` takes the **scoped, explicit** path: mode is a context manager on a Sequential, not a sticky attribute on the operator graph.
 
 ```python
 pipe = gz.Sequential([
@@ -561,22 +509,17 @@ class _ModeGated(Operator):
         return gt
 ```
 
-`Sequential._apply` threads the current `_mode` to `_ModeGated` children
-explicitly (a private kwarg or a contextvar — either works; the contextvar form
-nests cleanly for `Sequential`-in-`Sequential`). Either way, **there is no
-"current mode" without an active `with` block** — a defensive default that
-prevents the PyTorch bug at construction time.
+`Sequential._apply` threads the current `_mode` to `_ModeGated` children explicitly (a private kwarg or a contextvar — either works; the contextvar form nests cleanly for `Sequential`-in-`Sequential`).
+Either way, **there is no "current mode" without an active `with` block** — a defensive default that prevents the PyTorch bug at construction time.
 
-**Tradeoff.** Slightly more verbose than `pipe.train()` / `pipe.eval()`. The
-verbosity is the feature — every train-mode invocation is grep-able in source,
-and code that forgets to enter the scope fails loudly instead of silently
-producing augmented "validation" tensors.
+**Tradeoff.** Slightly more verbose than `pipe.train()` / `pipe.eval()`.
+The verbosity is the feature — every train-mode invocation is grep-able in source, and code that forgets to enter the scope fails loudly instead of silently producing augmented "validation" tensors.
 
 ### Provenance / Watermark
 
-Operator graph stamps lineage metadata into the output GeoTensor. Survives
-subsequent transformations, lands in the COG header on save. Now your output
-COGs *know* what produced them.
+Operator graph stamps lineage metadata into the output GeoTensor.
+Survives subsequent transformations, lands in the COG header on save.
+Now your output COGs *know* what produced them.
 
 ```python
 pipe = gz.core.Provenance.wrap(my_methane_pipeline)
@@ -594,29 +537,22 @@ out.metadata["provenance"]
 georeader.save_cog(out, "/out/methane.tif")  # provenance baked into COG tags
 ```
 
-Pairs naturally with the pinned-artifact pattern from the [use-cases doc](usecases.md#9-pinned--hashed-regulatory-artifact)
-— the provenance metadata in the COG references the artifact hash, so a
-consumer years later can chase the COG back to the exact pipeline that
-produced it.
+Pairs naturally with the pinned-artifact pattern from the [use-cases doc](usecases.md#9-pinned--hashed-regulatory-artifact) — the provenance metadata in the COG references the artifact hash, so a consumer years later can chase the COG back to the exact pipeline that produced it.
 
-**Tradeoff.** Provenance metadata grows with every wrap — a deeply-nested
-Graph produces a large lineage record. Cap at a reasonable depth, or store
-the full graph hash and a small operator-name summary rather than every
-config. Don’t let provenance bloat overshadow the pixel data.
+**Tradeoff.** Provenance metadata grows with every wrap — a deeply-nested Graph produces a large lineage record.
+Cap at a reasonable depth, or store the full graph hash and a small operator-name summary rather than every config. Don’t let provenance bloat overshadow the pixel data.
 
 -----
 
 ## Validation / QC (assertion family)
 
-The other identity-with-side-effect family — pass-through Operators that
-*check* invariants rather than observe state. See
-[the QC use case](usecases.md#8-data-validation--qc-as-operators)
-for the full pattern.
+The other identity-with-side-effect family — pass-through Operators that *check* invariants rather than observe state.
+See [the QC use case](usecases.md#8-data-validation--qc-as-operators) for the full pattern.
 
 ### AssertX (recap)
 
-A family of pass-through Operators that raise (or warn) on contract
-violations. Drop anywhere in a pipeline.
+A family of pass-through Operators that raise (or warn) on contract violations.
+Drop anywhere in a pipeline.
 
 ```python
 gz.Sequential([
@@ -629,8 +565,8 @@ gz.Sequential([
 
 ### Quarantine
 
-Non-raising QC: routes bad GeoTensors to a sidecar location for later
-debugging, and lets the pipeline continue. The “log_and_continue” of QC.
+Non-raising QC: routes bad GeoTensors to a sidecar location for later debugging, and lets the pipeline continue.
+The “log_and_continue” of QC.
 
 ```python
 gz.Sequential([
@@ -644,19 +580,14 @@ gz.Sequential([
 ])
 ```
 
-Behaviour: if the inner check passes, GeoTensor flows through. If it fails,
-the GeoTensor is written to the sink with the failure reason as sidecar
-metadata, the pipeline returns a sentinel (e.g. an all-NaN GeoTensor of the
-same shape), and downstream ops skip it gracefully.
+Behaviour: if the inner check passes, GeoTensor flows through.
+If it fails, the GeoTensor is written to the sink with the failure reason as sidecar metadata, the pipeline returns a sentinel (e.g. an all-NaN GeoTensor of the same shape), and downstream ops skip it gracefully.
 
-The orchestrator gets a “look here for bad data” pile that grows over time —
-a free dataset of failure modes for debugging and improving upstream readers.
+The orchestrator gets a “look here for bad data” pile that grows over time — a free dataset of failure modes for debugging and improving upstream readers.
 
-**Tradeoff.** Quarantine is a *hedge* — it trades immediate failure for
-delayed debugging. Don’t quarantine errors that indicate genuine bugs (wrong
-CRS, wrong band order); those should `raise`. Quarantine is for *expected
-edge cases* in the data (corrupt scenes, partial downloads, sensor
-glitches).
+**Tradeoff.** Quarantine is a *hedge* — it trades immediate failure for delayed debugging.
+Don’t quarantine errors that indicate genuine bugs (wrong CRS, wrong band order); those should `raise`.
+Quarantine is for *expected edge cases* in the data (corrupt scenes, partial downloads, sensor glitches).
 
 -----
 
@@ -666,9 +597,8 @@ Boring on their own, indispensable in combination.
 
 ### Identity
 
-Explicit no-op. The right thing to put in a `Branch` default, a `Switch`
-unmatched case, or anywhere a pipeline structurally needs an Operator but you
-have no work to do.
+Explicit no-op.
+The right thing to put in a `Branch` default, a `Switch` unmatched case, or anywhere a pipeline structurally needs an Operator but you have no work to do.
 
 ```python
 class Identity(Operator):
@@ -680,14 +610,14 @@ class Identity(Operator):
 gz.core.Branch(predicate=is_clean, if_true=gz.core.Identity(), if_false=cleanup)
 ```
 
-Use `Identity` rather than passing `None`. It serialises, it composes, it
-shows up in `repr()` and `ShapeTrace` output. Being explicit about no-ops
-makes them visible.
+Use `Identity` rather than passing `None`.
+It serialises, it composes, it shows up in `repr()` and `ShapeTrace` output.
+Being explicit about no-ops makes them visible.
 
 ### Const
 
-Returns a fixed GeoTensor regardless of input. Great for golden test fixtures
-and as a synthetic source in `Switch` defaults.
+Returns a fixed GeoTensor regardless of input.
+Great for golden test fixtures and as a synthetic source in `Switch` defaults.
 
 ```python
 class Const(Operator):
@@ -724,16 +654,15 @@ gz.Sequential([
 ])
 ```
 
-**Tradeoff.** Closures aren’t config-round-trippable. `Lambda` should be
-flagged `forbid_in_yaml=True` — research-only, never ships to prod. The first
-time a `Lambda` recurs, refactor it into a real Operator subclass with a name.
+**Tradeoff.** Closures aren’t config-round-trippable.
+`Lambda` should be flagged `forbid_in_yaml=True` — research-only, never ships to prod.
+The first time a `Lambda` recurs, refactor it into a real Operator subclass with a name.
 
 ### Sink
 
-A terminal write Operator that’s still composable. The classic write op
-(e.g. `WriteCOG`) returns nothing, which means it can’t be `Tap`-ped or
-`Snapshot`-ed and breaks cleanly into other ops. `Sink` writes *and* returns
-the input unchanged.
+A terminal write Operator that’s still composable.
+The classic write op (e.g. `WriteCOG`) returns nothing, which means it can’t be `Tap`-ped or `Snapshot`-ed and breaks cleanly into other ops.
+`Sink` writes *and* returns the input unchanged.
 
 ```python
 class Sink(Operator):
@@ -751,15 +680,11 @@ gz.Sequential([
 ])
 ```
 
-Useful for debugging (“what did the pipeline look like at step 3?”), for
-checkpointing long pipelines (write intermediate to disk in case the rest
-crashes), and for branching analysis (write intermediate, continue with final
-product).
+Useful for debugging (“what did the pipeline look like at step 3?”), for checkpointing long pipelines (write intermediate to disk in case the rest crashes), and for branching analysis (write intermediate, continue with final product).
 
 ### Subsample
 
-Random pixel sample inside a `Tap`-style op, for fast viz off a
-full-resolution GeoTensor without re-reading.
+Random pixel sample inside a `Tap`-style op, for fast viz off a full-resolution GeoTensor without re-reading.
 
 ```python
 gz.Sequential([
@@ -768,18 +693,15 @@ gz.Sequential([
 ])
 ```
 
-Or as a standalone transform that returns a smaller GeoTensor (decimated, with
-an updated transform):
+Or as a standalone transform that returns a smaller GeoTensor (decimated, with an updated transform):
 
 ```python
 small_gt = gz.core.Subsample(stride=10)(big_gt)  # every 10th pixel
 plt.imshow(small_gt.values)
 ```
 
-**Tradeoff.** Random subsampling biases summary statistics for non-uniform
-fields (e.g., concentrated NDVI hotspots in mostly-bare scenes). For fair
-visualisation, use stride-based subsampling; for fair statistics, use
-weighted random sampling.
+**Tradeoff.** Random subsampling biases summary statistics for non-uniform fields (e.g., concentrated NDVI hotspots in mostly-bare scenes).
+For fair visualisation, use stride-based subsampling; for fair statistics, use weighted random sampling.
 
 -----
 
@@ -789,9 +711,9 @@ These keep the surface tractable as the trick library grows.
 
 ### 1. Honest naming
 
-Don’t disguise an assertion as a transform. Don’t disguise a side effect as a
-computation. Users should be able to scan a Sequential and immediately see
-which steps mutate, which observe, which guard, and which control flow.
+Don’t disguise an assertion as a transform.
+Don’t disguise a side effect as a computation.
+Users should be able to scan a Sequential and immediately see which steps mutate, which observe, which guard, and which control flow.
 
 ```python
 # Good — the role of each step is obvious
@@ -813,21 +735,17 @@ Naming convention (suggested):
 
 ### 2. Round-trip discipline
 
-Operators that hold closures (`Tap`, `Lambda`, `Branch` with a callable
-predicate, `Spy` hooks) **cannot** round-trip to YAML faithfully. Their
-`get_config()` is a debug repr, not a faithful serialisation.
+Operators that hold closures (`Tap`, `Lambda`, `Branch` with a callable predicate, `Spy` hooks) **cannot** round-trip to YAML faithfully.
+Their `get_config()` is a debug repr, not a faithful serialisation.
 
 The library should:
 
 - Flag those Operators with `forbid_in_yaml = True`
 - Have the YAML loader refuse to instantiate any operator with that flag set
-- Have the YAML dumper raise (loudly) if asked to serialise a graph
-  containing one
+- Have the YAML dumper raise (loudly) if asked to serialise a graph containing one
 
-Production pipelines never contain closures. This keeps the “operator graph
-as audit artifact” guarantee from the [regulatory artifact use case](usecases.md#9-pinned--hashed-regulatory-artifact)
-honest — every operator in a regulatory artifact has a stable config, every
-config round-trips, every artifact reruns to the same answer.
+Production pipelines never contain closures.
+This keeps the “operator graph as audit artifact” guarantee from the [regulatory artifact use case](usecases.md#9-pinned--hashed-regulatory-artifact) honest — every operator in a regulatory artifact has a stable config, every config round-trips, every artifact reruns to the same answer.
 
 -----
 
@@ -848,5 +766,5 @@ Once these primitives exist, **most user “Operator subclass” needs go away.*
 |`WithProvenance`    |`Provenance.wrap(my_pipeline)`                                |
 |`S2OrLandsatNDVI`   |`Switch(key="sensor", cases={...})`                           |
 
-The library’s primitive set does the work; users compose. Adding a new trick
-adds one Operator, not a family of variants.
+The library’s primitive set does the work; users compose.
+Adding a new trick adds one Operator, not a family of variants.

--- a/projects/geotoolz/plans/geotoolz/examples/usecases.md
+++ b/projects/geotoolz/plans/geotoolz/examples/usecases.md
@@ -18,22 +18,14 @@ keywords: design, geotoolz, operators, use-cases, remote-sensing
 > **Status:** companion to [`geotoolz.md`](../geotoolz.md) — the missing "where does this thing live in a deployment?" gallery, covering notebook, ETL, ML, inference API, tile server, QC, reproducibility, and orchestrator patterns.
 > **Audience:** anyone deciding whether the operator-graph abstraction fits a given workflow; reviewers checking the v0.1 surface against real deployment shapes before committing.
 
-A gallery of patterns showing where the `geotoolz` operator algebra fits — across
-notebook exploration, ETL, ML training and inference, web APIs, and operational
-tooling. Each case includes context (who’s driving, what they’re trying to do),
-a **demo API** (calling code), an **example implementation sketch** where useful,
-and a short **tradeoffs** note covering when *not* to use the pattern.
+A gallery of patterns showing where the `geotoolz` operator algebra fits — across notebook exploration, ETL, ML training and inference, web APIs, and operational tooling.
+Each case includes context (who’s driving, what they’re trying to do), a **demo API** (calling code), an **example implementation sketch** where useful, and a short **tradeoffs** note covering when *not* to use the pattern.
 
-The unifying claim of the library: the *same* operator graph runs across all of
-these. What changes between cases is **who drives** — a notebook user, an HTTP
-request, a scheduler, a sampler, or another graph.
+The unifying claim of the library: the *same* operator graph runs across all of these.
+What changes between cases is **who drives** — a notebook user, an HTTP request, a scheduler, a sampler, or another graph.
 
-> Code blocks below are pseudocode — illustrative, not executable as-is. They
-> assume the API surface from
-> [`plans/geotoolz/`](https://jejjohnson.github.io/research_notebook/geotoolz)
-> and the catalog/sampler shapes from
-> [`plans/geodatabase/`](https://jejjohnson.github.io/research_notebook/geocatalog)
-> and [`plans/types/geoslice.md`](https://jejjohnson.github.io/research_notebook/geoslice).
+> Code blocks below are pseudocode — illustrative, not executable as-is.
+> They assume the API surface from [`plans/geotoolz/`](https://jejjohnson.github.io/research_notebook/geotoolz) and the catalog/sampler shapes from [`plans/geodatabase/`](https://jejjohnson.github.io/research_notebook/geocatalog) and [`plans/types/geoslice.md`](https://jejjohnson.github.io/research_notebook/geoslice).
 
 ## Contents
 
@@ -56,12 +48,9 @@ request, a scheduler, a sampler, or another graph.
 
 ## 1. Notebook exploration
 
-**The setting.** The first place a new operator earns its keep. A researcher
-trying out a spectral index variant, a postdoc tuning a cloud-mask threshold on
-a stubborn scene, or anyone debugging *why does my output look like that* — the
-common need is **seeing intermediate state** without exploding the pipeline into
-ten named variables. The pitch of the library at this stage isn’t “production
-ready”; it’s “the same shape you’ll deploy later.”
+**The setting.** The first place a new operator earns its keep.
+A researcher trying out a spectral index variant, a postdoc tuning a cloud-mask threshold on a stubborn scene, or anyone debugging *why does my output look like that* — the common need is **seeing intermediate state** without exploding the pipeline into ten named variables.
+The pitch of the library at this stage isn’t “production ready”; it’s “the same shape you’ll deploy later.”
 
 **Demo API.**
 
@@ -81,8 +70,8 @@ ndvi_gt = viz(scene_gt)
 plt.imshow(ndvi_gt.values, cmap="RdYlGn")
 ```
 
-`Tap` is the under-rated trick — an identity Operator with a side effect. It
-lets users live inside the chain instead of breaking it apart for inspection.
+`Tap` is the under-rated trick — an identity Operator with a side effect.
+It lets users live inside the chain instead of breaking it apart for inspection.
 Per-step stats, intermediate plots, lightweight asserts — all stay inline.
 
 **Implementation sketch.**
@@ -102,26 +91,18 @@ class Tap(Operator):
         return {"fn": repr(self.fn)}  # debug repr only — not round-trippable
 ```
 
-**Tradeoffs.** Because `fn` is a closure, `Tap` is *not* config-round-trippable;
-its `get_config()` is a debug repr, not faithful YAML. That’s the correct choice
-for a debug primitive — production pipelines should not contain `Tap`. A
-serialiser flag (`forbid_in_yaml=True`) on the class prevents accidental
-escape from the notebook.
+**Tradeoffs.** Because `fn` is a closure, `Tap` is *not* config-round-trippable; its `get_config()` is a debug repr, not faithful YAML. That’s the correct choice for a debug primitive — production pipelines should not contain `Tap`.
+A serialiser flag (`forbid_in_yaml=True`) on the class prevents accidental escape from the notebook.
 
 -----
 
 ## 2. ETL pipelines
 
-**The setting.** A researcher’s one-off “load → mask → correct → write COG”
-script becomes a scheduled job that has to run nightly across thousands of
-scenes. The two failure modes the library is meant to remove: **rewriting the
-pipeline** to fit the orchestrator, and **divergence** between the research
-notebook version and the production version. ETL here means: catalog drives the
-iteration; same operator graph applies to every row; results land in cloud
-storage.
+**The setting.** A researcher’s one-off “load → mask → correct → write COG” script becomes a scheduled job that has to run nightly across thousands of scenes.
+The two failure modes the library is meant to remove: **rewriting the pipeline** to fit the orchestrator, and **divergence** between the research notebook version and the production version.
+ETL here means: catalog drives the iteration; same operator graph applies to every row; results land in cloud storage.
 
-**Demo API.** Loads the pipeline from a YAML config so the same artefact can be
-audited, version-pinned, and re-run.
+**Demo API.** Loads the pipeline from a YAML config so the same artefact can be audited, version-pinned, and re-run.
 
 ```python
 import geotoolz as gz
@@ -173,8 +154,7 @@ operators:
     compress: deflate
 ```
 
-**Implementation sketch.** `CatalogPipeline` is itself an Operator — same
-`_apply` shape, just iterates rows.
+**Implementation sketch.** `CatalogPipeline` is itself an Operator — same `_apply` shape, just iterates rows.
 
 ```python
 class CatalogPipeline(Operator):
@@ -203,22 +183,16 @@ class CatalogPipeline(Operator):
             log.error("row %s failed: %s", row.id, e)
 ```
 
-**Tradeoffs.** Process-pool parallelism crosses pickle boundaries — every
-Operator and every reader must be pickleable. Closures, lambdas, and
-non-default-pickled cloud credentials break here, often silently. The
-`on_row_error="log_and_continue"` default is a hedge against the “one bad
-scene crashes the 10k-scene job” anti-pattern; the cost is that quiet failures
-need monitoring (count of skipped rows per run, failure rate alerts).
+**Tradeoffs.** Process-pool parallelism crosses pickle boundaries — every Operator and every reader must be pickleable.
+Closures, lambdas, and non-default-pickled cloud credentials break here, often silently.
+The `on_row_error="log_and_continue"` default is a hedge against the “one bad scene crashes the 10k-scene job” anti-pattern; the cost is that quiet failures need monitoring (count of skipped rows per run, failure rate alerts).
 
 -----
 
 ## 3. ML training and inference
 
-**The setting.** Train/serve skew is a perennial source of silent ML bugs —
-training preprocessing diverges from inference preprocessing over time, the
-model performs well in evaluation and badly in production, and nobody notices
-until a stakeholder spots the regression months later. The library’s claim
-here: *the same `preprocess` object* lives in both paths, by construction.
+**The setting.** Train/serve skew is a perennial source of silent ML bugs — training preprocessing diverges from inference preprocessing over time, the model performs well in evaluation and badly in production, and nobody notices until a stakeholder spots the regression months later.
+The library’s claim here: *the same `preprocess` object* lives in both paths, by construction.
 Augmentation differs (train-only), but the deterministic transforms are shared.
 
 **Demo API.**
@@ -265,27 +239,18 @@ infer = gz.inference.ApplyToChips(
 pred_gt = infer(scene_gt)
 ```
 
-**Tradeoffs.** Closures inside augment Operators (e.g. a captured RNG) break
-DataLoader workers — each worker gets the same seed and produces correlated
-batches. The fix is per-Operator `seed=` arguments and a `worker_init_fn` that
-re-seeds. Stitch overlap (`stride=224 < chip_size=256`) costs ~30% more reads
-for smoother boundaries; for fast inference set `stride == chip_size` and
-accept seam artefacts.
+**Tradeoffs.** Closures inside augment Operators (e.g. a captured RNG) break DataLoader workers — each worker gets the same seed and produces correlated batches.
+The fix is per-Operator `seed=` arguments and a `worker_init_fn` that re-seeds.
+Stitch overlap (`stride=224 < chip_size=256`) costs ~30% more reads for smoother boundaries; for fast inference set `stride == chip_size` and accept seam artefacts.
 
 -----
 
 ## 4. Lightning / LitServe inference API
 
-**The setting.** The model needs to ship as an HTTP service, with a long-lived
-process that holds the GPU and serves request/response over JSON. The shape is
-distinct from batch ETL because: requests arrive one-at-a-time (or in micro-batches),
-cold start matters, and the response payload usually isn’t a COG written to S3
-but a small JSON encoding the result. LitServe is well-suited because its
-decode/predict/encode split lines up exactly with read → operator-graph →
-serialise.
+**The setting.** The model needs to ship as an HTTP service, with a long-lived process that holds the GPU and serves request/response over JSON. The shape is distinct from batch ETL because: requests arrive one-at-a-time (or in micro-batches), cold start matters, and the response payload usually isn’t a COG written to S3 but a small JSON encoding the result.
+LitServe is well-suited because its decode/predict/encode split lines up exactly with read → operator-graph → serialise.
 
-**Demo API.** Loads the methane attribution pipeline at startup; `predict` is a
-single Operator call.
+**Demo API.** Loads the methane attribution pipeline at startup; `predict` is a single Operator call.
 
 ```python
 import litserve as ls
@@ -345,24 +310,17 @@ operators:
     on_fail: warn
 ```
 
-**Tradeoffs.** Including `config_hash` in every response is cheap insurance —
-clients can detect “the model changed under me” without out-of-band coordination.
-Cold start is dominated by `setup()`: keep heavy state (model weights,
-calibration tables, target spectra) in long-lived attributes, never construct
-them per `predict()`. Batch dynamically (LitServe’s `max_batch_size`) only if the
-underlying model genuinely benefits — geospatial Operators often don’t, since the
-chip-size dimension already saturates the GPU.
+**Tradeoffs.** Including `config_hash` in every response is cheap insurance — clients can detect “the model changed under me” without out-of-band coordination.
+Cold start is dominated by `setup()`: keep heavy state (model weights, calibration tables, target spectra) in long-lived attributes, never construct them per `predict()`.
+Batch dynamically (LitServe’s `max_batch_size`) only if the underlying model genuinely benefits — geospatial Operators often don’t, since the chip-size dimension already saturates the GPU.
 
 -----
 
 ## 5. Backend API (FastAPI, multi-pipeline)
 
-**The setting.** A platform team running many models (different sensors,
-different products, different pipeline versions) wants **one** service that hosts
-them all. The pipeline registry pattern: load every pipeline at startup, route
-based on URL path. Compared to LitServe (one model, one process), this trades
-GPU pinning for flexibility — an operations team can roll out a new pipeline by
-adding a YAML entry and restarting.
+**The setting.** A platform team running many models (different sensors, different products, different pipeline versions) wants **one** service that hosts them all.
+The pipeline registry pattern: load every pipeline at startup, route based on URL path.
+Compared to LitServe (one model, one process), this trades GPU pinning for flexibility — an operations team can roll out a new pipeline by adding a YAML entry and restarting.
 
 **Demo API.**
 
@@ -407,30 +365,22 @@ def list_pipelines():
     return {name: pipe.config_hash() for name, pipe in PIPELINES.items()}
 ```
 
-The `/pipelines/{name}` endpoint matters more than people think — `get_config()`
-lets the API describe its own behaviour to clients without out-of-band docs. The
-`/pipelines` listing with hashes lets monitoring detect drift between deployments.
+The `/pipelines/{name}` endpoint matters more than people think — `get_config()` lets the API describe its own behaviour to clients without out-of-band docs.
+The `/pipelines` listing with hashes lets monitoring detect drift between deployments.
 
-**Tradeoffs.** Loading every pipeline at startup grows memory linearly in the
-number of registered pipelines — fine for a few dozen, painful at hundreds.
-Above that scale, lazy-load on first request and cache. Hot reload (swap a YAML
-without restart) sounds attractive but interacts badly with in-flight requests
-holding references to the old graph; safer to require a process restart and let
-the load balancer drain.
+**Tradeoffs.** Loading every pipeline at startup grows memory linearly in the number of registered pipelines — fine for a few dozen, painful at hundreds.
+Above that scale, lazy-load on first request and cache.
+Hot reload (swap a YAML without restart) sounds attractive but interacts badly with in-flight requests holding references to the old graph; safer to require a process restart and let the load balancer drain.
 
 -----
 
 ## 6. User-uploaded pipelines for viz
 
-**The setting.** The democratisation case. A scientist or analyst — not
-necessarily a Python engineer — wants to compose a pipeline from a UI, see the
-result on a map, and share the recipe with collaborators. Letting a user submit
-YAML *as a request* is a natural mapping, but it bites the moment you call
-`hydra.utils.instantiate()` on untrusted input: a malicious payload like
-`_target_: os.system, args: ["rm -rf /"]` is arbitrary code execution.
+**The setting.** The democratisation case.
+A scientist or analyst — not necessarily a Python engineer — wants to compose a pipeline from a UI, see the result on a map, and share the recipe with collaborators.
+Letting a user submit YAML *as a request* is a natural mapping, but it bites the moment you call `hydra.utils.instantiate()` on untrusted input: a malicious payload like `_target_: os.system, args: ["rm -rf /"]` is arbitrary code execution.
 
-**The fix** is a sandboxed loader that walks the config tree and rejects any
-`_target_` not in a pre-vetted public registry of Operators.
+**The fix** is a sandboxed loader that walks the config tree and rejects any `_target_` not in a pre-vetted public registry of Operators.
 
 ```python
 # In geotoolz.serialization
@@ -469,29 +419,20 @@ if st.button("Run"):
         st.json(pipe.get_config())  # show what the user actually ran
 ```
 
-**Tradeoffs.** The sandbox doesn’t solve resource exhaustion — a malicious
-user can still submit a YAML that allocates huge intermediates or schedules a
-million `Sequential` steps. Time and memory limits per request are mandatory.
-The other side of the same coin: this pattern also gates *internal* contributors
-— a colleague’s experimental Operator can’t run in the demo until it lands in
-the registry, which is a feature for governance and a friction point for
-researchers. The right balance is a fast registry-promotion process, not a
-permissive sandbox.
+**Tradeoffs.** The sandbox doesn’t solve resource exhaustion — a malicious user can still submit a YAML that allocates huge intermediates or schedules a million `Sequential` steps.
+Time and memory limits per request are mandatory.
+The other side of the same coin: this pattern also gates *internal* contributors — a colleague’s experimental Operator can’t run in the demo until it lands in the registry, which is a feature for governance and a friction point for researchers.
+The right balance is a fast registry-promotion process, not a permissive sandbox.
 
 -----
 
 ## 7. Tile server (z/x/y → PNG)
 
-**The setting.** Slippy-map UX — a user pans a Leaflet/Mapbox view of their
-data, the browser issues XYZ tile requests, the server renders each tile on
-demand. This is *distinct* from a generic backend API because the request shape
-and latency budget are different: every request is `(z, x, y, layer)`, the
-response is a 256×256 PNG, p99 must be sub-second, and a single map view fans
-out to dozens of concurrent requests. The operator graph here is **the rendering
-pipeline** — read pixels → process → colormap → encode.
+**The setting.** Slippy-map UX — a user pans a Leaflet/Mapbox view of their data, the browser issues XYZ tile requests, the server renders each tile on demand.
+This is *distinct* from a generic backend API because the request shape and latency budget are different: every request is `(z, x, y, layer)`, the response is a 256×256 PNG, p99 must be sub-second, and a single map view fans out to dozens of concurrent requests.
+The operator graph here is **the rendering pipeline** — read pixels → process → colormap → encode.
 
-**Demo API.** Layer registry lives in a YAML so layers can be added without
-code changes.
+**Demo API.** Layer registry lives in a YAML so layers can be added without code changes.
 
 ```python
 from fastapi import FastAPI, Response
@@ -558,9 +499,8 @@ scl_class:
 ```
 
 
-**Implementation sketch.** Operators in this hot loop run ~10⁴ times per minute,
-so per-call construction work is the enemy. `Colormap` should load its LUT
-*once* in `__init__`:
+**Implementation sketch.** Operators in this hot loop run ~10⁴ times per minute, so per-call construction work is the enemy.
+`Colormap` should load its LUT *once* in `__init__`:
 
 ```python
 class Colormap(Operator):
@@ -576,25 +516,17 @@ class Colormap(Operator):
         return GeoTensor(values=rgba, transform=gt.transform, crs=gt.crs)
 ```
 
-**Tradeoffs.** A tile cache (Redis, CloudFront, on-disk) usually matters more
-than Python-level performance — the same tile gets requested by every user
-panning the same area. With caching, the operator graph runs once per distinct
-tile and the API mostly serves bytes. Without caching, every operator’s
-hot-path performance is exposed. Stateful operators (e.g. learned percentile
-clip) need careful handling here: the state must be loaded once at startup,
-not per-request.
+**Tradeoffs.** A tile cache (Redis, CloudFront, on-disk) usually matters more than Python-level performance — the same tile gets requested by every user panning the same area.
+With caching, the operator graph runs once per distinct tile and the API mostly serves bytes.
+Without caching, every operator’s hot-path performance is exposed.
+Stateful operators (e.g. learned percentile clip) need careful handling here: the state must be loaded once at startup, not per-request.
 
 -----
 
 ## 8. Data validation / QC as operators
 
-**The setting.** Data goes wrong in predictable ways — wrong CRS, wrong
-resolution, missing bands, all-NaN scenes from a failed download. Catching these
-at the right pipeline stage is the difference between “model trained on garbage
-for a week” and “pipeline halted on the first bad scene.” The library
-contribution is making **assertions look like operators**: pass-through
-Operators that raise (or warn) on contract violations, droppable anywhere in
-the chain.
+**The setting.** Data goes wrong in predictable ways — wrong CRS, wrong resolution, missing bands, all-NaN scenes from a failed download.
+Catching these at the right pipeline stage is the difference between “model trained on garbage for a week” and “pipeline halted on the first bad scene.” The library contribution is making **assertions look like operators**: pass-through Operators that raise (or warn) on contract violations, droppable anywhere in the chain.
 
 **Demo API.**
 
@@ -640,28 +572,21 @@ class AssertValueRange(Operator):
         return gt  # passes through unchanged
 ```
 
-The bigger pattern: every QC check is a research-time *“I bet this won’t break”*
-turned into a permanent runtime guard. CI gets a pipeline-correctness suite for
-free, and pipelines self-document their preconditions.
+The bigger pattern: every QC check is a research-time *“I bet this won’t break”* turned into a permanent runtime guard.
+CI gets a pipeline-correctness suite for free, and pipelines self-document their preconditions.
 
 **Tradeoffs.** Where a QC step fires (raise vs warn) is a per-deployment policy.
-A research notebook wants `on_fail="warn"` so exploration isn’t interrupted; a
-production ETL wants `on_fail="raise"` plus alerting. The same YAML can ship
-with `on_fail="${qc_policy}"` and let the loader inject the right value. The
-performance cost is real — full-array reductions (`nanmin`, `nanmax`) on large
-GeoTensors aren’t free. For tile-server hot paths, sample a small fraction of
-pixels rather than the full array.
+A research notebook wants `on_fail="warn"` so exploration isn’t interrupted; a production ETL wants `on_fail="raise"` plus alerting.
+The same YAML can ship with `on_fail="${qc_policy}"` and let the loader inject the right value.
+The performance cost is real — full-array reductions (`nanmin`, `nanmax`) on large GeoTensors aren’t free.
+For tile-server hot paths, sample a small fraction of pixels rather than the full array.
 
 -----
 
 ## 9. Pinned / hashed regulatory artifact
 
-**The setting.** A scientific paper, a regulatory submission, or an attribution
-claim from MARS-style operational monitoring needs to be **byte-exact
-reproducible** years later. “Re-run the pipeline” requires three things to be
-pinned together: the operator graph, the inputs (with content hashes, not just
-URIs), and the dependency stack (Python and binary). Treat the operator graph
-as **the deliverable**, not just a way to compute one.
+**The setting.** A scientific paper, a regulatory submission, or an attribution claim from MARS-style operational monitoring needs to be **byte-exact reproducible** years later. “Re-run the pipeline” requires three things to be pinned together: the operator graph, the inputs (with content hashes, not just URIs), and the dependency stack (Python and binary).
+Treat the operator graph as **the deliverable**, not just a way to compute one.
 
 **Demo API.**
 
@@ -692,8 +617,7 @@ print(art.config_yaml)        # human-readable
 result = art.rerun()           # bit-exact — *if* deps reproduce
 ```
 
-**Implementation sketch.** The artifact is a tarball of `(pipeline_yaml, config_hash, input_hashes, deps_lock, metadata.json)` — small, archivable,
-diffable across versions.
+**Implementation sketch.** The artifact is a tarball of `(pipeline_yaml, config_hash, input_hashes, deps_lock, metadata.json)` — small, archivable, diffable across versions.
 
 ```python
 class Artifact:
@@ -716,25 +640,19 @@ class Artifact:
         )
 ```
 
-**Tradeoffs.** A `poetry.lock` alone is not enough for true byte-exactness —
-BLAS implementations, GPU drivers, libc versions, even the order in which
-floating-point reductions are evaluated all affect numerical output. Honest
-framing: the artifact *guarantees* the operator graph and inputs; it *aspires
-to* numerical reproducibility, with the deps_lock as a best-effort. For
-genuine bit-exactness, ship a Docker image hash alongside the artifact.
-External URIs decay over years; for true long-term archive, the artifact
-should optionally include the *bytes* of small inputs, not just their hashes.
+**Tradeoffs.** A `poetry.lock` alone is not enough for true byte-exactness — BLAS implementations, GPU drivers, libc versions, even the order in which floating-point reductions are evaluated all affect numerical output.
+Honest framing: the artifact *guarantees* the operator graph and inputs; it *aspires to* numerical reproducibility, with the deps_lock as a best-effort.
+For genuine bit-exactness, ship a Docker image hash alongside the artifact.
+External URIs decay over years; for true long-term archive, the artifact should optionally include the *bytes* of small inputs, not just their hashes.
 
 -----
 
 ## 10. Active learning / uncertainty-driven sampling
 
-**The setting.** Labels are expensive (an expert annotator costs more than a
-GPU-hour). The classic active-learning loop: train a model, score the
-unlabeled pool by uncertainty, send the highest-uncertainty examples for
-labelling, retrain. The library contribution: a sampler that **consumes
-operator output** to decide what to sample next. Same composition primitives,
-but the iterator is now informed by inference.
+**The setting.** Labels are expensive (an expert annotator costs more than a GPU-hour).
+The classic active-learning loop: train a model, score the unlabeled pool by uncertainty, send the highest-uncertainty examples for labelling, retrain.
+The library contribution: a sampler that **consumes operator output** to decide what to sample next.
+Same composition primitives, but the iterator is now informed by inference.
 
 **Demo API.**
 
@@ -782,27 +700,18 @@ class ActiveSampler:
             yield sl
 ```
 
-**Tradeoffs.** The dirty secret of active learning: **scoring is itself
-expensive** — you’re running model inference over the entire unlabeled pool
-just to pick the next batch. For large catalogs this dominates the labelling
-budget you were trying to save. Mitigations: random sub-sampling before scoring
-(score 10% of the pool, label the top 1%), or tiered scoring (cheap heuristic
-filters first, expensive model second). Pure top-k by uncertainty also
-under-explores — pair with a `mode="diverse"` option that uses a clustering
-step on chip embeddings before picking, to avoid a top-100 that’s all one
-land-cover type.
+**Tradeoffs.** The dirty secret of active learning: **scoring is itself expensive** — you’re running model inference over the entire unlabeled pool just to pick the next batch. For large catalogs this dominates the labelling budget you were trying to save.
+Mitigations: random sub-sampling before scoring (score 10% of the pool, label the top 1%), or tiered scoring (cheap heuristic filters first, expensive model second).
+Pure top-k by uncertainty also under-explores — pair with a `mode="diverse"` option that uses a clustering step on chip embeddings before picking, to avoid a top-100 that’s all one land-cover type.
 
 -----
 
 ## 11. Cross-sensor fusion (the `Graph` case)
 
-**The setting.** Combining modalities — radar with optical, optical with DEM,
-optical with weather reanalysis. Each input has different spatial extent,
-resolution, CRS, and acquisition time, and the fusion rule isn’t a single
-linear chain. This is where `Sequential` runs out and `Graph` earns its keep.
-The user is an applied scientist building a multi-modal classifier; the value
-is *expressing the DAG declaratively* instead of as a tangle of intermediate
-variables.
+**The setting.** Combining modalities — radar with optical, optical with DEM, optical with weather reanalysis.
+Each input has different spatial extent, resolution, CRS, and acquisition time, and the fusion rule isn’t a single linear chain.
+This is where `Sequential` runs out and `Graph` earns its keep.
+The user is an applied scientist building a multi-modal classifier; the value is *expressing the DAG declaratively* instead of as a tangle of intermediate variables.
 
 **Demo API.**
 
@@ -830,32 +739,22 @@ out = g(optical=s2_gt, sar=s1_gt, dem=dem_gt)
 # out["crop_map"] and out["fused_stack"] are both GeoTensors
 ```
 
-The same `Graph` can serialise to YAML and run in any deployment shape from the
-preceding cases — backend API endpoint, scheduled job, notebook session.
-Multi-output graphs are particularly useful for downstream debugging: ship the
-intermediate `fused_stack` alongside the final classification so consumers can
-audit it.
+The same `Graph` can serialise to YAML and run in any deployment shape from the preceding cases — backend API endpoint, scheduled job, notebook session.
+Multi-output graphs are particularly useful for downstream debugging: ship the intermediate `fused_stack` alongside the final classification so consumers can audit it.
 
-**Tradeoffs.** `AlignAndStack` is the load-bearing operator and the place
-fusion pipelines silently fail — picking which input defines the target grid
-(`target_grid="optical"`) discards information from the other inputs (SAR
-gets resampled to the optical grid, losing the SAR’s native resolution). For
-some workflows that’s exactly right; for others (super-resolution from SAR
-to optical, for example) the choice is wrong. Make the choice explicit and
-test it. Multi-input arity also complicates Operator validation — a `Graph`
-with a missing input fails at runtime, not construction time, unless you add
-explicit input-presence checks.
+**Tradeoffs.** `AlignAndStack` is the load-bearing operator and the place fusion pipelines silently fail — picking which input defines the target grid (`target_grid="optical"`) discards information from the other inputs (SAR gets resampled to the optical grid, losing the SAR’s native resolution).
+For some workflows that’s exactly right; for others (super-resolution from SAR to optical, for example) the choice is wrong.
+Make the choice explicit and test it.
+Multi-input arity also complicates Operator validation — a `Graph` with a missing input fails at runtime, not construction time, unless you add explicit input-presence checks.
 
 -----
 
 ## 12. Workflow orchestrator task units
 
-**The setting.** Production scheduling — Airflow, Prefect, Dagster. The
-orchestrator owns retry, parallelism, monitoring, alerting, and DAG topology;
-the operator graph owns the science. The interface between them is small:
-**pickleable task units** that the orchestrator can submit to workers. An
-Operator graph already is one — you just need a thin task wrapper that
-reconstructs it from a YAML path on the worker side.
+**The setting.** Production scheduling — Airflow, Prefect, Dagster.
+The orchestrator owns retry, parallelism, monitoring, alerting, and DAG topology; the operator graph owns the science.
+The interface between them is small: **pickleable task units** that the orchestrator can submit to workers.
+An Operator graph already is one — you just need a thin task wrapper that reconstructs it from a YAML path on the worker side.
 
 **Demo API** (Prefect):
 
@@ -885,29 +784,20 @@ def daily_methane_flow(date: str):
     return [f.result() for f in futures]
 ```
 
-The Operator stays a serialisable YAML artifact; the orchestrator owns retry,
-parallelism, monitoring. Clean separation between *what to compute* and *how to
-schedule it*.
+The Operator stays a serialisable YAML artifact; the orchestrator owns retry, parallelism, monitoring.
+Clean separation between *what to compute* and *how to schedule it*.
 
-**Tradeoffs.** Pickling crosses worker boundaries, so the same constraints as
-case 2 apply — no closures, no captured RNGs, no unbounded factories. Retries
-need to be **idempotent**: if `run_op` is retried, the output COG path is the
-same and is overwritten, not duplicated. State that lives outside the operator
-graph (database writes, message queues) is the orchestrator’s problem — don’t
-bake side effects into Operators. Alerting on failure rate (rather than first
-failure) is appropriate at the orchestrator layer; an operator-level
-`on_fail="raise"` would defeat that.
+**Tradeoffs.** Pickling crosses worker boundaries, so the same constraints as case 2 apply — no closures, no captured RNGs, no unbounded factories.
+Retries need to be **idempotent**: if `run_op` is retried, the output COG path is the same and is overwritten, not duplicated.
+State that lives outside the operator graph (database writes, message queues) is the orchestrator’s problem — don’t bake side effects into Operators.
+Alerting on failure rate (rather than first failure) is appropriate at the orchestrator layer; an operator-level `on_fail="raise"` would defeat that.
 
 -----
 
 ## 13. Pipeline diffing / A-B regression
 
-**The setting.** You’re about to roll out a new version of a production
-pipeline — a tweaked atmospheric correction, a new cloud-mask threshold, a
-calibration update. The release-management question: *did anything regress
-that I didn’t intend?* Because operator graphs serialise, you can both **diff**
-them (config-level) and **run them side-by-side** on the same input
-(numerical-level).
+**The setting.** You’re about to roll out a new version of a production pipeline — a tweaked atmospheric correction, a new cloud-mask threshold, a calibration update.
+The release-management question: *did anything regress that I didn’t intend?* Because operator graphs serialise, you can both **diff** them (config-level) and **run them side-by-side** on the same input (numerical-level).
 
 **Demo API.**
 
@@ -982,41 +872,28 @@ class AB:
         return ABReport(rows)
 ```
 
-**Tradeoffs.** Mean RMSE alone can hide bimodal regressions — most slices fine,
-a few catastrophically worse. Always look at per-tile distributions and the
-worst-N tiles, not just aggregate stats. Choosing the metric is itself a
-design decision: RMSE is wrong for probability outputs (use cross-entropy or
-KL), wrong for hard classifications (use confusion-matrix shifts). The
-`config_diff` is human-readable but doesn’t capture *semantic* difference — a
-parameter rename that’s mathematically equivalent shows up as a diff anyway.
+**Tradeoffs.** Mean RMSE alone can hide bimodal regressions — most slices fine, a few catastrophically worse.
+Always look at per-tile distributions and the worst-N tiles, not just aggregate stats.
+Choosing the metric is itself a design decision: RMSE is wrong for probability outputs (use cross-entropy or KL), wrong for hard classifications (use confusion-matrix shifts).
+The `config_diff` is human-readable but doesn’t capture *semantic* difference — a parameter rename that’s mathematically equivalent shows up as a diff anyway.
 Pair config-level diffing with numerical AB testing, and trust the numerics.
 
 -----
 
 ## Cases considered but not expanded
 
-A few patterns came up but didn’t earn a full section either because they’re
-covered elsewhere or because they’re explicitly out of scope:
+A few patterns came up but didn’t earn a full section either because they’re covered elsewhere or because they’re explicitly out of scope:
 
-- **Foundation-model embedding stores.** Same shape as
-  [#10](#10-active-learning--uncertainty-driven-sampling), but the operator output
-  is a dense vector you write to a vector DB. See Example O in the
-  [GeoCatalog Phase 1 doc](https://jejjohnson.github.io/research_notebook/geocatalog).
-- **Differentiable / JAX path.** The “future work” case — same Operator
-  surface, but `_apply` becomes JAX-traceable. Worth mocking up once `coordax`
-  integration matures.
-- **Streaming (Flink / Beam).** Explicitly out-of-scope per the
-  [`geotoolz.md`](https://jejjohnson.github.io/research_notebook/geotoolz)
-  honest-scope section. Each Operator could be wrapped as a Flink UDF, but
-  composition guarantees would be lost.
-- **Edge / mobile inference.** `ModelOp` ships the model, not the surrounding
-  pre/post-processing operators. Out of scope for the operator-graph
-  abstraction.
+- **Foundation-model embedding stores.** Same shape as [#10](#10-active-learning--uncertainty-driven-sampling), but the operator output is a dense vector you write to a vector DB. See Example O in the [GeoCatalog Phase 1 doc](https://jejjohnson.github.io/research_notebook/geocatalog).
+- **Differentiable / JAX path.** The “future work” case — same Operator surface, but `_apply` becomes JAX-traceable.
+  Worth mocking up once `coordax` integration matures.
+- **Streaming (Flink / Beam).** Explicitly out-of-scope per the [`geotoolz.md`](https://jejjohnson.github.io/research_notebook/geotoolz) honest-scope section.
+  Each Operator could be wrapped as a Flink UDF, but composition guarantees would be lost.
+- **Edge / mobile inference.** `ModelOp` ships the model, not the surrounding pre/post-processing operators.
+  Out of scope for the operator-graph abstraction.
 
 ## The pattern
 
-The operator graph is useful **wherever you’d otherwise hand-roll glue between
-input → transform → output**. What changes between cases is *who drives*: a
-notebook user, an HTTP request, a scheduler, a sampler, a tile renderer, or
-another graph. The library’s job is to keep the graph itself a stable artefact
-across all of them — written once, audited once, run anywhere.
+The operator graph is useful **wherever you’d otherwise hand-roll glue between input → transform → output**.
+What changes between cases is *who drives*: a notebook user, an HTTP request, a scheduler, a sampler, a tile renderer, or another graph.
+The library’s job is to keep the graph itself a stable artefact across all of them — written once, audited once, run anywhere.

--- a/projects/geotoolz/plans/geotoolz/geotoolz.md
+++ b/projects/geotoolz/plans/geotoolz/geotoolz.md
@@ -15,9 +15,11 @@ license: CC-BY-4.0
 keywords: design, geotoolz, operators, remote-sensing
 ---
 
-> **Scope:** a composable Operator library for remote sensing — preprocess, infer, and evaluate satellite imagery on top of `georeader.GeoTensor`. Sibling to `xr_toolz`, targeted at a different community and a different substrate. Functions, classes, and presets, all RS-shaped.
->
-> **Status:** design proposal. Assumes `georeader` 2.0 (the `np.ndarray`-subclass `GeoTensor` with `__array_ufunc__`) exists as today. Borrows architectural patterns from `xr_toolz` but re-implements the composition core to avoid coordination tax.
+> **Scope:** a composable Operator library for remote sensing — preprocess, infer, and evaluate satellite imagery on top of `georeader.GeoTensor`.
+> Sibling to `xr_toolz`, targeted at a different community and a different substrate.
+> Functions, classes, and presets, all RS-shaped.
+> **Status:** design proposal. Assumes `georeader` 2.0 (the `np.ndarray`-subclass `GeoTensor` with `__array_ufunc__`) exists as today.
+> Borrows architectural patterns from `xr_toolz` but re-implements the composition core to avoid coordination tax.
 
 ---
 
@@ -38,36 +40,56 @@ keywords: design, geotoolz, operators, remote-sensing
 
 ## 1. Inventory: what `geotoolz` is
 
-A composable Operator library targeted at remote sensing. Sibling to `xr_toolz` at the architectural level; orthogonal at the substrate level.
+A composable Operator library targeted at remote sensing.
+Sibling to `xr_toolz` at the architectural level; orthogonal at the substrate level.
 
 ### 1.1 The two-tier model
 
-`geotoolz` ships **two tiers**, where `xr_toolz` ships three. The collapse is possible because `GeoTensor` is an `np.ndarray` *subclass* with `__array_ufunc__` / `__array_finalize__` — it transparently carries metadata through ufuncs, slicing, copies, and views. The intermediate "tensor function" tier `xr_toolz` needs (because `xarray.DataArray` is *composition* over an ndarray, not a subclass) collapses into the Array tier here.
+`geotoolz` ships **two tiers**, where `xr_toolz` ships three.
+The collapse is possible because `GeoTensor` is an `np.ndarray` *subclass* with `__array_ufunc__` / `__array_finalize__` — it transparently carries metadata through ufuncs, slicing, copies, and views.
+The intermediate "tensor function" tier `xr_toolz` needs (because `xarray.DataArray` is *composition* over an ndarray, not a subclass) collapses into the Array tier here.
 
 | Tier | Location | Input | Output | Coordinate semantics |
 | --- | --- | --- | --- | --- |
 | **A — Array (primitive)** | `geotoolz.<module>._src.array` | `Float[ndarray, "..."]` (jaxtyped) | `Float[ndarray, "..."]` | `axis=` |
 | **B — Operator** | `geotoolz.<module>` (public) | `GeoTensor` (or two for multi-input) | `GeoTensor` / scalar / `Figure` | constructor `axis=` / `band=` |
 
-**Tier A — primitives.** Pure `np.ndarray → np.ndarray` functions, jaxtyped at the signature so callers see `Float[ndarray, "*batch bands H W"]`. Ufunc-pure where possible; for non-ufunc upstream calls (`skimage`, `scipy.ndimage`, `sklearn`) primitives return a plain `ndarray` — **no subclass dance inside the primitive**. Semi-public: importable, jaxtyped, documented, but the canonical user-facing surface is the Operator.
+**Tier A — primitives.** Pure `np.ndarray → np.ndarray` functions, jaxtyped at the signature so callers see `Float[ndarray, "*batch bands H W"]`.
+Ufunc-pure where possible; for non-ufunc upstream calls (`skimage`, `scipy.ndimage`, `sklearn`) primitives return a plain `ndarray` — **no subclass dance inside the primitive**.
+Semi-public: importable, jaxtyped, documented, but the canonical user-facing surface is the Operator.
 
-**Tier B — Operators.** The carrier-aware boundary. There are **three cases** an Operator's `_apply` may need to handle, and each has a distinct pattern:
+**Tier B — Operators.** The carrier-aware boundary.
+There are **three cases** an Operator's `_apply` may need to handle, and each has a distinct pattern:
 
-1. **Shape-preserving + ufunc-pure** (e.g. `NDVI`, `Mask`, arithmetic, slicing): delegate straight to the primitive. `__array_ufunc__` round-trips the metadata automatically — `_apply` is one line.
-2. **Shape-preserving + non-ufunc** (e.g. `LeeSpeckle` via `scipy.ndimage`, `MaskFromQABits` via boolean ops, classification via `sklearn.predict`): strip → run → re-wrap. `out = primitive(np.asarray(gt)); return gt._wrap(out)`. One line of dance per Operator that needs it.
-3. **Shape- or metadata-changing** (`Resize`, `Regrid`, `Pansharpen`, multi-input fusion across CRSs, dim-reducing ops like `MeanComposite`): the primitive returns a plain `ndarray` and the Operator **constructs a fresh `GeoTensor`** with a *new* `transform` / `crs` / `dims`. `_wrap` does **not** apply — `_wrap` preserves metadata, but the metadata is precisely what changes here. Use `georeader`'s `GeoTensor` constructor directly.
+1. **Shape-preserving + ufunc-pure** (e.g. `NDVI`, `Mask`, arithmetic, slicing): delegate straight to the primitive.
+   `__array_ufunc__` round-trips the metadata automatically — `_apply` is one line.
+2. **Shape-preserving + non-ufunc** (e.g. `LeeSpeckle` via `scipy.ndimage`, `MaskFromQABits` via boolean ops, classification via `sklearn.predict`): strip → run → re-wrap.
+   `out = primitive(np.asarray(gt)); return gt._wrap(out)`.
+   One line of dance per Operator that needs it.
+3. **Shape- or metadata-changing** (`Resize`, `Regrid`, `Pansharpen`, multi-input fusion across CRSs, dim-reducing ops like `MeanComposite`): the primitive returns a plain `ndarray` and the Operator **constructs a fresh `GeoTensor`** with a *new* `transform` / `crs` / `dims`.
+   `_wrap` does **not** apply — `_wrap` preserves metadata, but the metadata is precisely what changes here.
+   Use `georeader`'s `GeoTensor` constructor directly.
 
-Operators carry config (Hydra-friendly) and compose via `Sequential` and `Graph`. The three cases are not exotic edge cases — Case 3 covers most of `compositing`, `pansharpen`, `sampling`, and any reprojection-flavoured op. Treat all three as first-class patterns from day one.
+Operators carry config (Hydra-friendly) and compose via `Sequential` and `Graph`.
+The three cases are not exotic edge cases — Case 3 covers most of `compositing`, `pansharpen`, `sampling`, and any reprojection-flavoured op.
+Treat all three as first-class patterns from day one.
 
-**Why two tiers, not three.** `xr_toolz` has a middle "tensor function" tier because lifting `DataArray ↔ ndarray` is real work (extract `.values`, run, re-attach `.coords` / `.dims`). For `GeoTensor` that work collapses to `gt._wrap(out)` — one line at the Operator boundary. A dedicated tier-of-functions for that one line would be ceremony without value.
+**Why two tiers, not three.** `xr_toolz` has a middle "tensor function" tier because lifting `DataArray ↔ ndarray` is real work (extract `.values`, run, re-attach `.coords` / `.dims`).
+For `GeoTensor` that work collapses to `gt._wrap(out)` — one line at the Operator boundary.
+A dedicated tier-of-functions for that one line would be ceremony without value.
 
-**What jaxtyping does (and doesn't) buy us.** Tier A's `Float[ndarray, "..."]` annotations communicate *shape contracts* — IDE-visible, optional runtime-checkable, lower barrier than typing every primitive against `GeoTensor`. They do **not** communicate georef-awareness. The Operator type signature (`GeoTensor → GeoTensor`) remains the canonical place where georef-awareness is asserted. Primitives are "discipline plus jaxtyping"; Operators are "the typed contract".
+**What jaxtyping does (and doesn't) buy us.** Tier A's `Float[ndarray, "..."]` annotations communicate *shape contracts* — IDE-visible, optional runtime-checkable, lower barrier than typing every primitive against `GeoTensor`.
+They do **not** communicate georef-awareness.
+The Operator type signature (`GeoTensor → GeoTensor`) remains the canonical place where georef-awareness is asserted.
+Primitives are "discipline plus jaxtyping"; Operators are "the typed contract".
 
-**Tests.** Tier A for analytic ground truth (math is right on numpy arrays, shapes match jaxtyping); Tier B for config round-trip + GeoTensor metadata propagation. No middle tier means no third place to test.
+**Tests.** Tier A for analytic ground truth (math is right on numpy arrays, shapes match jaxtyping); Tier B for config round-trip + GeoTensor metadata propagation.
+No middle tier means no third place to test.
 
 ### 1.2 Module surface
 
-Twelve modules, organised by RS workflow stage. Roughly 80 Operators in steady state; v0.1 ships ~25 (the asterisks below).
+Twelve modules, organised by RS workflow stage.
+Roughly 80 Operators in steady state; v0.1 ships ~25 (the asterisks below).
 
 | Group | Module | Operators |
 | --- | --- | --- |
@@ -90,11 +112,20 @@ Twelve modules, organised by RS workflow stage. Roughly 80 Operators in steady s
 
 ### 1.3 What it explicitly is *not*
 
-- **Not `xr_toolz`.** Different substrate (`GeoTensor` vs `xr.Dataset`). Different audience. Same architectural patterns, separately implemented.
-- **Not `georeader`.** No I/O, no CRS plumbing, no reader classes, no catalog construction. Those are `georeader`'s job. `geotoolz` consumes `GeoTensor`s and produces `GeoTensor`s.
-- **Not a numpy primitives library.** Tier A primitives live inside `_src/array.py` per module — semi-public (importable, jaxtyped, documented), but the **canonical** surface is the Operator. `from geotoolz.indices._src.array import ndvi` works for users who want pure-numpy + jaxtyping; `gz.indices.NDVI(...)(gt)` is what most users will write. Primitives are "discipline + shape contracts"; Operators are "the typed georef-aware contract".
-- **Not framework-coupled.** `ModelOp` doesn't import torch / JAX / sklearn — it duck-types via `getattr(model, "predict")` or `model(arr)`. Optional `[ml]` extra for torch/sklearn presets if needed.
-- **Not a kitchen sink.** Curated. RS-shaped. Sensor presets are pinned to product versions to bound the maintenance surface.
+- **Not `xr_toolz`.** Different substrate (`GeoTensor` vs `xr.Dataset`).
+  Different audience.
+  Same architectural patterns, separately implemented.
+- **Not `georeader`.** No I/O, no CRS plumbing, no reader classes, no catalog construction.
+  Those are `georeader`'s job.
+  `geotoolz` consumes `GeoTensor`s and produces `GeoTensor`s.
+- **Not a numpy primitives library.** Tier A primitives live inside `_src/array.py` per module — semi-public (importable, jaxtyped, documented), but the **canonical** surface is the Operator.
+  `from geotoolz.indices._src.array import ndvi` works for users who want pure-numpy + jaxtyping; `gz.indices.NDVI(...)(gt)` is what most users will write.
+  Primitives are "discipline + shape contracts"; Operators are "the typed georef-aware contract".
+- **Not framework-coupled.** `ModelOp` doesn't import torch / JAX / sklearn — it duck-types via `getattr(model, "predict")` or `model(arr)`.
+  Optional `[ml]` extra for torch/sklearn presets if needed.
+- **Not a kitchen sink.** Curated.
+  RS-shaped.
+  Sensor presets are pinned to product versions to bound the maintenance surface.
 
 ---
 
@@ -102,10 +133,14 @@ Twelve modules, organised by RS workflow stage. Roughly 80 Operators in steady s
 
 **Personas:**
 
-1. **The RS researcher** wants "load S2 → mask clouds → atmospheric correct → NDVI → save COG" as one composable pipeline. Today they write 40 lines of glue code per analysis.
-2. **The ML engineer** wants tiled inference: chip a scene, run a model on each chip, stitch back, save a georeferenced output. Today they write a custom dataloader + inference loop per project.
-3. **The hyperspectral retrieval scientist** wants a matched filter operator that takes a target spectrum and a hyperspectral `GeoTensor`. Today they copy code from a paper supplement.
-4. **The Hydra-driven pipeline author** wants to declare the whole workflow in YAML and have it reproducibly run. Today they hand-roll a class registry per project.
+1. **The RS researcher** wants "load S2 → mask clouds → atmospheric correct → NDVI → save COG" as one composable pipeline.
+   Today they write 40 lines of glue code per analysis.
+2. **The ML engineer** wants tiled inference: chip a scene, run a model on each chip, stitch back, save a georeferenced output.
+   Today they write a custom dataloader + inference loop per project.
+3. **The hyperspectral retrieval scientist** wants a matched filter operator that takes a target spectrum and a hyperspectral `GeoTensor`.
+   Today they copy code from a paper supplement.
+4. **The Hydra-driven pipeline author** wants to declare the whole workflow in YAML and have it reproducibly run.
+   Today they hand-roll a class registry per project.
 5. **The "I just want to make a quick figure" user** wants `S2_L2A_RGB(brightness=2.0)(gt)` and gets a sensible RGB visualisation in three tokens.
 
 **Goal arc:**
@@ -158,7 +193,8 @@ The unifying line: **every RS workflow is a `Sequential` of operators, declared 
 
 ### 3.2 Why re-implement the composition core
 
-`Operator`, `Sequential`, `Graph`, `Input`, `Node`, `ModelOp` are ~300 LOC total. Sharing them through a third package costs a release process, a coordination tax, and a temptation to add features for one library that the other doesn't want. **Re-implementing is cheaper and freer.**
+`Operator`, `Sequential`, `Graph`, `Input`, `Node`, `ModelOp` are ~300 LOC total. Sharing them through a third package costs a release process, a coordination tax, and a temptation to add features for one library that the other doesn't want.
+**Re-implementing is cheaper and freer.**
 
 What `geotoolz` will diverge on:
 
@@ -167,15 +203,21 @@ What `geotoolz` will diverge on:
 - **Multi-input arity.** RS commonly pairs imagery with masks or labels; geotoolz's Operator accepts `(image, mask)` or `(image, ref)` directly without going through Graph for this case.
 - **ModelOp batching.** geotoolz's `ModelOp` defaults to chip-batched inference; xr_toolz's defaults to dataset-flattened inference.
 
-These small differences add up. Sharing across libraries would mean both diverge from a least-common-denominator.
+These small differences add up.
+Sharing across libraries would mean both diverge from a least-common-denominator.
 
 ### 3.3 Compared with adjacent libraries
 
-- **TorchGeo.** Heavy torch dep, ML-first, `BoundingBox` query model. `geotoolz` is torch-optional and focused on Operator composition; the audiences overlap but the abstraction tier differs.
-- **xarray-spatial.** xarray-bound. NDVI etc. but no operator framework, no inference, no presets.
-- **`stackstac` / `odc-stac`.** Catalog + xarray composition. Different abstraction tier.
-- **`xr_toolz`** itself. Wrong substrate for RS workflows.
-- **plain rasterio + custom code.** What users do today. Verbose, no composition, snippet-shaped.
+- **TorchGeo.** Heavy torch dep, ML-first, `BoundingBox` query model.
+  `geotoolz` is torch-optional and focused on Operator composition; the audiences overlap but the abstraction tier differs.
+- **xarray-spatial.** xarray-bound.
+  NDVI etc. but no operator framework, no inference, no presets.
+- **`stackstac` / `odc-stac`.** Catalog + xarray composition.
+  Different abstraction tier.
+- **`xr_toolz`** itself.
+  Wrong substrate for RS workflows.
+- **plain rasterio + custom code.** What users do today.
+  Verbose, no composition, snippet-shaped.
 
 `geotoolz` slots between torchgeo and xarray-spatial: more opinionated than xarray-spatial, less framework-coupled than torchgeo.
 
@@ -214,9 +256,11 @@ class NDVI(Operator):
                 "axis": self.axis, "eps": self.eps}
 ```
 
-The Operator carries config (Hydra-friendly) and delegates straight to the primitive. **No middle tier, no logic duplicated.**
+The Operator carries config (Hydra-friendly) and delegates straight to the primitive.
+**No middle tier, no logic duplicated.**
 
-**Non-ufunc case.** Anything that calls `scipy.ndimage`, `skimage`, or `sklearn` strips the GeoTensor subclass — those upstream libraries call `np.asarray()` internally. The Operator's `_apply` is the wrap boundary:
+**Non-ufunc case.** Anything that calls `scipy.ndimage`, `skimage`, or `sklearn` strips the GeoTensor subclass — those upstream libraries call `np.asarray()` internally.
+The Operator's `_apply` is the wrap boundary:
 
 ```python
 from scipy.ndimage import uniform_filter
@@ -242,7 +286,8 @@ class LeeSpeckle(Operator):
 
 The wrap is one line, lives in exactly one place per Operator, never propagates upstream.
 
-**Shape- or metadata-changing case.** When the output's shape, transform, or CRS differs from the input — the third case from §1.1 — `_wrap` does **not** apply. The Operator constructs a fresh `GeoTensor`:
+**Shape- or metadata-changing case.** When the output's shape, transform, or CRS differs from the input — the third case from §1.1 — `_wrap` does **not** apply.
+The Operator constructs a fresh `GeoTensor`:
 
 ```python
 from skimage.transform import resize as _skimage_resize
@@ -275,9 +320,11 @@ class Resize(Operator):
     def get_config(self): return {"target_shape": self.target_shape, "order": self.order}
 ```
 
-Same shape applies to `Pansharpen` (changes spatial resolution to the pan grid), `Regrid` (changes CRS + transform), `MeanComposite` over time (drops the time axis from `dims`), and any multi-input fusion that lands on a target grid. The Operator owns the metadata construction; `georeader` provides the constructor; primitives stay numpy-typed.
+Same shape applies to `Pansharpen` (changes spatial resolution to the pan grid), `Regrid` (changes CRS + transform), `MeanComposite` over time (drops the time axis from `dims`), and any multi-input fusion that lands on a target grid.
+The Operator owns the metadata construction; `georeader` provides the constructor; primitives stay numpy-typed.
 
-**Tests.** Tier A for analytic ground truth (math is right on numpy arrays, shapes match jaxtyping). Tier B for config round-trip *and* GeoTensor metadata propagation (transform, CRS, fill_value preserved through both ufunc-pure and non-ufunc operators).
+**Tests.** Tier A for analytic ground truth (math is right on numpy arrays, shapes match jaxtyping).
+Tier B for config round-trip *and* GeoTensor metadata propagation (transform, CRS, fill_value preserved through both ufunc-pure and non-ufunc operators).
 
 ### 4.2 The dual-mode `Operator.__call__` (Graph mode)
 
@@ -294,7 +341,8 @@ class Operator:
         raise NotImplementedError
 ```
 
-Same operator works eagerly in `Sequential` and symbolically in `Graph`. No parallel hierarchy.
+Same operator works eagerly in `Sequential` and symbolically in `Graph`.
+No parallel hierarchy.
 
 ### 4.3 The split-object pattern for stateful operators (D2)
 
@@ -310,7 +358,8 @@ clip = ApplyPercentileClip(percentiles=percentiles)
 clipped = clip(gt)
 ```
 
-Every operator in a `Sequential` is `GeoTensor → GeoTensor`, always. State is an artifact, not a hidden field.
+Every operator in a `Sequential` is `GeoTensor → GeoTensor`, always.
+State is an artifact, not a hidden field.
 
 ### 4.4 Sampler stride math (carried from earlier reports)
 
@@ -321,7 +370,8 @@ n_y = \left\lceil \frac{H - h}{s_y} \right\rceil + 1, \qquad
 n_x = \left\lceil \frac{W - w}{s_x} \right\rceil + 1
 $$
 
-Final-row/column chips are shifted (not truncated) to keep chip size exact. `GridSampler` returns a sequence of slice tuples; `ApplyToChips` iterates over them, applies a chip op, hands the chip + slice to `Stitch`.
+Final-row/column chips are shifted (not truncated) to keep chip size exact.
+`GridSampler` returns a sequence of slice tuples; `ApplyToChips` iterates over them, applies a chip op, hands the chip + slice to `Stitch`.
 
 ### 4.5 Compositing reductions
 
@@ -334,7 +384,8 @@ For a stacked time series `X ∈ ℝ^(T × B × H × W)`:
 | `MaxNDVIComposite` | for each $(h,w)$: $t^* = \arg\max_t \mathrm{NDVI}(X_t)$; output $X_{t^*}$ |
 | `CloudFreeComposite` | for each $(h,w)$: most recent $t$ with `mask_t = 0` |
 
-The `valid` set is computed from a paired QA `GeoTensor` passed alongside the imagery. Multi-input Operator: `CloudFreeComposite()(imagery_gt, mask_gt)`.
+The `valid` set is computed from a paired QA `GeoTensor` passed alongside the imagery.
+Multi-input Operator: `CloudFreeComposite()(imagery_gt, mask_gt)`.
 
 ### 4.6 Matched filter (hyperspectral)
 
@@ -344,7 +395,9 @@ $$
 \mathrm{MF}(x) = \frac{(x - \mu)^\top \Sigma^{-1} t}{t^\top \Sigma^{-1} t}
 $$
 
-with `μ` = scene mean spectrum, `Σ` = scene covariance, `t` = target spectrum. Pure numpy at the array tier; one-line einsum reshape. Sibling detectors (`ACE`, `RX`) reuse the same covariance compute via the split-object pattern (compute Σ once, share across detectors).
+with `μ` = scene mean spectrum, `Σ` = scene covariance, `t` = target spectrum.
+Pure numpy at the array tier; one-line einsum reshape.
+Sibling detectors (`ACE`, `RX`) reuse the same covariance compute via the split-object pattern (compute Σ once, share across detectors).
 
 ### 4.7 Pansharpening (Brovey, condensed)
 
@@ -352,7 +405,8 @@ $$
 \mathrm{R}'_{h,w} = \mathrm{R}_{h,w} \cdot \frac{\mathrm{P}_{h,w}}{\mathrm{R}_{h,w} + \mathrm{G}_{h,w} + \mathrm{B}_{h,w} + \epsilon}
 $$
 
-Resamples the multispectral bands to the pan grid first (via `skimage.transform.resize` — a non-ufunc, shape-changing call wrapped at the Operator boundary, where the Operator constructs a fresh `GeoTensor` with the pan-grid transform), then applies the per-channel ratio. Same pattern for Gram-Schmidt and HCS, different math.
+Resamples the multispectral bands to the pan grid first (via `skimage.transform.resize` — a non-ufunc, shape-changing call wrapped at the Operator boundary, where the Operator constructs a fresh `GeoTensor` with the pan-grid transform), then applies the per-channel ratio.
+Same pattern for Gram-Schmidt and HCS, different math.
 
 ### 4.8 Lee speckle filter (SAR)
 
@@ -362,7 +416,8 @@ $$
 \hat{x} = \bar{x} + W \cdot (y - \bar{x}), \quad W = \frac{\sigma_x^2}{\sigma_x^2 + \sigma_n^2}
 $$
 
-with `ȳ`, `σ_y²` from a sliding window, `σ_n²` an estimate of speckle noise. `scipy.ndimage.uniform_filter` for the local statistics; pure numpy for the rest.
+with `ȳ`, `σ_y²` from a sliding window, `σ_n²` an estimate of speckle noise.
+`scipy.ndimage.uniform_filter` for the local statistics; pure numpy for the rest.
 
 ---
 
@@ -370,31 +425,44 @@ with `ȳ`, `σ_y²` from a sliding window, `σ_n²` an estimate of speckle noise
 
 ### 5.1 `georeader` — primary substrate
 
-`geotoolz` operators take and return `GeoTensor`. `__array_ufunc__` handles metadata round-trips for ufunc-pure operations transparently; for non-ufunc upstream calls (`skimage`, `scipy.ndimage`, `sklearn`), the Operator's `_apply` does the strip / run / `_wrap` dance at the Operator boundary. **Zero changes required to `georeader`.**
+`geotoolz` operators take and return `GeoTensor`.
+`__array_ufunc__` handles metadata round-trips for ufunc-pure operations transparently; for non-ufunc upstream calls (`skimage`, `scipy.ndimage`, `sklearn`), the Operator's `_apply` does the strip / run / `_wrap` dance at the Operator boundary.
+**Zero changes required to `georeader`.**
 
 ### 5.2 `numpy / scipy / scikit-image / scikit-learn` — compute
 
-All Tier A primitives consume `np.ndarray` (jaxtyped) and return `np.ndarray`. `geotoolz` consumes the upstream libraries; never re-implements. Hard deps.
+All Tier A primitives consume `np.ndarray` (jaxtyped) and return `np.ndarray`.
+`geotoolz` consumes the upstream libraries; never re-implements.
+Hard deps.
 
 ### 5.3 `xrpatcher` — chip extraction (optional)
 
-`geotoolz.sampling.GridSampler` can use `xrpatcher` internally for the windowing logic, or a hand-rolled stride math (the §4.4 formula). `xrpatcher` is an optional `[patcher]` extra; the hand-rolled path is the default.
+`geotoolz.sampling.GridSampler` can use `xrpatcher` internally for the windowing logic, or a hand-rolled stride math (the §4.4 formula).
+`xrpatcher` is an optional `[patcher]` extra; the hand-rolled path is the default.
 
 ### 5.4 `georeader.catalog` — large-scale processing
 
-`geotoolz.catalog_ops.CatalogPipeline(catalog, op)` iterates a catalog, applies an Operator per row, writes outputs. The catalog itself (build, query, intersect, persist) is **`georeader`'s job**, not `geotoolz`'s. `geotoolz` is a consumer.
+`geotoolz.catalog_ops.CatalogPipeline(catalog, op)` iterates a catalog, applies an Operator per row, writes outputs.
+The catalog itself (build, query, intersect, persist) is **`georeader`'s job**, not `geotoolz`'s.
+`geotoolz` is a consumer.
 
 ### 5.5 ML frameworks (`torch` / `jax` / `sklearn`) — optional, via `ModelOp`
 
-`ModelOp(model)` calls `getattr(model, "predict")`, `getattr(model, "__call__")`, or a user-provided method name. Never imports a framework. Optional `[ml]` extra ships convenience subclasses (`SklearnModelOp`, `TorchModelOp`) that set sensible defaults but stay duck-typed.
+`ModelOp(model)` calls `getattr(model, "predict")`, `getattr(model, "__call__")`, or a user-provided method name.
+Never imports a framework.
+Optional `[ml]` extra ships convenience subclasses (`SklearnModelOp`, `TorchModelOp`) that set sensible defaults but stay duck-typed.
 
 ### 5.6 `Hydra` / `hydra-zen` — config-driven pipelines
 
-Every Operator's `get_config()` returns JSON. `hydra-zen.builds(NDVI, red_idx=2, nir_idx=3)` round-trips. YAML pipelines compose without ceremony. Optional `[hydra]` extra ships pre-built configs for the standard operators.
+Every Operator's `get_config()` returns JSON. `hydra-zen.builds(NDVI, red_idx=2, nir_idx=3)` round-trips.
+YAML pipelines compose without ceremony.
+Optional `[hydra]` extra ships pre-built configs for the standard operators.
 
 ### 5.7 `xr_toolz` — sibling library, no dep
 
-`geotoolz` and `xr_toolz` share architectural patterns (D2, D3, D11) but no code. Users with both substrates install both. See [§10](#10-xr_toolz-coexistence).
+`geotoolz` and `xr_toolz` share architectural patterns (D2, D3, D11) but no code.
+Users with both substrates install both.
+See [§10](#10-xr_toolz-coexistence).
 
 ---
 
@@ -532,7 +600,8 @@ class ModelOp(Operator):
 - `axis=` for the integer axis convention; `dim_name=` (optional) for human-readable repr.
 - Single-input `_apply(self, gt)`; multi-input `_apply(self, gt_a, gt_b)` (unambiguous from arity).
 - `get_config()` returns JSON. Rich state (e.g. fitted percentiles, a model) is a constructor argument; users save / load it themselves.
-- No `**kwargs` in public constructors. Every option named.
+- No `**kwargs` in public constructors.
+  Every option named.
 
 ### 6.6 Hydra-zen YAML compatibility
 
@@ -584,34 +653,56 @@ viz = ["matplotlib"]
 atmos = ["py6s"]
 ```
 
-Five hard deps. Everything else opt-in.
+Five hard deps.
+Everything else opt-in.
 
 ### 6.8 Versioning and stability
 
-Pre-1.0 (`0.x`). Operator constructor signatures are the public surface. Tier A primitive signatures are *semi-public* — jaxtyping annotations document the shape contract, but signatures may evolve until 1.0. Sensor presets are pinned with version suffixes (`S2_L2A_RGB_v1`) so users can stay on an old preset across breaking sensor changes.
+Pre-1.0 (`0.x`).
+Operator constructor signatures are the public surface.
+Tier A primitive signatures are *semi-public* — jaxtyping annotations document the shape contract, but signatures may evolve until 1.0. Sensor presets are pinned with version suffixes (`S2_L2A_RGB_v1`) so users can stay on an old preset across breaking sensor changes.
 
 ---
 
 ## 7. Sharp edges
 
-1. **Don't share `Operator` with `xr_toolz`.** They diverge on call signature and chip semantics. The 300-LOC duplication is cheaper than the coordination tax.
-2. **`GeoTensor` subclass round-trip discipline.** For non-ufunc upstream calls (skimage, scipy.ndimage, sklearn), the **Operator's `_apply`** does the wrap — `out = primitive(np.asarray(gt)); return gt._wrap(out)`. One line per Operator that needs it; never inside the Tier A primitive. For shape-changing operations (resize, zoom, regridding), the primitive returns a plain ndarray and the Operator constructs a fresh `GeoTensor` with the new transform — `georeader` provides the construction helpers. **Footgun to document:** users importing primitives directly from `_src/array` get a plain `ndarray` back when the primitive is non-ufunc, even if they passed a `GeoTensor`. Per-primitive docstrings should mark "ufunc-pure" vs "non-ufunc" so the behaviour at primitive level is predictable.
-3. **Time-axis convention.** GeoTensor's `dims` may be `("time", "band", "y", "x")` or `("band", "time", "y", "x")` depending on how it was loaded. **Operators take `axis=` (int), never assume time is at axis 0.** The user passes `axis=` to match their tensor.
-4. **Multi-input arity is positional.** `CloudFreeComposite()(imagery, mask)` — the first GeoTensor is the imagery, the second is the mask. Document per Operator. Don't do `(image=..., mask=...)` keyword form; mixing positional and keyword args in `__call__` makes the dual-mode dispatch (eager vs graph) fragile.
-5. **`Sequential` strict on intermediate types.** Every step except the last must return a `GeoTensor`. Terminal ops (`WriteCOG`, viz operators) are allowed only at the end. Sequential validates and raises a clear `TypeError`.
-6. **Sensor presets are version-pinned.** When ESA changes Sentinel-2 product spec (it has, multiple times), the old `S2_L2A_RGB_v1` keeps working; `S2_L2A_RGB_v2` is a new operator. Users opt in.
-7. **`ModelOp` doesn't import frameworks.** Imports happen in user code, not in `geotoolz`. `from torch import nn` is the user's job. The optional `[ml]` extra is for *examples* and sensor-preset model wrappers, not for `ModelOp` itself.
-8. **Stateful operators use the split-object pattern.** No `fit` / `transform` duality on Operator. `CalculatePercentiles → ApplyPercentileClip(percentiles)`. State is an artifact.
-9. **Catalog ops live on georeader.** `geotoolz.catalog_ops.CatalogPipeline(catalog, op)` consumes a `georeader.catalog.GeoCatalog`. Don't reimplement catalog construction here.
-10. **Don't absorb every snippet.** Curated operator surface. If a user has a one-off RS computation, they write it as a one-off function or a custom `Operator` subclass — not as a PR adding it to `geotoolz`.
-11. **No `print` in operators.** Use `warnings.warn` for soft issues; raise for hard. Operators are building blocks; they shouldn't decorate stdout.
+1. **Don't share `Operator` with `xr_toolz`.** They diverge on call signature and chip semantics.
+   The 300-LOC duplication is cheaper than the coordination tax.
+2. **`GeoTensor` subclass round-trip discipline.** For non-ufunc upstream calls (skimage, scipy.ndimage, sklearn), the **Operator's `_apply`** does the wrap — `out = primitive(np.asarray(gt)); return gt._wrap(out)`.
+   One line per Operator that needs it; never inside the Tier A primitive.
+   For shape-changing operations (resize, zoom, regridding), the primitive returns a plain ndarray and the Operator constructs a fresh `GeoTensor` with the new transform — `georeader` provides the construction helpers.
+   **Footgun to document:** users importing primitives directly from `_src/array` get a plain `ndarray` back when the primitive is non-ufunc, even if they passed a `GeoTensor`.
+   Per-primitive docstrings should mark "ufunc-pure" vs "non-ufunc" so the behaviour at primitive level is predictable.
+3. **Time-axis convention.** GeoTensor's `dims` may be `("time", "band", "y", "x")` or `("band", "time", "y", "x")` depending on how it was loaded.
+   **Operators take `axis=` (int), never assume time is at axis 0.** The user passes `axis=` to match their tensor.
+4. **Multi-input arity is positional.** `CloudFreeComposite()(imagery, mask)` — the first GeoTensor is the imagery, the second is the mask.
+   Document per Operator.
+   Don't do `(image=..., mask=...)` keyword form; mixing positional and keyword args in `__call__` makes the dual-mode dispatch (eager vs graph) fragile.
+5. **`Sequential` strict on intermediate types.** Every step except the last must return a `GeoTensor`.
+   Terminal ops (`WriteCOG`, viz operators) are allowed only at the end.
+   Sequential validates and raises a clear `TypeError`.
+6. **Sensor presets are version-pinned.** When ESA changes Sentinel-2 product spec (it has, multiple times), the old `S2_L2A_RGB_v1` keeps working; `S2_L2A_RGB_v2` is a new operator.
+   Users opt in.
+7. **`ModelOp` doesn't import frameworks.** Imports happen in user code, not in `geotoolz`.
+   `from torch import nn` is the user's job.
+   The optional `[ml]` extra is for *examples* and sensor-preset model wrappers, not for `ModelOp` itself.
+8. **Stateful operators use the split-object pattern.** No `fit` / `transform` duality on Operator.
+   `CalculatePercentiles → ApplyPercentileClip(percentiles)`.
+   State is an artifact.
+9. **Catalog ops live on georeader.** `geotoolz.catalog_ops.CatalogPipeline(catalog, op)` consumes a `georeader.catalog.GeoCatalog`.
+   Don't reimplement catalog construction here.
+10. **Don't absorb every snippet.** Curated operator surface.
+    If a user has a one-off RS computation, they write it as a one-off function or a custom `Operator` subclass — not as a PR adding it to `geotoolz`.
+11. **No `print` in operators.** Use `warnings.warn` for soft issues; raise for hard.
+    Operators are building blocks; they shouldn't decorate stdout.
 12. **Float precision.** Default `float32` for image-bandwidth math, `float64` for stats and FFT. Per Operator, documented.
 
 ---
 
 ## 8. End-to-end examples
 
-`GeoTensor`-centric, using the proposed Operator surface. All examples assume `import geotoolz as gz` and `import numpy as np`.
+`GeoTensor`-centric, using the proposed Operator surface.
+All examples assume `import geotoolz as gz` and `import numpy as np`.
 
 | § | Example | Pattern |
 | --- | --- | --- |
@@ -774,7 +865,8 @@ gz.catalog_ops.CatalogPipeline(
 ).run()
 ```
 
-`CatalogPipeline` is a Tier B Operator that wraps the catalog iteration. The actual catalog (build / query / persistence) lives in `georeader.catalog`.
+`CatalogPipeline` is a Tier B Operator that wraps the catalog iteration.
+The actual catalog (build / query / persistence) lives in `georeader.catalog`.
 
 ### 8.7 Composition patterns
 
@@ -834,31 +926,40 @@ viz = S2_L2A_RGB_v1(brightness=2.0)(s2_gt)                      # GeoTensor (3, 
 plt.imshow(viz.transpose(1, 2, 0).values)
 ```
 
-The preset is just a `Sequential` with sensible defaults baked in. Users override via constructor args.
+The preset is just a `Sequential` with sensible defaults baked in.
+Users override via constructor args.
 
 ---
 
 ## 9. Verdict
 
-`geotoolz` is **the RS-shaped sibling to `xr_toolz`**. Same architectural patterns, different substrate, different audience, different opinionated surface. Two libraries, two use cases, that's it.
+`geotoolz` is **the RS-shaped sibling to `xr_toolz`**.
+Same architectural patterns, different substrate, different audience, different opinionated surface.
+Two libraries, two use cases, that's it.
 
 What needs to happen to ship v0.1:
 
-- [ ] Cut the new repo. `src/` layout, five hard deps.
-- [ ] Re-implement the composition core: `Operator`, `Sequential`, `Graph`, `Input`, `Node`, `Tap`. Borrow patterns from `xr_toolz`; ~300 LOC; no shared dep.
-- [ ] Author the v0.1 modules: `radiometry`, `indices`, `cloud`, `sampling`, `inference`, plus the core. ~25 Operators. **2 weeks.**
-- [ ] One `_src/{array, operators}.py` per module — preserves the two-tier discipline from day one. Tier A primitives jaxtyped (`jaxtyping >= 0.2`) at the signature.
+- [ ] Cut the new repo.
+  `src/` layout, five hard deps.
+- [ ] Re-implement the composition core: `Operator`, `Sequential`, `Graph`, `Input`, `Node`, `Tap`.
+  Borrow patterns from `xr_toolz`; ~300 LOC; no shared dep.
+- [ ] Author the v0.1 modules: `radiometry`, `indices`, `cloud`, `sampling`, `inference`, plus the core. ~25 Operators.
+  **2 weeks.**
+- [ ] One `_src/{array, operators}.py` per module — preserves the two-tier discipline from day one.
+  Tier A primitives jaxtyped (`jaxtyping >= 0.2`) at the signature.
 - [ ] Per-Operator `_wrap` discipline (Operators handle non-ufunc primitive output explicitly) + `GeoTensor` round-trip tests covering both ufunc-pure and non-ufunc primitives.
 - [ ] Hydra-zen smoke tests (every Operator's `get_config()` round-trips through `builds()`).
 - [ ] One end-to-end example notebook per category in §8 (six notebooks).
 
-v0.2 — `compositing`, `correction`, `catalog_ops`. **2 weeks.**
-v0.3 — `pansharpen`, `sar`, `hyperspectral` (matched filter, ACE, RX, unmixing). **2 weeks.**
-v0.4 — `presets.s2`, `presets.landsat`, `presets.emit`, `presets.enmap`. **1 week per sensor.**
+v0.2 — `compositing`, `correction`, `catalog_ops`.
+**2 weeks.** v0.3 — `pansharpen`, `sar`, `hyperspectral` (matched filter, ACE, RX, unmixing).
+**2 weeks.** v0.4 — `presets.s2`, `presets.landsat`, `presets.emit`, `presets.enmap`.
+**1 week per sensor.**
 
 What to defer past v0.4:
 
-- A full atmospheric correction story (Py6S/MODTRAN integration). Optional `[atmos]` extra; ship a stub `Py6SCorrection` operator.
+- A full atmospheric correction story (Py6S/MODTRAN integration).
+  Optional `[atmos]` extra; ship a stub `Py6SCorrection` operator.
 - Distributed processing (Dask integration on the `CatalogPipeline` parallelism). v0.5+.
 - xrpatcher integration as the default sampler. v0.5+.
 - A "geotoolz / xr_toolz interop" doc page. v0.4, when both have shipped enough to point at concrete patterns.
@@ -869,7 +970,8 @@ The total cost: roughly **two months** for v0.1–v0.4. The payoff: every RS wor
 
 ## 10. `xr_toolz` coexistence
 
-`geotoolz` and `xr_toolz` are siblings. This section codifies the boundary so users know which to reach for.
+`geotoolz` and `xr_toolz` are siblings.
+This section codifies the boundary so users know which to reach for.
 
 ### 10.1 The substrate-split rule
 
@@ -879,7 +981,8 @@ The total cost: roughly **two months** for v0.1–v0.4. The payoff: every RS wor
 | `georeader.GeoTensor` (numpy subclass with transform + crs) | `geotoolz` |
 | Raw `np.ndarray` (no metadata) | `numpy` / `scipy` / `scikit-image` directly |
 
-For users with both substrates: install both. Conversion between substrates is `georeader.dataarray.to_dataarray(gt)` / `from_dataarray(da)` — already in georeader.
+For users with both substrates: install both.
+Conversion between substrates is `georeader.dataarray.to_dataarray(gt)` / `from_dataarray(da)` — already in georeader.
 
 ### 10.2 Shared architectural patterns
 
@@ -894,15 +997,20 @@ Most architecture is shared; **the tier model is the one place they diverge**.
 | `get_config()` for Hydra round-trip | ✓ | ✓ |
 | No framework deps in core; ML via duck-typed `ModelOp` | ✓ | ✓ |
 
-**Why the tier asymmetry.** `GeoTensor` is an `np.ndarray` *subclass* with `__array_ufunc__` — the wrap from `ndarray` back to the carrier is one line (`gt._wrap(out)`) and lives at the Operator boundary. `xarray.DataArray` is *composition* over an ndarray — lifting `DataArray ↔ ndarray` requires `.values` extraction and explicit `.coords`/`.dims` re-attach, real enough work to deserve its own tier. The substrate dictates the tier count; both libraries land on the same pattern *given their substrate*.
+**Why the tier asymmetry.** `GeoTensor` is an `np.ndarray` *subclass* with `__array_ufunc__` — the wrap from `ndarray` back to the carrier is one line (`gt._wrap(out)`) and lives at the Operator boundary.
+`xarray.DataArray` is *composition* over an ndarray — lifting `DataArray ↔ ndarray` requires `.values` extraction and explicit `.coords`/`.dims` re-attach, real enough work to deserve its own tier.
+The substrate dictates the tier count; both libraries land on the same pattern *given their substrate*.
 
-The shared pattern docs live once (in `xr_toolz` or in a third "design conventions" doc); each library's own docs reference them and call out their tier-count specialisation. Code is independent.
+The shared pattern docs live once (in `xr_toolz` or in a third "design conventions" doc); each library's own docs reference them and call out their tier-count specialisation.
+Code is independent.
 
 ### 10.3 What does NOT cross-pollinate
 
-- **Operator implementations.** `xr_toolz.indices.NDVI` doesn't exist — climate users don't need NDVI as an Operator. If they do, they call `geotoolz.indices.NDVI` after converting to `GeoTensor`.
+- **Operator implementations.** `xr_toolz.indices.NDVI` doesn't exist — climate users don't need NDVI as an Operator.
+  If they do, they call `geotoolz.indices.NDVI` after converting to `GeoTensor`.
 - **`xr_toolz.kinematics.Coriolis(lat=...)`** stays in xr_toolz for climate users (operates on a `Dataset` with named lat/lon).
-- **`geotoolz.kinematics.geostrophic_velocity(...)`** is a leaf operator if RS workflows need it (operates on a `GeoTensor` with integer axes). Re-implementation is fine — different signatures, different defaults.
+- **`geotoolz.kinematics.geostrophic_velocity(...)`** is a leaf operator if RS workflows need it (operates on a `GeoTensor` with integer axes).
+  Re-implementation is fine — different signatures, different defaults.
 
 ### 10.4 Conversion patterns
 
@@ -916,67 +1024,110 @@ result_gt = georeader.dataarray.from_dataarray(result_da)     # GeoTensor
 georeader.save_cog(result_gt, "/out/result.tif")
 ```
 
-`georeader` is the bridge. Both libraries treat it as substrate, not as dep tier.
+`georeader` is the bridge.
+Both libraries treat it as substrate, not as dep tier.
 
 ### 10.5 Documentation cross-references
 
-A short doc page in each library: "I have *X* data, should I use this library or the other?" with a decision tree. Linked from both READMEs. Half-day of doc work, prevents the most common new-user confusion.
+A short doc page in each library: "I have *X* data, should I use this library or the other?" with a decision tree.
+Linked from both READMEs.
+Half-day of doc work, prevents the most common new-user confusion.
 
 ### 10.6 The endpoint
 
-Two libraries, two communities, one shared substrate library underneath, one shared design vocabulary on top. Each library focused, each community served, no awkward unifying compromise. **That's the right shape, and that's the recommendation.**
+Two libraries, two communities, one shared substrate library underneath, one shared design vocabulary on top.
+Each library focused, each community served, no awkward unifying compromise.
+**That's the right shape, and that's the recommendation.**
 
 ---
 
 ## 11. Open questions, gotchas, and risks
 
-The architecture is sound; several execution-level concerns deserve flags. None are blockers; all are things to manage actively. Strategic risks first, implementation gotchas second, scope honesty third.
+The architecture is sound; several execution-level concerns deserve flags.
+None are blockers; all are things to manage actively.
+Strategic risks first, implementation gotchas second, scope honesty third.
 
 ### 11.1 Strategic risks
 
-**`georeader 2.0` (`feature/geotensor_npapi`) is critical-path.** The two-tier model assumes the ndarray-subclass `GeoTensor` with `__array_ufunc__` lands cleanly upstream. If that branch stalls, `geotoolz` blocks — the wrap discipline depends on it. Track the merge as a blocker on v0.1; if it slips, the contingency is to ship `geotoolz` against a vendored `GeoTensor` until upstream catches up.
+**`georeader 2.0` (`feature/geotensor_npapi`) is critical-path.** The two-tier model assumes the ndarray-subclass `GeoTensor` with `__array_ufunc__` lands cleanly upstream.
+If that branch stalls, `geotoolz` blocks — the wrap discipline depends on it.
+Track the merge as a blocker on v0.1; if it slips, the contingency is to ship `geotoolz` against a vendored `GeoTensor` until upstream catches up.
 
-**`coordax` is research-grade.** The future-work JAX path leans on `coordax` (NeuralGCM, Google), which is early and has no stability commitment. Pin known-good versions; spike before committing the JAX path; have a fallback (`equinox` + `jaxtyping` directly, reinventing the small bit of labelled-array machinery you actually need). Treat the JAX path as **v0.5+**, not v0.1, until coordax stabilises.
+**`coordax` is research-grade.** The future-work JAX path leans on `coordax` (NeuralGCM, Google), which is early and has no stability commitment.
+Pin known-good versions; spike before committing the JAX path; have a fallback (`equinox` + `jaxtyping` directly, reinventing the small bit of labelled-array machinery you actually need).
+Treat the JAX path as **v0.5+**, not v0.1, until coordax stabilises.
 
-**80-operator scope vs roadmap pace.** v0.1–v0.4 budgets ~2 months for ~80 operators at ~1.5 day/operator quality. Realistic estimate is 5–6 months at 1 FTE; if it's a side project, double the timeline. **Mitigation:** cut sensor presets to v0.5+ for low-priority sensors (Himawari-AHI HSD, MTG-FCI, SEVIRI-HRIT); ship MODIS + ABI as the v0.1 sensor proofs and let the rest accumulate as need arises.
+**80-operator scope vs roadmap pace.** v0.1–v0.4 budgets ~2 months for ~80 operators at ~1.5 day/operator quality.
+Realistic estimate is 5–6 months at 1 FTE; if it's a side project, double the timeline.
+**Mitigation:** cut sensor presets to v0.5+ for low-priority sensors (Himawari-AHI HSD, MTG-FCI, SEVIRI-HRIT); ship MODIS + ABI as the v0.1 sensor proofs and let the rest accumulate as need arises.
 
-**Sensor preset maintenance is a forever commitment.** ESA / NASA / EUMETSAT product specs change every 1–2 years; each change spawns a new `_v2` preset. Budget ~5–10 preset bumps/year as steady-state maintenance, not one-time dev cost. Document a version-bump runbook so this doesn't become tribal knowledge.
+**Sensor preset maintenance is a forever commitment.** ESA / NASA / EUMETSAT product specs change every 1–2 years; each change spawns a new `_v2` preset.
+Budget ~5–10 preset bumps/year as steady-state maintenance, not one-time dev cost.
+Document a version-bump runbook so this doesn't become tribal knowledge.
 
 ### 11.2 Implementation gotchas (test these in CI)
 
-**`__array_function__` (NEP-18) coverage in `GeoTensor`.** `__array_ufunc__` covers ufuncs only. Functions like `np.fft.fft2`, `np.linalg.svd`, `np.einsum`, `np.percentile`, and many `np.linalg.*` go through `__array_function__`, not `__array_ufunc__`. Verify `GeoTensor` implements both, or document which numpy submodules strip the subclass. Add a CI test that round-trips metadata through every numpy module the operators touch (`fft`, `linalg`, basic ufuncs, reductions, indexing).
+**`__array_function__` (NEP-18) coverage in `GeoTensor`.** `__array_ufunc__` covers ufuncs only.
+Functions like `np.fft.fft2`, `np.linalg.svd`, `np.einsum`, `np.percentile`, and many `np.linalg.*` go through `__array_function__`, not `__array_ufunc__`.
+Verify `GeoTensor` implements both, or document which numpy submodules strip the subclass.
+Add a CI test that round-trips metadata through every numpy module the operators touch (`fft`, `linalg`, basic ufuncs, reductions, indexing).
 
 **`gt._wrap(out)` semantic edge cases.** Spec the rule per case so 80 operators don't each invent their own:
 - **Scalar output** (`tensor.mean()`): wrap into 0-d GeoTensor with original transform, or return scalar?
 - **Dim-reducing output** (`tensor.max(axis=-1)`): preserve transform but drop the axis from `dims`?
 - **Multi-input with divergent metadata** (`composite(image, mask)` where mask has no transform): which input's metadata wins?
-- **Boolean indexing** (`tensor[tensor > 0]`): returns 1-D, transform meaningless. Disallow at Operator level?
+- **Boolean indexing** (`tensor[tensor > 0]`): returns 1-D, transform meaningless.
+  Disallow at Operator level?
 
 Pick rules now; document in a `_wrap` design-doc entry that the Operator authors reference.
 
-**ndarray subclass fragility outside numpy.** `GeoTensor` survives numpy + scipy + skimage + matplotlib. It does **not** survive PyTorch (`torch.from_numpy` strips it), JAX (`jnp.asarray` strips it), or Dask without explicit `meta=` plumbing. This bounds the "GeoTensor flows everywhere" mental model — outside numpy-land, conversion is **explicit**. Document the supported boundary in the `GeoTensor` user docs.
+**ndarray subclass fragility outside numpy.** `GeoTensor` survives numpy + scipy + skimage + matplotlib.
+It does **not** survive PyTorch (`torch.from_numpy` strips it), JAX (`jnp.asarray` strips it), or Dask without explicit `meta=` plumbing.
+This bounds the "GeoTensor flows everywhere" mental model — outside numpy-land, conversion is **explicit**.
+Document the supported boundary in the `GeoTensor` user docs.
 
-**Async ↔ sync Operator boundary.** `Operator._apply` is sync; the async readers (`AsyncGeoTIFFReader`, the `AsyncGeoData` Protocol) are async. Mixing them inside `_apply` means `asyncio.run()` per Operator call — one event loop per invocation, expensive at batch scale. Pick a design before v0.1: (a) introduce an `AsyncOperator` family with `async def _apply` and an `AsyncSequential` runner; (b) restrict async to the `CatalogPipeline` boundary (sync operators on already-fetched data, async only at the read step — probably the cleanest); (c) sync wrapper that reuses an event loop across calls.
+**Async ↔ sync Operator boundary.** `Operator._apply` is sync; the async readers (`AsyncGeoTIFFReader`, the `AsyncGeoData` Protocol) are async.
+Mixing them inside `_apply` means `asyncio.run()` per Operator call — one event loop per invocation, expensive at batch scale.
+Pick a design before v0.1: (a) introduce an `AsyncOperator` family with `async def _apply` and an `AsyncSequential` runner; (b) restrict async to the `CatalogPipeline` boundary (sync operators on already-fetched data, async only at the read step — probably the cleanest); (c) sync wrapper that reuses an event loop across calls.
 
-**Pickling discipline for production.** "Operator graph as FastAPI handler" depends on pickling working. `@dataclass`-shaped operators pickle fine; lambdas, closures, unbound methods break silently. Add a CI test that pickles every example operator graph in §8 and unpickles cleanly. If the test ever fails, the failing example is the bug.
+**Pickling discipline for production.** "Operator graph as FastAPI handler" depends on pickling working.
+`@dataclass`-shaped operators pickle fine; lambdas, closures, unbound methods break silently.
+Add a CI test that pickles every example operator graph in §8 and unpickles cleanly.
+If the test ever fails, the failing example is the bug.
 
-**Three-cases-not-two for `_apply`.** §1.1 / §4.1 lay out the three cases (ufunc-pure, non-ufunc shape-preserving, shape/metadata-changing). The third covers most of `compositing`, `pansharpen`, `sampling`, and any reprojection-flavoured op. Treat it as first-class from day one — shape-changing operators construct a fresh `GeoTensor`, they don't `_wrap`.
+**Three-cases-not-two for `_apply`.** §1.1 / §4.1 lay out the three cases (ufunc-pure, non-ufunc shape-preserving, shape/metadata-changing).
+The third covers most of `compositing`, `pansharpen`, `sampling`, and any reprojection-flavoured op.
+Treat it as first-class from day one — shape-changing operators construct a fresh `GeoTensor`, they don't `_wrap`.
 
 ### 11.3 Scope honesty
 
-**`_src` privacy is fuzzy.** Currently semi-public ("importable, jaxtyped, documented"). Users will import primitives directly and hit subclass-stripping for non-ufunc primitives. Decide before v0.1:
-- **(a)** Make `_src` truly private (single-underscore module names, "do not import" docstrings, optional `__all__` enforcement). Cleanest.
-- **(b)** Expose primitives at a deliberate public namespace (`geotoolz.indices.array.ndvi`). Honest but doubles the API surface.
-- **(c)** Keep the current "semi-public" path and document per-primitive ufunc-pure vs non-ufunc behaviour. Maximum footgun risk.
+**`_src` privacy is fuzzy.** Currently semi-public ("importable, jaxtyped, documented").
+Users will import primitives directly and hit subclass-stripping for non-ufunc primitives.
+Decide before v0.1:
+- **(a)** Make `_src` truly private (single-underscore module names, "do not import" docstrings, optional `__all__` enforcement).
+  Cleanest.
+- **(b)** Expose primitives at a deliberate public namespace (`geotoolz.indices.array.ndvi`).
+  Honest but doubles the API surface.
+- **(c)** Keep the current "semi-public" path and document per-primitive ufunc-pure vs non-ufunc behaviour.
+  Maximum footgun risk.
 
 **Recommendation:** (a) for v0.1; promote to (b) only if real users ask for primitives as a first-class import path.
 
-**Array-API compliance for primitives.** True backend-agnostic primitives use the [array-API standard](https://data-apis.org/array-api/) (`xp.add`, not `np.add`), portable across numpy / JAX / PyTorch. Current primitives use `np.*` directly — JAX requires rewrites. **Cost-now-or-later trade-off:** factoring through array-API at v0.1 is small (some primitives become slightly less readable); doing it as a v0.5 retrofit is expensive. If the JAX path matters, eat the cost now.
+**Array-API compliance for primitives.** True backend-agnostic primitives use the [array-API standard](https://data-apis.org/array-api/) (`xp.add`, not `np.add`), portable across numpy / JAX / PyTorch. Current primitives use `np.*` directly — JAX requires rewrites.
+**Cost-now-or-later trade-off:** factoring through array-API at v0.1 is small (some primitives become slightly less readable); doing it as a v0.5 retrofit is expensive.
+If the JAX path matters, eat the cost now.
 
-**`ModelOp` is inference-only.** Duck-typed `__call__` works for inference across torch / JAX / sklearn. It does *not* unify training (different optimizers, gradient APIs, loss surfaces, batch semantics). State this explicitly in `ModelOp` docs so users don't expect a training abstraction.
+**`ModelOp` is inference-only.** Duck-typed `__call__` works for inference across torch / JAX / sklearn.
+It does *not* unify training (different optimizers, gradient APIs, loss surfaces, batch semantics).
+State this explicitly in `ModelOp` docs so users don't expect a training abstraction.
 
-**"Same operator everywhere" has limits.** Holds for: numpy, Dask-orchestrated batch, distributed JAX, FastAPI, Airflow, Ray. Does *not* hold for: Sedona/Spark (different paradigm — would need SQL emission), streaming engines (Flink/Beam, not streaming-aware), edge inference (`ModelOp` ships the model, not the operator graph). Keep the in-scope vs out-of-scope list explicit in the public motivation doc ([`geostack_notes.md`](../../geostack_notes.md) "Honest research-to-prod scope").
+**"Same operator everywhere" has limits.** Holds for: numpy, Dask-orchestrated batch, distributed JAX, FastAPI, Airflow, Ray.
+Does *not* hold for: Sedona/Spark (different paradigm — would need SQL emission), streaming engines (Flink/Beam, not streaming-aware), edge inference (`ModelOp` ships the model, not the operator graph).
+Keep the in-scope vs out-of-scope list explicit in the public motivation doc ([`geostack_notes.md`](../../geostack_notes.md) "Honest research-to-prod scope").
 
-**Aggregate learning curve.** Two-layer ladder + jaxtyping + Hydra-zen + GeoTensor wrap discipline + dual-mode `__call__` + split-object stateful pattern + sensor presets is more than the "Keras simple" pitch suggests. Tutorial gallery (§8) should introduce concepts one at a time, not in a single kitchen-sink example. *"What you need to know to write your first NDVI pipeline" → "What you need to know to ship a Hydra-driven catalog inference run"* — a curriculum, not a manual.
+**Aggregate learning curve.** Two-layer ladder + jaxtyping + Hydra-zen + GeoTensor wrap discipline + dual-mode `__call__` + split-object stateful pattern + sensor presets is more than the "Keras simple" pitch suggests.
+Tutorial gallery (§8) should introduce concepts one at a time, not in a single kitchen-sink example.
+*"What you need to know to write your first NDVI pipeline" → "What you need to know to ship a Hydra-driven catalog inference run"* — a curriculum, not a manual.
 
-**Sub-pickle interop risks.** `Sequential` exported as ONNX, used as a `torch.utils.data.Dataset`, tracked by `mlflow` — these are integration questions that *will* come up. Scope which integrations are first-class vs out-of-scope before v0.1, even if the answer is "first-class only mlflow at v0.4, the rest is user-driven".
+**Sub-pickle interop risks.** `Sequential` exported as ONNX, used as a `torch.utils.data.Dataset`, tracked by `mlflow` — these are integration questions that *will* come up.
+Scope which integrations are first-class vs out-of-scope before v0.1, even if the answer is "first-class only mlflow at v0.4, the rest is user-driven".

--- a/projects/geotoolz/plans/geotoolz/skimage/design_skimage.md
+++ b/projects/geotoolz/plans/geotoolz/skimage/design_skimage.md
@@ -1,0 +1,504 @@
+---
+title: geotoolz.skimage design doc
+subject: geotoolz design
+subtitle: Wrapping scikit-image as Operators over GeoTensor
+short_title: skimage bridge
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: design, geotoolz, skimage, operators, remote-sensing
+---
+
+> **Status:** draft (2026-05-10) — first design pass on the skimage bridge.
+> **Scope:** how every `scikit-image` function lands in a `geotoolz` Operator graph through a small family of wrapping Operators (`PerBand`, `MultiBand`, `Func`), axis-aware `HWC`/`CHW` adapters, dtype safety, and NaN handling.
+> **Audience:** anyone composing geospatial preprocessing or feature-engineering pipelines that lean on skimage's filtering, morphology, segmentation, restoration, registration, or feature-extraction surface.
+
+## Goals
+
+Make every scikit-image function usable inside a `geotoolz` operator graph **as a single Operator**, without per-function wrapping code. scikit-image is decades of community work on filtering, morphology, segmentation, restoration, feature extraction, and registration — wrapping it well gives geotoolz an enormous algorithmic surface for a few hundred lines of glue.
+
+Concretely:
+
+- A small family of **wrapping Operators** (`PerBand`, `MultiBand`, `Func`) that adapt skimage’s calling conventions to `GeoTensor`.
+- **Axis-aware adapters** that handle skimage’s `HWC`-vs-`CHW` channel conventions transparently.
+- **dtype safety** — skimage functions are picky about input ranges (`float [0, 1]`, `uint8 [0, 255]`); the wrappers handle conversion in and back.
+- **NaN handling** — most skimage filters propagate NaN destructively over spatial footprints; provide masking and restoration strategies.
+- **Sugar for the common cases** (`Morphology.opening`, `Filter.gaussian`) without exploding the API surface.
+
+## Non-goals
+
+- Re-implementing skimage in JAX or on GPU. (`cucim` is the GPU-accelerated drop-in if needed — works through the same wrappers.)
+- Stateful estimators. skimage is almost entirely stateless functions; the rare exceptions (e.g., trained denoising models) are out of scope.
+- 3D volumetric processing. skimage supports it; geotoolz currently doesn’t carry a Z axis.
+  Revisit if voxel data becomes a real case.
+
+## Design philosophy
+
+**Thin glue, not reimplement.** Three wrappers (`PerBand`, `MultiBand`, `Func`) plus a handful of conventions cover the entire skimage surface.
+Resist the urge to ship `geotoolz.skimage.Gaussian`, `geotoolz.skimage.Sobel`, `geotoolz.skimage.Canny`, etc. — that’s an N-ary wrapping anti-pattern that doesn’t scale to skimage’s hundreds of functions.
+
+**Functions are first-class.** The wrapped object is a Python function, not a class.
+`get_config()` records the function by fully-qualified name so YAML round-trip works; the loader resolves it on import.
+
+```yaml
+_target_: geotoolz.skimage.PerBand
+fn: skimage.filters.gaussian
+kwargs:
+  sigma: 2.0
+  preserve_range: true
+```
+
+**Explicit shape contracts.** skimage functions have wildly different shape expectations — 2D-only, 3D with `channel_axis`, ND with `axis`.
+The wrappers make the contract explicit at construction; mismatches fail loud rather than producing weirdly-shaped output.
+
+-----
+
+## Carrier types
+
+### `GeoTensor` (no new carriers)
+
+Unlike the sklearn integration (which needs `PixelTable` for `(N, F)` shape), skimage stays in image space.
+Inputs and outputs are both `GeoTensor`.
+The wrappers handle internal shape juggling (axis transposes, band looping) but never expose a non-`GeoTensor` carrier to users.
+
+Shape conventions for skimage:
+
+- **Per-band** functions expect `(H, W)` 2D arrays.
+  Wrapper loops over the band axis.
+- **Multi-channel** functions accept `channel_axis=` and operate on either `(H, W, C)` (HWC, the skimage default for ≥0.19) or `(C, H, W)` (CHW) depending on the value.
+  Wrapper handles axis convention.
+- **ND** functions (`scipy.ndimage`-style) operate on arbitrary dimensions via an `axis=` parameter.
+  Wrapper passes through.
+
+geotoolz uses **CHW** internally.
+The wrappers translate.
+
+-----
+
+## Wrapping Operators
+
+Three core wrappers.
+The user-facing API is small; everything else is composed from these.
+
+### `PerBand` — for 2D-only functions
+
+```python
+class PerBand(Operator):
+    """Apply a 2D skimage function independently to each band."""
+    def __init__(self, fn: Callable, *, dtype_in: str | None = None,
+                 dtype_out: str | None = None, **kwargs):
+        self.fn = fn
+        self.kwargs = kwargs
+        self.dtype_in, self.dtype_out = dtype_in, dtype_out
+
+    def _apply(self, gt: GeoTensor) -> GeoTensor:
+        arr = _to_dtype(np.asarray(gt), self.dtype_in)
+        bands_out = [self.fn(arr[i], **self.kwargs) for i in range(arr.shape[0])]
+        out = np.stack(bands_out, axis=0)
+        out = _to_dtype(out, self.dtype_out)
+        return GeoTensor(values=out, transform=gt.transform, crs=gt.crs)
+
+    def get_config(self):
+        return {
+            "fn":        f"{self.fn.__module__}.{self.fn.__name__}",
+            "dtype_in":  self.dtype_in,
+            "dtype_out": self.dtype_out,
+            **self.kwargs,
+        }
+```
+
+Usage:
+
+```python
+from skimage import filters, morphology
+
+gz.skimage.PerBand(filters.gaussian, sigma=2.0)
+gz.skimage.PerBand(morphology.opening, footprint=morphology.disk(3))
+gz.skimage.PerBand(filters.median, footprint=morphology.disk(5))
+```
+
+### `MultiBand` — for functions with a `channel_axis`
+
+```python
+class MultiBand(Operator):
+    """Apply a multi-channel skimage function, handling channel-axis convention."""
+    def __init__(self, fn: Callable, *, channel_axis: int = 0,
+                 dtype_in: str | None = None, dtype_out: str | None = None,
+                 **kwargs):
+        self.fn = fn
+        self.channel_axis = channel_axis
+        self.kwargs = kwargs
+        self.dtype_in, self.dtype_out = dtype_in, dtype_out
+
+    def _apply(self, gt: GeoTensor) -> GeoTensor:
+        arr = _to_dtype(np.asarray(gt), self.dtype_in)
+        out = self.fn(arr, channel_axis=self.channel_axis, **self.kwargs)
+        out = _to_dtype(out, self.dtype_out)
+        return GeoTensor(values=out, transform=gt.transform, crs=gt.crs)
+```
+
+Usage:
+
+```python
+from skimage import color, feature
+
+gz.skimage.MultiBand(color.rgb2lab, channel_axis=0)
+gz.skimage.MultiBand(feature.multiscale_basic_features, channel_axis=0,
+                    intensity=True, edges=True, texture=True)
+```
+
+### `Func` — generic escape hatch
+
+For functions that don’t fit the per-band or multi-band patterns — segmentation, registration, anything that operates on the array as a whole and returns something with a different shape or dtype.
+
+```python
+class Func(Operator):
+    """Generic wrapper for any skimage function."""
+    def __init__(self, fn: Callable, *, requires: str = "2d",
+                 dtype_in: str | None = None, dtype_out: str | None = None,
+                 **kwargs):
+        # requires: "2d" | "3d_hwc" | "3d_chw" | "nd"
+        self.fn, self.requires, self.kwargs = fn, requires, kwargs
+        self.dtype_in, self.dtype_out = dtype_in, dtype_out
+
+    def _apply(self, gt: GeoTensor) -> GeoTensor:
+        arr = _prepare_shape(np.asarray(gt), self.requires)
+        arr = _to_dtype(arr, self.dtype_in)
+        out = self.fn(arr, **self.kwargs)
+        out = _to_dtype(out, self.dtype_out)
+        out = _restore_shape(out, gt.shape, self.requires)
+        return GeoTensor(values=out, transform=gt.transform, crs=gt.crs)
+```
+
+Usage:
+
+```python
+gz.skimage.Func(skimage.segmentation.slic, requires="3d_hwc",
+               n_segments=200, compactness=10)
+gz.skimage.Func(skimage.exposure.equalize_adapthist, requires="2d",
+               clip_limit=0.03, dtype_in="float01", dtype_out="float32")
+```
+
+### Why three wrappers, not one
+
+A single `Func(...)` with smart dispatch could cover everything, but the explicit `PerBand` / `MultiBand` naming signals intent and lets static readers of YAML configs see *how* the function consumes the array.
+A `PerBand(filters.gaussian, sigma=2)` is unambiguously per-band; the same expressed as `Func(filters.gaussian, requires="2d", sigma=2, _loop="band")` hides the semantics behind a parameter.
+
+-----
+
+## Channel-axis conventions
+
+skimage 0.19+ standardised on a `channel_axis` parameter.
+Earlier versions used `multichannel=True` (deprecated).
+The wrappers always pass `channel_axis` explicitly; users supplying older `multichannel`-style calls get a clear error.
+
+geotoolz convention: **CHW** (`channel_axis=0`).
+For skimage functions that strongly prefer HWC, `MultiBand` includes a `transpose_to_hwc=True` mode that runs `channel_axis=-1` internally:
+
+```python
+gz.skimage.MultiBand(some_hwc_function, transpose_to_hwc=True)
+# Internally: CHW → HWC, apply, HWC → CHW
+```
+
+`OnHWC` is a sugar Operator for the common case:
+
+```python
+class OnHWC(Operator):
+    """Transpose CHW → HWC, apply inner Operator, transpose back."""
+    def __init__(self, inner: Operator):
+        self.inner = inner
+    def _apply(self, gt):
+        arr = np.asarray(gt).transpose(1, 2, 0)
+        gt_hwc = GeoTensor(values=arr, transform=gt.transform, crs=gt.crs)
+        out_hwc = self.inner(gt_hwc)
+        out = np.asarray(out_hwc).transpose(2, 0, 1)
+        return GeoTensor(values=out, transform=gt.transform, crs=gt.crs)
+```
+
+-----
+
+## dtype safety
+
+The single most common skimage footgun: passing a `uint16` Sentinel-2 array to a function that expects `float [0, 1]` and getting either silent garbage or an obscure error.
+The wrappers solve this via `dtype_in` and `dtype_out` parameters that handle conversion transparently.
+
+### Supported dtype conventions
+
+|Token      |Meaning             |Conversion                         |
+|-----------|--------------------|-----------------------------------|
+|`"float01"`|float in `[0, 1]`   |`arr / arr.max()` or `img_as_float`|
+|`"float32"`|float32 (no rescale)|`arr.astype(np.float32)`           |
+|`"float64"`|float64 (no rescale)|`arr.astype(np.float64)`           |
+|`"uint8"`  |uint8 in `[0, 255]` |`img_as_ubyte`                     |
+|`"uint16"` |uint16 (no rescale) |`arr.astype(np.uint16)`            |
+|`None`     |no conversion       |unchanged                          |
+
+Usage:
+
+```python
+gz.skimage.PerBand(
+    skimage.exposure.equalize_adapthist,
+    clip_limit=0.03,
+    dtype_in="float01",        # rescale input to [0, 1]
+    dtype_out="float32",       # cast output back
+)
+```
+
+### Why this matters
+
+Three reasons to handle dtype in the wrapper rather than asking users to do it inline:
+
+1. **Round-trip discipline.** `dtype_in="float01"` is a YAML-serialisable field; an inline `(arr / 10_000.0)` call inside a `Lambda` is not.
+2. **Composition correctness.** Operators downstream expect `GeoTensor` of the original dtype; the wrapper restores it.
+3. **Error visibility.** Wrong dtype produces a `WrappedSkimageError` at the wrapper boundary, not an obscure failure deep inside skimage.
+
+### Rescale strategies
+
+`"float01"` is intentionally vague — does `max` mean per-band or global?
+Per-array or per-dataset?
+The default is `img_as_float` (skimage’s own convention: integer types divided by their dtype’s max, float types passed through).
+Custom scaling via a separate `Rescale` Operator:
+
+```python
+gz.core.Rescale(in_range=(0, 10_000), out_range=(0, 1), dtype="float32")
+```
+
+Composes naturally:
+
+```python
+gz.Sequential([
+    gz.core.Rescale(in_range=(0, 10_000), out_range=(0, 1)),
+    gz.skimage.PerBand(skimage.exposure.equalize_adapthist, clip_limit=0.03),
+    gz.core.Rescale(in_range=(0, 1), out_range=(0, 10_000), dtype="uint16"),
+])
+```
+
+For workflows where dtype handling is non-trivial (different rescaling per band, dataset-derived rescale ranges from training statistics), keep the rescaling explicit as separate Operators — don’t bury it in `dtype_in`.
+
+-----
+
+## NaN handling
+
+skimage filters propagate NaN destructively over their spatial footprints.
+A single NaN pixel in a 5×5 Gaussian footprint corrupts 25 output pixels.
+Mishandled, a small cloud mask becomes a much larger artefact in the filtered output.
+
+The integration provides three primary strategies, configured via a `nan_policy` parameter on every wrapper:
+
+|Strategy     |Behaviour                                                  |Use case                                                  |
+|-------------|-----------------------------------------------------------|----------------------------------------------------------|
+|`propagate`  |Pass NaN through (default for most skimage functions)      |When NaN propagation is fine                              |
+|`mask`       |Fill NaN with `fill_value` before, restore NaN after       |Filters where input NaN is invalid                        |
+|`interpolate`|Fill NaN with interpolated values before, restore NaN after|When NaN regions are small and noise-free output is needed|
+|`raise`      |Error on any NaN                                           |Strict ETL                                                |
+|`warn`       |Log NaN presence, then propagate                           |Debug / staging                                           |
+
+### Why `propagate` is the default
+
+skimage’s documented behaviour is NaN-propagating.
+Defaulting to anything else creates surprise.
+Users who want NaN-aware filtering opt in explicitly:
+
+```python
+gz.skimage.PerBand(
+    filters.gaussian, sigma=2.0,
+    nan_policy="mask", fill_value=0.0,
+)
+```
+
+### `interpolate` strategy in detail
+
+For smoothing filters (Gaussian, median, denoise) over a scene with small cloud-masked regions, the right behaviour is usually: fill NaN with sensible values *before* filtering, then *restore* NaN at the original locations so masked pixels stay masked but don’t bleed into their neighbours.
+
+```python
+class NanPolicy:
+    @staticmethod
+    def apply_interpolate(arr, fn, **kwargs):
+        mask = np.isnan(arr)
+        if not mask.any():
+            return fn(arr, **kwargs)
+        # cheap interpolation: replace NaN with local mean
+        filled = arr.copy()
+        filled[mask] = _local_mean_fill(arr, mask)
+        out = fn(filled, **kwargs)
+        out[mask] = np.nan
+        return out
+```
+
+For high-quality interpolation use `scipy.interpolate.griddata` or `skimage.restoration.inpaint_biharmonic`; for speed use a local mean.
+The choice is exposed via `interpolate_method`:
+
+```python
+gz.skimage.PerBand(
+    filters.gaussian, sigma=2.0,
+    nan_policy="interpolate", interpolate_method="biharmonic",
+)
+```
+
+### Composition: NaN handling as separate Operators
+
+Same pattern as the sklearn design — NaN handling can be lifted out:
+
+```python
+gz.Sequential([
+    gz.skimage.NanFill(method="biharmonic"),
+    gz.skimage.PerBand(filters.gaussian, sigma=2.0, nan_policy="propagate"),
+    gz.skimage.NanRestore(),                          # restores NaN at masked positions
+])
+```
+
+The standalone `NanFill` / `NanRestore` Operators are more flexible — useful when the same fill should serve multiple downstream filters without recomputing.
+
+-----
+
+## Sugar for the common cases
+
+While the *anti-pattern* is shipping `Gaussian`, `Sobel`, `Canny`, etc., **a small set of sugar Operators** for genuinely-common patterns saves users from importing skimage modules and constructing footprints by hand.
+
+### `Morphology` namespace
+
+The most common morphological operations with footprint shorthands:
+
+```python
+gz.skimage.Morphology.opening(radius=3, shape="disk")
+gz.skimage.Morphology.closing(radius=5, shape="square")
+gz.skimage.Morphology.erosion(radius=2, shape="disk")
+gz.skimage.Morphology.dilation(radius=2, shape="disk")
+gz.skimage.Morphology.tophat(radius=10, shape="disk")
+gz.skimage.Morphology.bottomhat(radius=10, shape="disk")
+```
+
+Implementation:
+
+```python
+class Morphology:
+    @staticmethod
+    def opening(*, radius: int, shape: str = "disk"):
+        return PerBand(
+            morphology.opening,
+            footprint=_footprint(shape, radius),
+        )
+    # ... and so on
+```
+
+`_footprint("disk", 3)` returns `morphology.disk(3)`, etc.
+
+### `Filter` namespace
+
+```python
+gz.skimage.Filter.gaussian(sigma=2.0)
+gz.skimage.Filter.median(radius=3)
+gz.skimage.Filter.sobel()
+gz.skimage.Filter.scharr()
+```
+
+### Naming convention
+
+Sugar Operators live under namespaced static classes (`Morphology`, `Filter`, `Color`, `Feature`).
+They are *not* their own Operator classes — they are factory functions returning `PerBand` / `MultiBand` / `Func` instances.
+This keeps the wrapper count fixed at three and lets sugar evolve without schema migration.
+
+```yaml
+# YAML output of Morphology.opening(radius=3, shape="disk") is identical to PerBand
+_target_: geotoolz.skimage.PerBand
+fn: skimage.morphology.opening
+kwargs:
+  footprint: [[0,1,1,1,0],[1,1,1,1,1],[1,1,1,1,1],[1,1,1,1,1],[0,1,1,1,0]]
+```
+
+Or, if footprint serialisation is unwieldy, use a normalised form:
+
+```yaml
+_target_: geotoolz.skimage.Morphology.opening
+radius: 3
+shape: disk
+```
+
+The latter is more readable but requires the loader to know about each sugar factory.
+The former is mechanical and works for anything.
+**Recommendation:** support the readable form for the sugar namespaces; fall through to `_target_: PerBand` form for arbitrary functions.
+
+-----
+
+## Compatibility utilities (reference)
+
+The full surface — roughly 15 operators and utilities.
+The three core wrappers carry most of the work; the rest are conventions, sugar, and NaN helpers.
+
+### Core wrappers
+
+- `gz.skimage.PerBand(fn, *, dtype_in, dtype_out, nan_policy, **kwargs)` — 2D-only functions applied per band
+- `gz.skimage.MultiBand(fn, *, channel_axis, dtype_in, dtype_out, nan_policy, **kwargs)` — multi-channel functions
+- `gz.skimage.Func(fn, *, requires, dtype_in, dtype_out, nan_policy, **kwargs)` — generic escape hatch
+
+### Axis convention helpers
+
+- `gz.skimage.OnHWC(inner_op)` — runs inner op in HWC space
+- `gz.skimage.Transpose(order)` — explicit axis reordering Operator
+
+### dtype helpers
+
+- `gz.core.Rescale(in_range, out_range, dtype)` — explicit linear rescaling (lives in `core`, not `skimage`-specific)
+
+### NaN helpers
+
+- `gz.skimage.NanFill(method="biharmonic" | "local_mean" | "constant", fill_value=...)` — fill NaN
+- `gz.skimage.NanRestore()` — restore NaN from stashed mask metadata
+
+### Sugar namespaces
+
+- `gz.skimage.Morphology.{opening, closing, erosion, dilation, tophat, bottomhat}`
+- `gz.skimage.Filter.{gaussian, median, sobel, scharr, prewitt, laplace}`
+- `gz.skimage.Color.{rgb2lab, lab2rgb, rgb2hsv, hsv2rgb, rgb2gray}`
+- `gz.skimage.Segmentation.{slic, watershed, felzenszwalb, quickshift}`
+- `gz.skimage.Feature.{canny, hog, blob_log, blob_dog, peak_local_max}`
+
+### Sugar conventions
+
+- Footprint shapes: `"disk" | "square" | "diamond" | "octagon"` (mapping to `skimage.morphology` factory functions)
+- Default `nan_policy="propagate"` for filters; `"raise"` for segmentation (which produces nonsense on NaN inputs)
+
+-----
+
+## Tradeoffs and out of scope
+
+**CPU-bound.** skimage is numpy/Cython.
+The wrappers inherit that.
+For GPU acceleration, swap `import skimage` for `import cucim.skimage` — same function names, GPU-backed, drops through the same wrappers without code changes.
+Worth documenting prominently.
+
+**NaN-aware filtering is approximate.** “Fill before, restore after” is not mathematically rigorous — a Gaussian convolution that should integrate over NaN pixels with weight 0 isn’t what `fill→filter→mask` produces.
+For rigorous treatment, use `astropy.convolution.convolve` (NaN-aware convolution) via a custom `Func` wrapper.
+Document that the built-in strategies are pragmatic, not rigorous.
+
+**Per-band looping is slow for hyperspectral.** A `PerBand` Gaussian over a 200-band hyperspectral cube runs 200 Python-level iterations.
+For genuinely per-band hyperspectral work, prefer wrapping `scipy.ndimage` functions that vectorise via `axis=` parameters, or push to GPU via `cucim`.
+The fallback works but isn’t optimal.
+
+**Boundary modes vary across functions.** skimage’s `filters.gaussian` defaults to `mode="nearest"`; `filters.median` uses `mode="mirror"`; `morphology.opening` uses no padding at all (output shape shrinks).
+The wrappers don’t normalise this — users must know each function’s defaults.
+Document a “common boundary gotchas” appendix.
+
+**Segmentation output dtype.** `slic`, `watershed`, etc. return integer label maps with no spatial information of their own.
+The wrapper restores `transform` and `crs` from the input, but the label numbering is arbitrary and not stable across runs (changes with seed, sample order).
+Don’t expect a `slic` segmentation from yesterday to match today’s pixel-for-pixel even on identical input.
+
+**Footprint serialisation.** `morphology.disk(5)` returns an 11×11 numpy array; serialising that into YAML is ugly.
+Sugar factories (`Morphology.opening( radius=5, shape="disk")`) sidestep this; raw `PerBand(morphology.opening, footprint=disk(5))` requires the YAML to embed the footprint or reference a factory by name.
+Default: sugar for the common cases, explicit footprint arrays for custom shapes.
+
+## Open questions
+
+- **`OnHWC` placement.** Should it live in `geotoolz.skimage` (its main use is skimage), or in `geotoolz.core` (it’s a generic axis adapter)?
+  Probably `core`, since it’s useful beyond skimage.
+- **dtype `float01` semantics.** `img_as_float` divides by dtype max, which is wrong for Sentinel-2 reflectance (stored as `uint16` with values up to ~10000, not 65535).
+  Document that `float01` is “naive rescaling for skimage’s conventions” and that proper reflectance normalisation needs explicit `Rescale`.
+- **Whether to ship a `cucim` parallel namespace.** `gz.skimage_gpu.PerBand` wrapping `cucim.skimage.filters.gaussian`?
+  Or just document the `import cucim.skimage as skimage` swap pattern?
+  The swap pattern is cleaner; ship documentation, not a parallel namespace.

--- a/projects/geotoolz/plans/geotoolz/skimage/examples_skimage.md
+++ b/projects/geotoolz/plans/geotoolz/skimage/examples_skimage.md
@@ -1,0 +1,581 @@
+---
+title: geotoolz.skimage examples
+subject: geotoolz examples
+subtitle: A gallery of skimage Operator patterns over GeoTensor
+short_title: skimage examples
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: design, geotoolz, skimage, examples, remote-sensing
+---
+
+> **Status:** companion to [`design_skimage.md`](design_skimage.md) — concrete worked examples for the skimage Operator bridge.
+> **Audience:** anyone reaching for skimage from a `geotoolz` pipeline (preprocessing, feature engineering, viz post-processing) and looking for the canonical recipe before writing their own wrapper.
+
+Companion to the [design doc](design_skimage.md).
+Examples cover denoising, morphology, feature extraction, segmentation, restoration, edge detection, and ML-feature engineering — across the patterns where skimage fits naturally into geospatial workflows.
+
+## Contents
+
+- [How skimage fits in](#how-skimage-fits-in)
+- [Workflow patterns](#workflow-patterns)
+- [1. Speckle reduction for SAR (per-band Lee filter)](#1-speckle-reduction-for-sar-per-band-lee-filter)
+- [2. Cloud-mask post-processing (morphology)](#2-cloud-mask-post-processing-morphology)
+- [3. Adaptive contrast enhancement (CLAHE for viz)](#3-adaptive-contrast-enhancement-clahe-for-viz)
+- [4. Edge detection for field boundaries](#4-edge-detection-for-field-boundaries)
+- [5. Superpixel segmentation (object-based image analysis)](#5-superpixel-segmentation-object-based-image-analysis)
+- [6. Inpainting cloud-masked gaps](#6-inpainting-cloud-masked-gaps)
+- [7. Multi-scale features for ML](#7-multi-scale-features-for-ml)
+- [8. Texture features (GLCM) for land-cover classification](#8-texture-features-glcm-for-land-cover-classification)
+- [9. Blob detection for object localisation](#9-blob-detection-for-object-localisation)
+- [10. Image registration / co-alignment](#10-image-registration--co-alignment)
+
+-----
+
+## How skimage fits in
+
+skimage is decades of community work on image processing — filtering, morphology, segmentation, restoration, registration, feature extraction.
+For geospatial data, it lives in three places naturally:
+
+**Preprocessing** — speckle reduction, contrast enhancement, gap-filling.
+Runs before downstream analysis or ML.
+
+**Feature engineering for ML** — texture statistics, multi-scale features, edge maps.
+The outputs become input bands for a classifier or regressor.
+
+**Post-processing** — morphological cleanup of classification masks, region labelling, vectorisation prep.
+Runs after a model produces a raw output.
+
+The three wrappers (`PerBand`, `MultiBand`, `Func`) cover every skimage function.
+The examples below show which wrapper fits each task and why.
+
+## Workflow patterns
+
+A short orientation for *where in a pipeline* skimage typically sits:
+
+**Single-scene work.** Most skimage examples below operate on a single GeoTensor at a time — they’re stateless and chip-friendly.
+Drop them into any `Sequential` and they compose like any other Operator.
+
+**Chipwise inference.** Wrap a skimage-heavy pipeline in `ApplyToChips` for big scenes.
+Watch the edge effects — most skimage filters have boundary modes that produce artefacts at chip seams.
+Use overlap (stride < chip_size) and stitch with averaging where possible.
+
+**Catalog-scale ETL.** Drop the same skimage Operators into a `CatalogPipeline` to run across many scenes.
+The only constraint: skimage functions are CPU-bound, so wall-clock time scales with worker count.
+
+**As pre/post processing around an ML model.** Common pattern — skimage preprocesses features, ML model classifies, skimage cleans up the output.
+The whole thing is one `Sequential`.
+
+-----
+
+## 1. Speckle reduction for SAR (per-band Lee filter)
+
+**Setting.** Sentinel-1 SAR data is dominated by multiplicative speckle noise.
+Lee filtering or its variants smooth speckle while preserving edges.
+A required preprocessing step before most SAR analysis.
+
+**Wrapper.** `PerBand` — Lee filter is 2D and operates per-polarisation.
+
+```python
+import geotoolz as gz
+from skimage.restoration import denoise_tv_chambolle
+
+# Lee filter not in skimage core; use TV-Chambolle as a close cousin
+speckle_filter = gz.skimage.PerBand(
+    denoise_tv_chambolle,
+    weight=0.1,
+    n_iter_max=200,
+    dtype_in="float32",
+    dtype_out="float32",
+)
+
+sar_pipeline = gz.Sequential([
+    gz.sar.LinearToDB(),          # convert linear backscatter to dB
+    speckle_filter,                # filter in dB space (additive noise)
+    gz.sar.DBToLinear(),           # back to linear if needed downstream
+])
+```
+
+For the actual Lee filter (a fast sliding-window mean/variance estimator):
+
+```python
+def lee_filter(arr, size=7):
+    from scipy.ndimage import uniform_filter
+    mean = uniform_filter(arr, size)
+    sqr_mean = uniform_filter(arr ** 2, size)
+    var = sqr_mean - mean ** 2
+    overall_var = arr.var()
+    weights = var / (var + overall_var)
+    return mean + weights * (arr - mean)
+
+# Wrap with PerBand — works for any 2D function, not just skimage's
+gz.skimage.PerBand(lee_filter, size=7)
+```
+
+**Notes.**
+
+- `dtype_in="float32"` is critical here.
+  `denoise_tv_chambolle` expects floats and silently does bad things on integer input.
+  The wrapper makes this conversion explicit and YAML-round-trippable.
+- The pipeline runs the filter in dB space (where speckle is additive) rather than linear space (where it’s multiplicative).
+  Mathematically cleaner — TV-Chambolle assumes additive noise.
+- For very large SAR scenes, this is per-pixel CPU-bound.
+  Push to GPU via `cucim.skimage.restoration.denoise_tv_chambolle` for a ~10–50× speedup; same wrapper, just the import changes.
+
+-----
+
+## 2. Cloud-mask post-processing (morphology)
+
+**Setting.** Sentinel-2’s QA60 cloud mask is noisy at the boundaries — isolated cloudy pixels in clear regions, isolated clear pixels in cloudy regions, and ragged edges.
+Morphological opening removes small false-positive clouds; closing fills small holes in cloud bodies; a final dilation expands the mask conservatively to catch unmasked cloud shadows.
+
+**Wrapper.** `PerBand`, accessed via the `Morphology` sugar namespace.
+
+```python
+import geotoolz as gz
+
+cloud_cleanup = gz.Sequential([
+    gz.cloud.MaskFromQABits(qa_band=-1, bits=[10, 11]),  # raw mask
+    gz.skimage.Morphology.opening(radius=2, shape="disk"),   # remove small islands
+    gz.skimage.Morphology.closing(radius=3, shape="disk"),   # fill small holes
+    gz.skimage.Morphology.dilation(radius=5, shape="disk"),  # conservative buffer
+])
+
+# Use the cleaned mask in downstream pipelines
+classification = gz.Sequential([
+    feature_pipeline,
+    gz.cloud.ApplyMask(cloud_cleanup),
+    classifier,
+])
+```
+
+**Notes.**
+
+- The sugar namespace produces `PerBand` Operators under the hood — the YAML config records them as `_target_: geotoolz.skimage.Morphology.opening` with `radius=2, shape="disk"`.
+  Loader resolves the sugar to the underlying `PerBand(morphology.opening, footprint=disk(2))`.
+- Order matters.
+  Opening *then* closing is “remove specks, then fill holes” — the typical cleanup.
+  Closing *then* opening is “fill holes, then remove specks” which produces a different result.
+  Document the intent in comments.
+- For cloud shadows specifically, the `dilation` step is asymmetric — you want to expand the mask in the sun direction.
+  A directional structuring element (`shape="line"` with an angle) does this; for most workflows the symmetric disk is sufficient.
+
+-----
+
+## 3. Adaptive contrast enhancement (CLAHE for viz)
+
+**Setting.** Sentinel-2 true-colour visualisation.
+Histogram-stretched RGB looks flat — shadows are black, highlights are washed out.
+CLAHE (Contrast Limited Adaptive Histogram Equalization) gives much better visual contrast for browse imagery and tile-server output.
+
+**Wrapper.** `PerBand` with explicit dtype conversion.
+
+```python
+import geotoolz as gz
+from skimage import exposure
+
+true_color_clahe = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),
+    gz.radiometry.SelectBands(indices=[3, 2, 1]),    # NIR, R, G — false color
+    gz.radiometry.PercentileClip(p_min=2, p_max=98),
+    gz.core.Rescale(in_range=(0, 10_000), out_range=(0, 1), dtype="float32"),
+    gz.skimage.PerBand(
+        exposure.equalize_adapthist,
+        clip_limit=0.03,
+        kernel_size=128,
+        dtype_in="float01",
+        dtype_out="float32",
+    ),
+    gz.viz.ToUint8RGB(),       # final cast for PNG encoding
+])
+```
+
+**Notes.**
+
+- The explicit `Rescale` before CLAHE is intentional. `equalize_adapthist` with `dtype_in="float01"` would call `img_as_float`, which divides by `dtype.max` — for `uint16` Sentinel-2 reflectance with max value ~10000, that gives values around `0.15`.
+  CLAHE on tiny values produces no visible contrast.
+  The explicit `Rescale(in_range=(0, 10_000))` does the right thing.
+- This pipeline drops into a tile server (the [use-cases doc Example 7](../examples/usecases.md#7-tile-server-zxy--png)) as a layer config. Latency is dominated by CLAHE’s per-tile computation — for sub-second tile rendering, pre-compute and cache.
+
+-----
+
+## 4. Edge detection for field boundaries
+
+**Setting.** Agricultural field-boundary extraction.
+Edges in NDVI or NIR bands often align with field margins (different crops, harvest dates, soil types).
+Sobel or Canny edge detection produces a per-pixel boundary-likelihood map.
+
+**Wrapper.** `PerBand` for Sobel; `Func` for Canny (which is 2D-only with strict input requirements).
+
+```python
+import geotoolz as gz
+
+# Simple: Sobel magnitude per band
+sobel_pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),
+    gz.indices.NDVI(red_idx=2, nir_idx=3),
+    gz.skimage.Filter.sobel(),
+])
+
+# More refined: Canny edges on a smoothed NDVI
+canny_pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),
+    gz.indices.NDVI(red_idx=2, nir_idx=3),
+    gz.skimage.Filter.gaussian(sigma=1.5),
+    gz.skimage.Func(
+        skimage.feature.canny,
+        requires="2d",
+        sigma=1.0,
+        low_threshold=0.1,
+        high_threshold=0.2,
+        dtype_in="float32",
+    ),
+])
+```
+
+**Notes.**
+
+- `Filter.sobel()` is the sugar; it expands to `PerBand(filters.sobel)` under the hood.
+- Canny is `Func` rather than `PerBand` because the input must be a single 2D array — the upstream `NDVI` already produces a single-band output, so no looping is needed.
+  Using `PerBand` here would still work (loop over one band) but `Func` is more honest.
+- For *vectorising* the resulting edge raster into polygons, hand the output to `rasterio.features.shapes` or `geopandas`. skimage stops at raster edges; geotoolz doesn’t (yet) bridge to vector.
+
+-----
+
+## 5. Superpixel segmentation (object-based image analysis)
+
+**Setting.** Object-based image analysis (OBIA) — group similar neighbouring pixels into segments, then classify the segments rather than individual pixels.
+Reduces noise, captures spatial context, and produces output that’s easier to vectorise.
+SLIC (Simple Linear Iterative Clustering) is the standard fast segmenter.
+
+**Wrapper.** `Func` with `requires="3d_hwc"` because SLIC consumes a multi-channel image and returns a single-channel integer label map.
+
+```python
+import geotoolz as gz
+from skimage import segmentation
+
+slic_segmenter = gz.skimage.Func(
+    segmentation.slic,
+    requires="3d_hwc",                       # SLIC wants HWC input
+    n_segments=400,
+    compactness=10,
+    sigma=1.0,
+    start_label=1,
+    channel_axis=-1,
+    dtype_in="float01",
+    dtype_out="int32",
+)
+
+obia_pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),
+    gz.radiometry.SelectBands(indices=[1, 2, 3, 7]),   # G, R, NIR, SWIR
+    gz.radiometry.PercentileClip(p_min=2, p_max=98),
+    gz.core.Rescale(in_range=(0, 10_000), out_range=(0, 1)),
+    slic_segmenter,                                     # → integer-label GeoTensor
+])
+```
+
+For pixel-wise classification informed by segments:
+
+```python
+gz.Sequential([
+    feature_pipeline,
+    gz.core.Fanout({
+        "features": gz.core.Identity(),
+        "segments": slic_segmenter,
+    }),
+    # Aggregate per-segment features (e.g., mean per segment per band)
+    gz.spatial.AggregateBySegments(reduction="mean"),
+    gz.sklearn.PixelwiseClassifier(estimator=segment_clf, ...),
+])
+```
+
+**Notes.**
+
+- `requires="3d_hwc"` triggers the wrapper to transpose CHW → HWC before applying SLIC, then output is already 2D (single label map per pixel), no inverse transpose needed.
+- Segment labels are **arbitrary integers** that change between runs (depend on internal initialisation order).
+  Don’t expect stable labels across re-runs even with the same input — use `start_label` and a fixed random seed if reproducibility matters.
+- For very large scenes, SLIC is memory-heavy.
+  `slic_zero` is a faster variant for the same wrapper signature; `felzenszwalb` is another alternative with different boundary characteristics.
+
+-----
+
+## 6. Inpainting cloud-masked gaps
+
+**Setting.** A Sentinel-2 NDVI mosaic has small holes from masked clouds.
+For visualisation or for downstream filters that don’t tolerate NaN, fill the holes via biharmonic inpainting — a physically-motivated smooth interpolation that respects boundary values.
+
+**Wrapper.** `Func` with `requires="2d"` (inpainting operates on a 2D array with a mask).
+
+```python
+import geotoolz as gz
+from skimage import restoration
+
+class InpaintNaN(Operator):
+    """Biharmonic inpaint over NaN pixels."""
+    def _apply(self, gt):
+        arr = np.asarray(gt).astype(np.float32)
+        mask = np.isnan(arr)
+        if not mask.any():
+            return gt
+        # inpaint per band
+        filled = np.stack([
+            restoration.inpaint_biharmonic(arr[i], mask[i])
+            for i in range(arr.shape[0])
+        ], axis=0)
+        return GeoTensor(values=filled, transform=gt.transform, crs=gt.crs)
+```
+
+Or more idiomatically using `NanFill`:
+
+```python
+gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),
+    gz.indices.NDVI(red_idx=2, nir_idx=3),
+    gz.skimage.NanFill(method="biharmonic"),   # fills NaN gaps
+])
+```
+
+**Notes.**
+
+- Biharmonic inpainting is slow (~seconds per band for a 1024×1024 chip).
+  For dense gap-filling at scale, use a faster method (`method="local_mean"`) and accept the quality trade-off.
+- Use sparingly — inpainting *invents* data.
+  For scientific analysis, keep NaN visible and propagate.
+  For visualisation or as a preprocessing step for filters that crash on NaN, inpainting is correct.
+- Pair with [`Snapshot`](../examples/tips_n_tricks.md#snapshot) to inspect before/after — the `NanFill` should produce visually-plausible output; if it doesn’t, something’s wrong upstream.
+
+-----
+
+## 7. Multi-scale features for ML
+
+**Setting.** Build an ML feature stack from multi-scale image statistics — Gaussian-blurred versions at multiple sigmas, gradient magnitudes, local intensity — to feed a pixel-wise classifier. skimage has a built-in `multiscale_basic_features` that produces all of these in one call.
+
+**Wrapper.** `MultiBand` with `channel_axis=0` (skimage’s function uses channel axis for multi-channel input).
+
+```python
+import geotoolz as gz
+from skimage import feature
+
+multiscale_features = gz.skimage.MultiBand(
+    feature.multiscale_basic_features,
+    channel_axis=0,
+    intensity=True,
+    edges=True,
+    texture=True,
+    sigma_min=1.0,
+    sigma_max=16.0,
+    num_sigma=5,
+)
+
+feature_pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),
+    gz.radiometry.SelectBands(indices=[1, 2, 3, 7]),
+    multiscale_features,           # → many feature bands
+])
+
+classify = gz.Sequential([
+    feature_pipeline,
+    gz.sklearn.PixelwiseClassifier(estimator=clf, ...),
+])
+```
+
+**Notes.**
+
+- The output has many more channels than the input — `multiscale_basic_features` with `num_sigma=5` and three feature types produces ~45 bands from a 4-band input.
+  Downstream `PixelwiseClassifier` automatically picks this up (sklearn’s `n_features_in_` matches the flattened feature count).
+- Fit the classifier on the *same* multi-scale feature definition you’ll use at inference.
+  As with all skimage preprocessing, parity between fit and serve matters — the feature pipeline goes in the YAML, the classifier pickle references it through provenance.
+- Memory cost is real: 45 bands × `(512, 512)` chip × `float32` = ~45 MB per chip just for features.
+  For `RandomForestClassifier`, this is fine.
+  For deep models, consider feature subsetting or smaller sigmas.
+
+-----
+
+## 8. Texture features (GLCM) for land-cover classification
+
+**Setting.** Gray-Level Co-occurrence Matrix (GLCM) statistics are classical texture descriptors — useful for separating urban from bare soil, or forest from shrubland, where spectral signatures alone are ambiguous.
+Compute GLCM properties (contrast, homogeneity, energy, correlation) in sliding windows over each band.
+
+**Wrapper.** Custom `Func` because GLCM doesn’t fit any single skimage function — it’s `greycomatrix` + `greycoprops` over a sliding window.
+
+```python
+import geotoolz as gz
+from skimage.feature import graycomatrix, graycoprops
+from numpy.lib.stride_tricks import sliding_window_view
+
+def glcm_features(band, window=16, distances=[1], angles=[0, np.pi/2]):
+    """Per-pixel GLCM contrast and homogeneity over a window."""
+    band_u8 = (band * 255 / band.max()).astype(np.uint8)
+    out_contrast = np.zeros_like(band, dtype=np.float32)
+    out_homog = np.zeros_like(band, dtype=np.float32)
+    # naive sliding window — not optimised, illustrative only
+    for i in range(window//2, band.shape[0] - window//2):
+        for j in range(window//2, band.shape[1] - window//2):
+            patch = band_u8[i-window//2:i+window//2, j-window//2:j+window//2]
+            glcm = graycomatrix(patch, distances, angles, levels=256, symmetric=True)
+            out_contrast[i, j] = graycoprops(glcm, "contrast").mean()
+            out_homog[i, j] = graycoprops(glcm, "homogeneity").mean()
+    return np.stack([out_contrast, out_homog], axis=0)  # (2, H, W)
+
+# Wrap — per-band returning a 2-channel per-band output
+glcm_op = gz.skimage.Func(
+    glcm_features,
+    requires="2d",
+    window=16,
+    dtype_in="float01",
+    dtype_out="float32",
+)
+```
+
+For practical use, prefer a vectorised GLCM implementation (e.g., via `numba` or `cucim` GPU acceleration) — the naive version above is illustrative but slow.
+
+**Notes.**
+
+- GLCM is genuinely slow without optimisation.
+  For catalog-scale work, use `cucim.skimage.feature` on GPU, or pre-aggregate windows at lower resolution.
+- The output is a multi-channel feature stack (`contrast`, `homogeneity`, optionally `energy`, `correlation`).
+  Drop the whole thing into a feature pipeline alongside spectral bands.
+- For texture-aware classification, combine GLCM features with a per-pixel classifier (Example 7 pattern) — the multi-scale + texture combination often outperforms spectral-only models for built-up area mapping.
+
+-----
+
+## 9. Blob detection for object localisation
+
+**Setting.** Detect localised circular or near-circular features in a raster — solar panels, methane point sources, isolated water bodies, dust plumes.
+`blob_log` (Laplacian of Gaussian) finds local maxima at multiple scales.
+
+**Wrapper.** `Func` with `requires="2d"`; output is a list of `(y, x, sigma)` tuples, not a raster — need a small custom Operator to handle that conversion.
+
+```python
+import geotoolz as gz
+from skimage import feature
+
+class BlobDetector(Operator):
+    """Detect blobs in a single band; return a GeoTensor mask of blob centres."""
+    def __init__(self, band_idx=0, min_sigma=2, max_sigma=10, threshold=0.05):
+        self.band_idx = band_idx
+        self.min_sigma, self.max_sigma = min_sigma, max_sigma
+        self.threshold = threshold
+
+    def _apply(self, gt):
+        band = np.asarray(gt[self.band_idx]).astype(np.float32)
+        blobs = feature.blob_log(
+            band,
+            min_sigma=self.min_sigma,
+            max_sigma=self.max_sigma,
+            threshold=self.threshold,
+        )
+        mask = np.zeros_like(band, dtype=np.float32)
+        for y, x, sigma in blobs:
+            mask[int(y), int(x)] = sigma   # store sigma as proxy for size
+        return GeoTensor(
+            values=mask[np.newaxis],       # (1, H, W)
+            transform=gt.transform, crs=gt.crs,
+        )
+
+# Or, in a pipeline:
+gz.Sequential([
+    matched_filter_pipeline,             # produces methane likelihood
+    BlobDetector(min_sigma=2, max_sigma=10, threshold=0.1),
+])
+```
+
+**Notes.**
+
+- The custom Operator handles the list-of-tuples-to-raster conversion that doesn’t fit any of the three wrappers cleanly.
+  This is the *right* pattern when the function’s return shape doesn’t match the input.
+- The output isn’t a feature stack — it’s a sparse raster with one non-zero value per detected blob.
+  Downstream consumers should treat it as a point-list-encoded-as-raster, not a continuous field.
+- For vector output (`{lat, lon, sigma, intensity}` rows in a GeoDataFrame), the Operator could write directly to a parquet sidecar via a custom terminal Operator — that’s a `Sink`-pattern variant.
+
+-----
+
+## 10. Image registration / co-alignment
+
+**Setting.** Two images of the same scene from different dates are slightly misaligned (sub-pixel to a few pixels) due to orbital geometry and reprojection.
+Phase cross-correlation gives a global translation estimate that can be applied as a sub-pixel shift.
+
+**Wrapper.** `Func` with `requires="2d"`; return value is a `(shift_y, shift_x)` tuple, not a raster — custom Operator.
+
+```python
+import geotoolz as gz
+from skimage.registration import phase_cross_correlation
+from scipy.ndimage import shift
+
+class Coregister(Operator):
+    """Align target to reference using phase cross-correlation."""
+    def __init__(self, *, reference_band=0, upsample_factor=10):
+        self.reference_band = reference_band
+        self.upsample_factor = upsample_factor
+
+    def _apply_pair(self, ref_gt, tgt_gt):
+        ref = np.asarray(ref_gt[self.reference_band]).astype(np.float32)
+        tgt = np.asarray(tgt_gt[self.reference_band]).astype(np.float32)
+        offset, _, _ = phase_cross_correlation(
+            ref, tgt, upsample_factor=self.upsample_factor,
+        )
+        # apply shift to every band of target
+        shifted = np.stack([
+            shift(tgt_gt[i], offset, mode="nearest")
+            for i in range(tgt_gt.shape[0])
+        ], axis=0)
+        return GeoTensor(values=shifted, transform=tgt_gt.transform, crs=tgt_gt.crs)
+```
+
+Use inside a `Graph` for paired inputs:
+
+```python
+ref = gz.core.Input("reference")
+tgt = gz.core.Input("target")
+aligned = Coregister(reference_band=0)._apply_pair(ref, tgt)
+
+g = gz.core.Graph(
+    inputs={"reference": ref, "target": tgt},
+    outputs={"aligned_target": aligned},
+)
+out = g(reference=ref_gt, target=tgt_gt)
+```
+
+**Notes.**
+
+- Phase cross-correlation estimates *global translation* only.
+  For more complex misalignment (rotation, scale, local distortion), use `skimage.transform.AffineTransform` with feature-matching or move to GDAL’s reprojection tooling.
+- The `upsample_factor=10` gives sub-pixel accuracy (~0.1 pixel).
+  Higher values give more precision but slow down the FFT-based correlation.
+- Co-registration is a *prerequisite* for many time-series and change-detection workflows.
+  Running it as the first step of a pipeline (against a fixed reference scene) ensures all subsequent ops see aligned data.
+
+-----
+
+## Cross-cutting observations
+
+Several patterns recur across these examples worth naming:
+
+**dtype handling lives at the wrapper boundary.** Every example specifies `dtype_in` and/or `dtype_out` explicitly.
+Inputs from real readers come in `uint16` (S2 reflectance), `float32` (SAR backscatter), `int16` (DEMs); skimage functions want various things.
+Setting these in the wrapper keeps the conversion visible in YAML and easy to debug.
+
+**Sugar for the common cases, escape hatch for the rest.** Examples 2, 4, and 5 use the sugar namespaces (`Morphology`, `Filter`); Examples 6, 9, and 10 drop to custom Operators or `Func` because the function doesn’t fit a one-line invocation.
+The split is right — sugar covers ~80% of real use; the wrappers cover the rest; custom Operators cover the genuinely-novel cases.
+
+**NaN is the boundary between “works” and “produces garbage near edges”.** Every filter and morphology op has implicit NaN behaviour that’s almost never what you want.
+Either propagate NaN intentionally, fill before filtering (Example 6 pattern), or mask out filter outputs near NaN boundaries explicitly.
+The default `propagate` is honest but rarely operationally correct — set `nan_policy` deliberately.
+
+**Output shape parity.** Examples 1–4, 7–8 preserve `(C, H, W)` — input shape and output shape match (modulo band count).
+Examples 5, 9–10 *change* the shape semantics — segmentation produces label maps, blob detection produces sparse rasters, registration applies transformations.
+Document this in the Operator’s docstring; downstream consumers care.
+
+**Per-band looping is the bottleneck for hyperspectral.** Examples that use `PerBand` over 200-band hyperspectral data run 200 Python iterations.
+Move to `cucim` GPU acceleration (`import cucim.skimage as skimage`) for a near-drop-in speedup, or use vectorised numpy/scipy equivalents (`scipy.ndimage.gaussian_filter` vectorises over `axes=`).
+
+**Chip seams are the silent failure mode.** Running `ApplyToChips` over a skimage filter without overlap produces visible seams at chip boundaries.
+For *any* spatial filter, use `stride < chip_size` and stitch with averaging where possible.
+Catch the seams early with [`Diff`](../examples/tips_n_tricks.md#diff) against a whole-scene reference run on small test scenes.

--- a/projects/geotoolz/plans/geotoolz/sklearn/design_sklearn.md
+++ b/projects/geotoolz/plans/geotoolz/sklearn/design_sklearn.md
@@ -1,0 +1,557 @@
+---
+title: geotoolz.sklearn design doc
+subject: geotoolz design
+subtitle: Wrapping scikit-learn estimators as Operators over GeoTensor
+short_title: sklearn bridge
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: design, geotoolz, sklearn, operators, machine-learning, remote-sensing
+---
+
+> **Status:** draft (2026-05-10) — first design pass on the sklearn bridge.
+> **Scope:** how every scikit-learn estimator (and every `BaseEstimator`-protocol third party — `xgboost`, `lightgbm`, `catboost`, `imbalanced-learn`) lands in a `geotoolz` Operator graph through one `PixelTable` bridging type, a small family of shape adapters (spatial-pixelwise, spatiotemporal-pixelwise, chipwise), and four estimator wrappers (Classifier, Regressor, Transformer, Clusterer) — with first-class NaN strategy taxonomy and an explicit fit-out-of-graph discipline.
+> **Audience:** anyone composing geospatial ML pipelines that lean on the sklearn estimator surface — pixelwise classifiers, transformers, clusterers, gradient-boosted regressors, or any third-party library following the BaseEstimator protocol.
+
+## Goals
+
+Make every scikit-learn estimator (and every third-party library following the `BaseEstimator` protocol — `xgboost`, `lightgbm`, `catboost`, `imbalanced-learn`, custom estimators) usable inside a `geotoolz` operator graph **as a single Operator**, without per-estimator wrapping code.
+
+Concretely:
+
+- One bridging type (`PixelTable`) for sklearn’s `(n_samples, n_features)` shape.
+- A small family of **shape adapters** for the standard majorisation patterns (spatial pixelwise, spatiotemporal pixelwise, chipwise).
+- A small family of **estimator wrappers** — Classifier, Regressor, Transformer, Clusterer — that compose the shape adapter with `.predict` / `.transform`.
+- **First-class NaN handling** with a rich strategy taxonomy, since NaN is the default state of geospatial data and sklearn estimators are intolerant of it.
+- **Fitting is not in the operator graph.** Fit utilities are separate; pre-fitted estimators are the artifact that flows into pipelines.
+
+## Non-goals
+
+- Re-implementing sklearn algorithms in JAX or on GPU.
+- Training inside the operator graph (state, multi-pass).
+- `sktime` / time-series-specific estimators — covered by a follow-on `geotoolz.sktime` integration with the same shape vocabulary.
+- Bridging sklearn to xarray (that’s `xr_toolz`’s job).
+
+## Design philosophy
+
+**Thin glue, not reimplement.** Wrap, don’t fork.
+Every operator in this integration should be ≤ 100 lines.
+The hard work is in defining the right *shape adapters* and the right *NaN policy* — once those are correct, the estimator wrappers are trivial.
+
+**One bridge type, many adapters.** Sklearn’s universe is 2D `(N, F)`.
+The adapters convert between geotoolz’s spatial / spatiotemporal carriers and that shape.
+Adapters are first-class Operators — composable, configurable, and exposed as primitives for users who need custom shape work.
+
+**Honest about state.** Estimators are stateful.
+The operator graph isn’t.
+Resolve by treating the fitted estimator as a **pre-computed artifact** (loaded from `.joblib`, passed in at construction time, hashed into provenance), not as state that the graph manages.
+
+-----
+
+## Carrier types
+
+### `GeoTensor` (recap)
+
+The primary carrier.
+Two shape conventions:
+
+- **Spatial-only:** `(C, H, W)` — bands × rows × cols.
+  Carries `transform` and `crs`.
+- **Spatiotemporal:** `(C, T, H, W)` — bands × time × rows × cols.
+  Carries `transform`, `crs`, and `interval` (the temporal range from `GeoSlice`).
+
+(Some upstream readers also produce `(T, C, H, W)` frame-major arrays; the adapters should accept both via an explicit `time_axis` parameter, default 1.)
+
+### `PixelTable` (new — bridges to sklearn)
+
+Companion carrier for sklearn’s `(n_samples, n_features)` view.
+Holds:
+
+```python
+@dataclass(frozen=True)
+class PixelTable:
+    values:    np.ndarray              # (N, F)
+    height:    int                     # spatial H, for inversion
+    width:     int                     # spatial W, for inversion
+    t_size:    int | None = None       # temporal extent, if any
+    transform: Affine | None = None    # carried through for inversion
+    crs:       CRS | None = None
+    feature_layout: tuple[str, ...] = ()  # e.g. ("c",) or ("t", "c")
+    sample_layout:  tuple[str, ...] = ()  # e.g. ("h", "w") or ("h", "w", "t")
+    mask:      np.ndarray | None = None   # (N,) bool — True where row is valid
+```
+
+The `feature_layout` and `sample_layout` are how the inverse adapter knows which axis a flattened dimension came from.
+The `mask` is how NaN-aware strategies carry validity through.
+
+A `PixelTable` is **not** a `GeoTensor` — different invariants (rows aren’t spatially localised, no per-pixel transform).
+Keeping them distinct prevents accidentally calling a spatial operator on a flattened pixel table.
+
+-----
+
+## Shape adapters
+
+The heart of the integration.
+Adapters are first-class Operators with config- round-trippable parameters.
+The naming convention is `To{X}Major` / `From{X}Major`.
+
+### Spatial pixelwise
+
+The standard land-cover / scene-classification pattern.
+Each pixel is a sample; the bands form the feature vector.
+
+```python
+class ToPixelMajor(Operator):
+    """(C, H, W) → PixelTable with (H*W, C)."""
+    def _apply(self, gt: GeoTensor) -> PixelTable:
+        c, h, w = gt.shape
+        values = np.asarray(gt).transpose(1, 2, 0).reshape(h * w, c)
+        return PixelTable(
+            values=values, height=h, width=w,
+            transform=gt.transform, crs=gt.crs,
+            feature_layout=("c",), sample_layout=("h", "w"),
+        )
+
+class FromPixelMajor(Operator):
+    """PixelTable (H*W, C') → GeoTensor (C', H, W)."""
+    def _apply(self, pt: PixelTable) -> GeoTensor:
+        n, c = pt.values.shape
+        values = pt.values.reshape(pt.height, pt.width, c).transpose(2, 0, 1)
+        return GeoTensor(values=values, transform=pt.transform, crs=pt.crs)
+```
+
+### Spatiotemporal pixelwise
+
+The standard crop-classification-from-time-series pattern.
+Each pixel is a sample; its full timeseries is flattened into the feature vector.
+
+```python
+ToTemporalPixelMajor(time_handling="features")
+# (C, T, H, W) → PixelTable (H*W, T*C)
+# feature_layout=("t", "c"), sample_layout=("h", "w")
+```
+
+Two other temporal majorisations are supported because they correspond to distinct downstream tasks:
+
+```python
+# Time as samples — each (pixel, timestep) pair is a sample. For temporal
+# anomaly detection, change-point classifiers, per-step regressors.
+ToTemporalPixelMajor(time_handling="samples")
+# (C, T, H, W) → PixelTable (H*W*T, C)
+# feature_layout=("c",), sample_layout=("h", "w", "t")
+
+# Per-pixel timeseries — for `sktime`-style estimators that expect each row
+# to *be* a timeseries (panel format).
+ToTemporalPixelMajor(time_handling="panel")
+# (C, T, H, W) → PanelTable (H*W, C, T)
+```
+
+The `panel` mode produces a third carrier (`PanelTable`) used only by `sktime`-compatible estimators.
+Most sklearn workflows live in `features` mode.
+
+**Often the right move is to reduce time first**, keeping the sklearn wrapper time-agnostic.
+A `TimeAggregate` operator (mean, percentile, harmonic amplitude) collapses `(C, T, H, W) → (C', H, W)`; then a plain `PixelwiseX` runs on the spatial result.
+This pushes temporal feature engineering into a dedicated operator and keeps the sklearn integration simple.
+The dedicated adapters are there for cases where temporal structure matters as a feature to the estimator itself.
+
+### Chipwise / scenewise
+
+The whole chip is one sample, all pixels are features.
+For scene-level classification, image-level regression, embedding-based retrieval.
+
+```python
+ToChipMajor()
+# (C, H, W) → PixelTable (1, C*H*W) with sample_layout=("chip",)
+# or for a batch of chips, (B, C*H*W)
+```
+
+### Bandwise (rare but real)
+
+Each band is a sample; pixels are features.
+For spectral clustering across bands.
+
+```python
+ToBandMajor()
+# (C, H, W) → PixelTable (C, H*W)
+```
+
+### The shape-adapter contract
+
+Every `To{X}Major` adapter:
+
+1. Preserves enough metadata in the output `PixelTable` for a `From{X}Major` to reconstruct the original carrier shape.
+2. Records the layout explicitly (`feature_layout`, `sample_layout`) so downstream operators can introspect and validate.
+3. Round-trips through YAML (`get_config()` returns a flat dict of primitives).
+4. Optionally carries a validity mask through, enabling NaN policies that need to skip rows.
+
+-----
+
+## Estimator wrappers
+
+Four core wrappers, one per sklearn estimator type.
+Each composes a shape adapter (configurable, default `ToPixelMajor`) with the estimator’s `.predict` / `.transform` / `.predict_proba` method.
+
+```python
+gz.sklearn.PixelwiseClassifier(estimator=clf)          # .predict, integer labels
+gz.sklearn.PixelwiseRegressor(estimator=reg)           # .predict, continuous
+gz.sklearn.PixelwiseTransformer(estimator=pca)         # .transform → multi-band
+gz.sklearn.PixelwiseClusterer(estimator=kmeans)        # .predict, cluster IDs
+gz.sklearn.PixelwiseProba(estimator=clf)               # .predict_proba → C bands
+gz.sklearn.PixelwiseDecision(estimator=svm)            # .decision_function
+```
+
+Each accepts the same kwargs:
+
+```python
+gz.sklearn.PixelwiseClassifier(
+    estimator=clf,
+    adapter=gz.sklearn.ToPixelMajor(),    # configurable; default by name
+    nan_policy=gz.sklearn.NanPolicy.default("classifier"),
+    output_dtype="uint8",
+)
+```
+
+For temporal estimators, swap the adapter:
+
+```python
+gz.sklearn.PixelwiseClassifier(
+    estimator=time_series_clf,
+    adapter=gz.sklearn.ToTemporalPixelMajor(time_handling="features"),
+)
+```
+
+For sklearn objects that don’t fit the type-named wrappers (custom estimators with non-standard methods), there’s a generic escape hatch:
+
+```python
+gz.sklearn.SklearnOp(
+    estimator=custom,
+    method="predict",           # which method to call
+    adapter=ToPixelMajor(),
+    nan_policy=NanPolicy(...),
+)
+```
+
+The type-named wrappers are sugar over `SklearnOp` with sensible defaults (`output_dtype`, `nan_policy` defaults appropriate for the method).
+
+-----
+
+## NaN handling
+
+The single most important design surface in this integration.
+Geospatial data is mostly NaN somewhere (clouds, sensor gaps, out-of-swath, masking), and sklearn estimators are intolerant of it.
+The strategy needs to be **explicit, configurable per-axis, and visible in the operator graph’s YAML config**.
+
+### Strategy taxonomy
+
+|Strategy   |Behaviour                                                       |When to use                                  |
+|-----------|----------------------------------------------------------------|---------------------------------------------|
+|`raise`    |Error on any NaN in input                                       |Production ETL where NaN is a bug            |
+|`warn`     |Log NaN presence, then apply fallback strategy                  |Debug / staging                              |
+|`propagate`|Pass NaN through to estimator (usually crashes)                 |Custom NaN-tolerant estimators               |
+|`mask`     |Skip NaN rows; output `fill_value` at masked positions          |Standard for inference                       |
+|`drop`     |Drop NaN rows entirely; output array has fewer rows             |Fitting-time only                            |
+|`impute`   |Fill NaN with strategy (mean, median, zero, constant)           |When NaN is sparse and imputation is harmless|
+|`partial`  |Per-sample: if NaN fraction below threshold, impute; else mask  |Mixed clean/sparse data                      |
+|`fill`     |Replace NaN with a sentinel value before estimator              |When estimator handles a known sentinel      |
+|`sentinel` |Treat a specific value (not NaN) as missing, then apply strategy|When upstream uses `-9999` etc.              |
+
+The strategies aren’t mutually exclusive — `partial` composes `impute` and `mask`; `sentinel` composes a value-to-NaN conversion with another strategy.
+
+### `NanPolicy` — a first-class config object
+
+```python
+@dataclass(frozen=True)
+class NanPolicy:
+    on_input:         str = "mask"          # strategy applied to features (X)
+    on_output:        str = "propagate"     # strategy for estimator-produced NaN
+    on_label:         str = "drop"          # fitting only: strategy for labels (y)
+    fill_value:       Any = np.nan          # written where masked rows would be
+    impute_strategy:  str = "mean"          # "mean" | "median" | "zero" | "constant"
+    impute_constant:  float = 0.0
+    threshold:        float | None = None   # for "partial": NaN fraction threshold
+    sentinel_value:   float | None = None   # for "sentinel": value to treat as NaN
+    on_violation:     str = "raise"         # what `raise` / `warn` do
+```
+
+Default policies per estimator type:
+
+```python
+NanPolicy.default("classifier")
+# NanPolicy(on_input="mask", on_output="propagate", fill_value=-1, on_label="drop")
+
+NanPolicy.default("regressor")
+# NanPolicy(on_input="mask", on_output="propagate", fill_value=np.nan, on_label="drop")
+
+NanPolicy.default("transformer")
+# NanPolicy(on_input="mask", on_output="propagate", fill_value=np.nan, on_label=None)
+```
+
+Sensible shortcuts:
+
+```python
+PixelwiseClassifier(estimator=clf, nan="mask")        # str shortcut → default mask policy
+PixelwiseClassifier(estimator=clf, nan=NanPolicy(on_input="impute", impute_strategy="median"))
+PixelwiseClassifier(estimator=clf, nan="raise")       # strict ETL
+```
+
+### Where NaN policy applies
+
+Three points in the lifecycle where NaN appears, each handled distinctly:
+
+**1. Input NaN (features X).** Most common case.
+Pixels with missing bands.
+Resolved by `nan_policy.on_input`.
+
+```python
+# (C, H, W) input → some pixels have NaN in some bands
+PixelwiseClassifier(estimator=clf, nan=NanPolicy(on_input="mask"))
+# Output: (1, H, W) with -1 (fill_value) at any NaN pixel.
+```
+
+**2. Label NaN (labels y, fit-time only).** Missing or invalid labels.
+Resolved by `nan_policy.on_label`.
+Typically `drop` (drop rows where label is missing — can’t fit a model on unlabeled samples).
+
+**3. Output NaN (estimator-produced).** Some regressors and transformers produce NaN under degenerate conditions.
+Resolved by `nan_policy.on_output`.
+Usually `propagate` is right — the estimator’s NaN is meaningful and should flow through.
+
+### Composition: NaN handling as an Operator
+
+For complex cases, NaN handling is itself an Operator chain that can be lifted out of the wrapper:
+
+```python
+gz.Sequential([
+    gz.sklearn.NanReplace(sentinel=-9999, with_=np.nan),  # sentinel → NaN
+    gz.sklearn.NanImpute(strategy="median"),              # fill NaN
+    gz.sklearn.PixelwiseClassifier(estimator=clf, nan="raise"),  # now strict
+])
+```
+
+Equivalent to wrapping the policy inside the classifier, but more explicit and easier to debug (intermediate carriers can be Snapshot-tapped).
+
+-----
+
+## Fitting (outside the graph)
+
+Deliberate design: **fitting is a separate ceremony.** The operator graph is stateless; the fitted estimator is the artifact that flows into it.
+This keeps graphs YAML-reproducible and avoids the “did this graph fit on the right data?” ambiguity.
+
+### Batch fit
+
+```python
+clf = gz.sklearn.fit_pixelwise(
+    estimator=Pipeline([
+        ("scaler", StandardScaler()),
+        ("clf",    RandomForestClassifier(n_estimators=200)),
+    ]),
+    X_pipeline=feature_pipeline,            # Operator producing GeoTensor features
+    y_pipeline=label_pipeline,              # Operator producing GeoTensor labels
+    catalog=training_catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=200),
+    n_pixels=500_000,                       # subsample down from accumulated chips
+    nan_policy=NanPolicy(on_input="drop", on_label="drop"),
+    sample_weight_band=None,                # optional: which band gives sample weights
+    random_state=42,
+)
+joblib.dump(clf, "/models/crop_rf.joblib")
+```
+
+The X and y pipelines are themselves Operators — they could be sourced from two different readers (Sentinel-2 features, a labeled land-cover raster for labels), and the helper handles spatial alignment via the shared `GeoSlice`.
+
+### Incremental fit
+
+For estimators that support `partial_fit` (SGD-based learners, MiniBatchKMeans), or when the training set is too large for memory:
+
+```python
+clf = gz.sklearn.fit_pixelwise_incremental(
+    estimator=SGDClassifier(loss="log_loss"),
+    X_pipeline=feature_pipeline,
+    y_pipeline=label_pipeline,
+    catalog=training_catalog,
+    sampler=gz.sampling.GridSampler(chip_size=(256, 256)),
+    chunk_size=10_000,
+    classes=np.arange(N_CLASSES),           # required for partial_fit on classifiers
+    epochs=3,
+    nan_policy=NanPolicy(on_input="drop", on_label="drop"),
+)
+```
+
+### Time-aware fitting
+
+When the X pipeline produces `(C, T, H, W)` and the estimator is temporal (or expects flattened-time features):
+
+```python
+clf = gz.sklearn.fit_pixelwise(
+    estimator=RandomForestClassifier(),
+    X_pipeline=temporal_feature_pipeline,
+    y_pipeline=label_pipeline,
+    adapter=gz.sklearn.ToTemporalPixelMajor(time_handling="features"),
+    ...
+)
+```
+
+The same adapter is then used at inference time, ensuring train/inference shape parity.
+
+### Sample weighting
+
+Geospatial labels often come with confidence scores or pixel-area weights.
+The helper accepts a `sample_weight_band` (the band index in the label GeoTensor that carries weights):
+
+```python
+fit_pixelwise(..., y_pipeline=label_pipeline, sample_weight_band=1)
+# Band 0 of y_pipeline output → labels; band 1 → sample_weight passed to estimator
+```
+
+### Persistence
+
+The fit helpers return the *fitted estimator object*, not an Operator.
+The user is responsible for `joblib.dump` (or ONNX export).
+At inference time:
+
+```python
+clf = joblib.load("/models/crop_rf.joblib")
+pipeline = gz.Sequential([
+    feature_pipeline,
+    gz.sklearn.PixelwiseClassifier(estimator=clf, nan="mask"),
+])
+```
+
+The Operator’s `get_config()` records the estimator’s class and parameters (via `estimator.get_params()`), plus a hash of the estimator pickle.
+The pickle path itself is *not* serialised — it’s a runtime injection.
+This matches how `ModelOp` handles PyTorch checkpoints: the artifact is referenced by hash, not embedded.
+
+-----
+
+## sklearn Pipeline interop
+
+The composition story. sklearn’s own `Pipeline`, `ColumnTransformer`, `FeatureUnion`, and any third-party estimator following the protocol drop in *as a single Operator*:
+
+```python
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.decomposition import PCA
+from xgboost import XGBClassifier
+
+# Build sklearn Pipeline normally
+sklearn_pipe = Pipeline([
+    ("scaler",  StandardScaler()),
+    ("pca",     PCA(n_components=8)),
+    ("clf",     XGBClassifier(n_estimators=200, tree_method="hist")),
+])
+sklearn_pipe.fit(X_train, y_train)
+joblib.dump(sklearn_pipe, "crop_full.joblib")
+
+# Geotoolz side: one Operator wraps the whole sklearn graph
+gz.sklearn.PixelwiseClassifier(estimator=joblib.load("crop_full.joblib"))
+```
+
+Why this matters: every estimator on PyPI that follows the `BaseEstimator` protocol (and that’s most of them) is supported without per-estimator code in `geotoolz`.
+The wrapping cost stays constant as the sklearn ecosystem grows.
+
+The estimator hash includes the full nested config, so an `xgboost` version bump shows up in provenance metadata — important for reproducibility audits.
+
+-----
+
+## Serialisation and reproducibility
+
+The trickiest part of the integration.
+Two challenges:
+
+**Pickle drift.** Sklearn pickles aren’t guaranteed stable across versions — a `RandomForestClassifier` pickle from sklearn 1.3 may not load in 1.5. Mitigations:
+
+- Pin `scikit-learn` (and `numpy`, `scipy`) in the `poetry.lock` that ships with regulatory artifacts.
+- For long-lived production models, prefer ONNX export over joblib: `skl2onnx.convert_sklearn(clf, ...)` produces a stable format readable by any ONNX runtime.
+- The `PixelwiseClassifier` should accept *either* a Python estimator object *or* an ONNX runtime session; behaviour is identical from the Operator side.
+
+**Provenance.** The artifact pattern from [the regulatory use case](../examples/usecases.md#9-pinned--hashed-regulatory-artifact) must extend to include estimator pickles.
+The pinned artifact contains:
+
+- pipeline YAML (geotoolz graph)
+- estimator pickles or ONNX files referenced by the YAML
+- combined hash covering both
+- `poetry.lock` covering sklearn + dependencies
+
+Otherwise the YAML alone is insufficient — you can’t re-run a graph that references `/models/crop_rf.joblib` without that file plus the sklearn version that produced it.
+
+-----
+
+## Compatibility utilities (reference)
+
+The full surface of the integration.
+Roughly 15 operators / utilities; the estimator wrappers are the user-facing API, the rest are primitives and helpers.
+
+### Shape adapters
+
+- `gz.sklearn.ToPixelMajor()` — `(C, H, W) → PixelTable (H*W, C)`
+- `gz.sklearn.FromPixelMajor()` — inverse
+- `gz.sklearn.ToTemporalPixelMajor(time_handling=...)` — `(C, T, H, W) → PixelTable` - `time_handling="features"` → `(H*W, T*C)` - `time_handling="samples"`  → `(H*W*T, C)` - `time_handling="panel"`    → `PanelTable (H*W, C, T)`
+- `gz.sklearn.FromTemporalPixelMajor()` — inverse (output shape determined by estimator’s per-row output)
+- `gz.sklearn.ToChipMajor()` — `(C, H, W) → (1, C*H*W)` for scene-level
+- `gz.sklearn.ToBandMajor()` — `(C, H, W) → (C, H*W)` for spectral clustering
+
+### Estimator wrappers
+
+- `gz.sklearn.PixelwiseClassifier(estimator=..., ...)` — `.predict` → integer label band
+- `gz.sklearn.PixelwiseRegressor(estimator=..., ...)` — `.predict` → continuous band
+- `gz.sklearn.PixelwiseTransformer(estimator=..., ...)` — `.transform` → C’ bands
+- `gz.sklearn.PixelwiseClusterer(estimator=..., ...)` — `.predict` → cluster IDs
+- `gz.sklearn.PixelwiseProba(estimator=..., ...)` — `.predict_proba` → per-class bands
+- `gz.sklearn.PixelwiseDecision(estimator=..., ...)` — `.decision_function`
+- `gz.sklearn.ChipwiseClassifier(estimator=..., ...)` — scene-level variants
+- `gz.sklearn.SklearnOp(estimator=..., method=..., ...)` — generic escape hatch
+
+### NaN handling
+
+- `gz.sklearn.NanPolicy(...)` — config object, defaults per estimator type
+- `gz.sklearn.NanReplace(sentinel=..., with_=np.nan)` — sentinel ↔ NaN conversion
+- `gz.sklearn.NanImpute(strategy=...)` — standalone imputer Operator
+
+### Fitting helpers (not Operators)
+
+- `gz.sklearn.fit_pixelwise(...)` — batch fit
+- `gz.sklearn.fit_pixelwise_incremental(...)` — `partial_fit` loop
+
+### ONNX bridge
+
+- `gz.sklearn.OnnxEstimator(session, input_name=..., output_name=...)` — wraps an ONNX runtime session in an sklearn-compatible protocol (`.predict`, `.transform`) so the same `PixelwiseX` wrappers work over ONNX inference
+
+-----
+
+## Honest tradeoffs
+
+**CPU-bound.** Sklearn is numpy/Cython; the wrappers inherit that.
+For high-throughput inference, GPU-accelerated estimators (XGBoost with `device= 'cuda'`, RAPIDS cuML) drop in via the same wrappers — but plain sklearn algorithms don’t get GPU acceleration just by living in a geotoolz pipeline.
+
+**Memory cost of `ToPixelMajor`.** A `(C, H, W)` chip with `H=W=512, C=10` is 10 MB; the corresponding `PixelTable` is also 10 MB (just reshaped).
+Fine.
+But `ToTemporalPixelMajor` with `time_handling="features"` on `(C=10, T=12, H=512, W=512)` produces a `(262144, 120)` table — 250 MB. For full-scene inference, prefer chip-based inference via `ApplyToChips` rather than whole-scene `ToTemporalPixelMajor`.
+
+**Pickle drift.** sklearn pickles aren’t a long-term archive format.
+Treat joblib files as deployment artifacts (months), not regulatory artifacts (years).
+For multi-year reproducibility, mandate ONNX export.
+
+**No in-graph fitting.** A real cost — users can’t write `gz.Sequential([ preprocess, FitAndPredict(estimator=clf) ])` and have the graph learn from the data flowing through.
+Workaround: fit utilities are first-class and ergonomic; the regulatory-artifact pattern includes both the YAML and the fitted estimator.
+The win is that operator graphs stay deterministic, which is worth more than the lost convenience.
+
+**Adapter naming surface.** `ToPixelMajor` vs `ToTemporalPixelMajor` vs `ToChipMajor` is fine at 4-5 names; if it grows to 10, refactor toward a single `Reshape(samples=..., features=...)` primitive with the named versions as thin sugar.
+
+**sklearn Pipeline introspection.** A wrapped sklearn `Pipeline` reports as one Operator in `geotoolz`‘s `get_config()`, even though it contains multiple sklearn stages.
+That’s correct for the operator-graph view (the fitted estimator is an atomic artifact) but means `Profile().wrap(op)` can’t time individual sklearn stages.
+For that, profile inside sklearn directly.
+
+## Open questions
+
+- **Should `PanelTable` exist now or wait for `geotoolz.sktime`?** The three-carrier proliferation (`GeoTensor`, `PixelTable`, `PanelTable`) is a real cost.
+  Pushing the `panel` case into the sktime integration would let `geotoolz.sklearn` stay with two carriers.
+- **`NanPolicy` config nesting in YAML.** A `NanPolicy` dataclass nested inside a `PixelwiseClassifier` config nested inside a `Sequential` is three levels of YAML. Worth a flat-string shorthand (`nan: "mask:fill=-1"` parsed into a `NanPolicy`)?
+- **Validation across the adapter / estimator boundary.** Should the wrapper verify at construction time that the adapter’s output feature count matches the estimator’s `n_features_in_`?
+  Pro: catches train/serve shape mismatches early.
+  Con: requires `__init__`-time introspection of a fitted estimator, which makes the construction less robust.

--- a/projects/geotoolz/plans/geotoolz/sklearn/design_sklearn.md
+++ b/projects/geotoolz/plans/geotoolz/sklearn/design_sklearn.md
@@ -491,7 +491,10 @@ Roughly 15 operators / utilities; the estimator wrappers are the user-facing API
 
 - `gz.sklearn.ToPixelMajor()` — `(C, H, W) → PixelTable (H*W, C)`
 - `gz.sklearn.FromPixelMajor()` — inverse
-- `gz.sklearn.ToTemporalPixelMajor(time_handling=...)` — `(C, T, H, W) → PixelTable` - `time_handling="features"` → `(H*W, T*C)` - `time_handling="samples"`  → `(H*W*T, C)` - `time_handling="panel"`    → `PanelTable (H*W, C, T)`
+- `gz.sklearn.ToTemporalPixelMajor(time_handling=...)` — `(C, T, H, W) → PixelTable`
+  - `time_handling="features"` → `(H*W, T*C)`
+  - `time_handling="samples"`  → `(H*W*T, C)`
+  - `time_handling="panel"`    → `PanelTable (H*W, C, T)`
 - `gz.sklearn.FromTemporalPixelMajor()` — inverse (output shape determined by estimator’s per-row output)
 - `gz.sklearn.ToChipMajor()` — `(C, H, W) → (1, C*H*W)` for scene-level
 - `gz.sklearn.ToBandMajor()` — `(C, H, W) → (C, H*W)` for spectral clustering

--- a/projects/geotoolz/plans/geotoolz/sklearn/examples_sklearn.md
+++ b/projects/geotoolz/plans/geotoolz/sklearn/examples_sklearn.md
@@ -1,0 +1,725 @@
+---
+title: geotoolz.sklearn examples
+subject: geotoolz examples
+subtitle: A gallery of sklearn Operator patterns over GeoTensor
+short_title: sklearn examples
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: design, geotoolz, sklearn, examples, machine-learning, remote-sensing
+---
+
+> **Status:** companion to [`design_sklearn.md`](design_sklearn.md) — worked examples across the three fit/predict mental models.
+> **Audience:** anyone wiring scikit-learn (or an `xgboost` / `lightgbm` / `catboost` / `imbalanced-learn` estimator) into a `geotoolz` pipeline for classification, regression, transformation, clustering, temporal modelling, cross-validation, or incremental fitting on raster data.
+
+Companion to the [design doc](design_sklearn.md).
+Examples cover classification, regression, transformations, sklearn Pipeline composition, unsupervised clustering, temporal models, cross-validation, and incremental fitting — across the three fit/predict mental models below.
+
+## Contents
+
+- [Mental models](#mental-models)
+- [Patch-generation strategies](#patch-generation-strategies)
+- [1. Crop classification (global fit, global predict)](#1-crop-classification-global-fit-global-predict)
+- [2. Chipwise inference for large scenes (global fit, local predict)](#2-chipwise-inference-for-large-scenes-global-fit-local-predict)
+- [3. Forest biomass regression](#3-forest-biomass-regression)
+- [4. Pixel-wise PCA dimensionality reduction](#4-pixel-wise-pca-dimensionality-reduction)
+- [5. Full sklearn Pipeline composition](#5-full-sklearn-pipeline-composition)
+- [6. Per-tile classifier (local fit, local predict)](#6-per-tile-classifier-local-fit-local-predict)
+- [7. Time-series crop classification](#7-time-series-crop-classification)
+- [8. Spatial cross-validation with `GridSearchCV`](#8-spatial-cross-validation-with-gridsearchcv)
+- [9. Unsupervised land-cover clustering](#9-unsupervised-land-cover-clustering)
+- [10. Incremental fitting for large training sets](#10-incremental-fitting-for-large-training-sets)
+
+-----
+
+## Mental models
+
+Three common fit/predict relationships in geospatial ML, each with different implications for the operator graph:
+
+**Fit globally + predict globally.** Sample training pixels across the full catalog (multiple scenes, multiple regions, multiple seasons).
+Fit one estimator.
+Apply that estimator to *anything* in the catalog at inference.
+The standard supervised-learning case — most appropriate when the underlying relationship between features and labels is stationary across the catalog.
+
+**Fit globally + predict locally (patches).** Same global fit, but inference runs patch-by-patch via `ApplyToChips`.
+The patches are an implementation detail of inference (memory, tile-server latency, parallelism), not a modelling choice.
+The estimator doesn’t know it’s being run on patches — the predictions are stitched back into the full output.
+
+**Fit locally + predict locally.** Train a separate estimator per region (per MGRS tile, per season, per ecoregion, per scene).
+Each estimator only predicts on its corresponding region.
+Use when spatial heterogeneity is real — different atmospheric conditions, different crop calendars, different sensor calibrations — and a global model would underperform.
+Implementation: a registry of fitted estimators, dispatched via `Switch` on metadata.
+
+A fourth pattern — **fit locally + predict globally** (transfer learning, domain adaptation) — exists but isn’t covered here; it’s an active research area, not a stable pattern.
+
+## Patch-generation strategies
+
+When the data comes in patches — for fitting *or* inference — there are several ways to produce them.
+The right choice depends on data scale, where the workflow lives, and whether `fit` and `predict` need the same patches.
+
+**1. `GeoCatalog` + sampler (geotoolz-native).** Lazy, catalog-driven.
+Each patch is read independently from cloud storage via a `GeoSlice`.
+Scales to planetary catalogs because no scene is ever fully materialised.
+The default choice for *training over a catalog* and for *inference over a catalog*.
+
+```python
+sampler = gz.sampling.GridSampler(chip_size=(256, 256))
+for sl in sampler(catalog):
+    with georeader.RasterioReader.open(sl.source_uri) as r:
+        gt = r.read_geoslice(sl)
+    process(gt)
+```
+
+**2. Read whole + `xrpatcher` (eager).** Read a full scene into xarray, then chop it into patches.
+One read, many patches — better I/O when patches are densely sampled from one scene.
+The right choice for *single-scene workflows* (experimentation, viz, quick prototypes).
+
+```python
+import xrpatcher
+ds = xr.open_dataset(scene_uri)
+patches = xrpatcher.XRDAPatcher(ds, patches=dict(x=256, y=256), strides=dict(x=224, y=224))
+for patch_ds in patches:
+    gt = GeoTensor.from_xarray(patch_ds)
+    process(gt)
+```
+
+**3. `ApplyToChips` (geotoolz, inference-only).** Wraps an in-memory GeoTensor as chips for *inference*.
+The right choice when you already have a full scene loaded and want to run a chipwise model over it.
+Not for fitting (no label coupling).
+
+```python
+infer = gz.inference.ApplyToChips(
+    sampler=gz.sampling.GridSampler(chip_size=(256, 256), stride=(224, 224)),
+    chip_op=pipeline,
+    stitcher=gz.sampling.Stitch(method="average"),
+)
+pred = infer(scene_gt)
+```
+
+Heuristics:
+
+|Task                                     |Strategy                    |
+|-----------------------------------------|----------------------------|
+|Training over many scenes                |GeoCatalog + `RandomSampler`|
+|Validation on a held-out scene catalog   |GeoCatalog + `GridSampler`  |
+|Inference on a single scene (full output)|`ApplyToChips`              |
+|Inference across a catalog               |`CatalogPipeline`           |
+|Single-scene experimentation             |Read whole + `xrpatcher`    |
+
+The examples below cite which strategy they use, with the rationale.
+
+-----
+
+## 1. Crop classification (global fit, global predict)
+
+**Setting.** Multi-class crop classification from Sentinel-2 monthly composites across an agricultural region (multiple MGRS tiles, one growing season).
+One Random Forest fit on pixels sampled from across the training catalog; applied to held-out scenes at inference.
+
+**Patch strategy.** `GeoCatalog + RandomSampler` for training (lazy, catalog-scale).
+Per-scene prediction at inference (each scene read whole in this example; chipwise inference shown in the next example).
+
+```python
+import geotoolz as gz
+import georeader
+import joblib
+from sklearn.ensemble import RandomForestClassifier
+
+# === Training catalog: S2 chips with co-located crop labels ===
+train_catalog = georeader.catalog.open_catalog("s3://crop/train_2024.parquet")
+
+feature_pipeline = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),
+    gz.correction.TOAToBOA(sun_zenith_band=-2),
+    gz.indices.AppendIndex(gz.indices.NDVI(red_idx=2, nir_idx=3), name="ndvi"),
+    gz.indices.AppendIndex(gz.indices.NDWI(green_idx=1, nir_idx=3), name="ndwi"),
+])
+
+label_pipeline = gz.Sequential([
+    gz.catalog_ops.ReadLabel(label_uri_field="label_uri", band="crop_class"),
+])
+
+# === Fit globally ===
+clf = gz.sklearn.fit_pixelwise(
+    estimator=RandomForestClassifier(n_estimators=300, max_depth=20, n_jobs=-1),
+    X_pipeline=feature_pipeline,
+    y_pipeline=label_pipeline,
+    catalog=train_catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=500),
+    n_pixels=1_000_000,
+    nan_policy=gz.sklearn.NanPolicy(on_input="drop", on_label="drop"),
+    random_state=42,
+)
+joblib.dump(clf, "/models/crop_rf_2024.joblib")
+
+# === Predict globally ===
+predict_pipeline = gz.Sequential([
+    feature_pipeline,
+    gz.sklearn.PixelwiseClassifier(
+        estimator=joblib.load("/models/crop_rf_2024.joblib"),
+        nan="mask",                       # NaN pixels → fill_value
+        output_dtype="uint8",
+    ),
+])
+
+test_catalog = georeader.catalog.open_catalog("s3://crop/test_2024.parquet")
+gz.catalog_ops.CatalogPipeline(
+    test_catalog,
+    gz.Sequential([
+        predict_pipeline,
+        gz.catalog_ops.WriteCOG(path_template="s3://out/crop_2024/{tile}.tif"),
+    ]),
+    n_workers=8,
+).run()
+```
+
+**Notes on this example.**
+
+- `nan_policy` differs between fit and predict.
+  Fitting *drops* NaN rows (you can’t learn from incomplete pixels).
+  Inference *masks* them and writes `fill_value` to the output (`-1` for classifiers by default).
+  The fit and predict pipelines aren’t required to share NaN strategy.
+- `feature_pipeline` is identical in both paths.
+  The cloud mask and atmospheric correction are part of the model’s contract — if they differ between train and serve, the model degrades silently.
+  Keeping one shared object is the train/serve skew prevention from the [use-cases doc](../examples/usecases.md#3-ml-training-and-inference).
+
+-----
+
+## 2. Chipwise inference for large scenes (global fit, local predict)
+
+**Setting.** Same crop classifier as Example 1, but inference now runs on full Sentinel-2 tiles (~10,980 × 10,980 pixels, ~1 GB in memory).
+Whole-scene inference would OOM on a workstation; chipwise inference holds memory constant.
+
+**Patch strategy.** `ApplyToChips` over a full-scene GeoTensor.
+The same model from Example 1 — no retraining.
+
+```python
+clf = joblib.load("/models/crop_rf_2024.joblib")
+
+# Chip operator: features + classifier. Same as Example 1's predict_pipeline.
+chip_op = gz.Sequential([
+    feature_pipeline,
+    gz.sklearn.PixelwiseClassifier(estimator=clf, nan="mask", output_dtype="uint8"),
+])
+
+# Wrap as a chipwise inference Operator.
+infer = gz.inference.ApplyToChips(
+    sampler=gz.sampling.GridSampler(chip_size=(512, 512), stride=(480, 480)),
+    chip_op=chip_op,
+    stitcher=gz.sampling.Stitch(method="majority"),  # vote per pixel across overlap
+)
+
+# Apply to full-scene GeoTensor.
+with georeader.RasterioReader.open("s3://s2/tile_29SND_2024-08-12.tif") as r:
+    scene_gt = r.read_geoslice(scene_slice)
+
+prediction = infer(scene_gt)
+georeader.save_cog(prediction, "/out/29SND_2024-08-12_crop.tif")
+```
+
+**Notes.**
+
+- Overlap (`stride=480 < chip_size=512`) costs ~10% more reads for smoother boundaries.
+  For classification, `Stitch(method="majority")` votes per pixel; for probability outputs use `method="average"`.
+- The classifier itself doesn’t change.
+  This is purely an inference-pattern shift driven by memory constraints, not a modelling decision.
+  The estimator artifact is the same.
+- For *production* tile-server use (Example 7 of the [use-cases doc](../examples/usecases.md#7-tile-server-zxy--png)), go further and tile at z/x/y level instead of pre-computing a full scene.
+
+-----
+
+## 3. Forest biomass regression
+
+**Setting.** Aboveground biomass (continuous, Mg/ha) from Sentinel-1 + Sentinel-2 fused features.
+Regression rather than classification — different default NaN policy, different output dtype, different metrics.
+
+**Patch strategy.** `GeoCatalog + RandomSampler` for training.
+Per-scene prediction at inference (same as Example 1).
+
+```python
+import geotoolz as gz
+from sklearn.ensemble import GradientBoostingRegressor
+
+# === Fused feature pipeline: optical + radar ===
+feature_pipeline = gz.Graph(
+    inputs={"optical": gz.core.Input("optical"), "sar": gz.core.Input("sar")},
+    outputs={"features": gz.fusion.AlignAndStack(target_grid="optical")(
+        gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11])(gz.core.Input("optical")),
+        gz.sar.LinearToDB()(gz.sar.LeeSpeckle(window=7)(gz.core.Input("sar"))),
+    )},
+)
+
+# === Fit ===
+reg = gz.sklearn.fit_pixelwise(
+    estimator=GradientBoostingRegressor(n_estimators=500, max_depth=5, learning_rate=0.05),
+    X_pipeline=feature_pipeline,
+    y_pipeline=gz.catalog_ops.ReadLabel(label_uri_field="agb_uri", band="agb_mg_ha"),
+    catalog=biomass_train_catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=300),
+    n_pixels=500_000,
+    nan_policy=gz.sklearn.NanPolicy(
+        on_input="drop",
+        on_label="drop",
+    ),
+)
+joblib.dump(reg, "/models/agb_gbr.joblib")
+
+# === Predict ===
+predict = gz.Sequential([
+    feature_pipeline,
+    gz.sklearn.PixelwiseRegressor(
+        estimator=joblib.load("/models/agb_gbr.joblib"),
+        nan="mask",
+        fill_value=np.nan,                # ← regression default; classification used -1
+        output_dtype="float32",
+    ),
+])
+```
+
+**Notes.**
+
+- `PixelwiseRegressor` rather than `PixelwiseClassifier`.
+  The wrapper calls `.predict()` either way, but defaults differ: `fill_value=np.nan` (vs `-1` for classifiers), `output_dtype="float32"` (vs `uint8`).
+- Regression is far more sensitive to feature scale than tree-based classification.
+  If using a linear regressor (Ridge, ElasticNet), prefer a sklearn `Pipeline([("scaler", StandardScaler()), ("reg", Ridge())])` (Example 5).
+- Uncertainty: `GradientBoostingRegressor` with `loss="quantile"` can give prediction intervals — wrap with `PixelwiseRegressor` for each quantile separately, or write a small custom wrapper that produces a 3-band output (5th, 50th, 95th).
+
+-----
+
+## 4. Pixel-wise PCA dimensionality reduction
+
+**Setting.** Hyperspectral data (~200 bands).
+Reduce to 10 principal components for downstream classification or visualisation.
+The transformer case — output is multi-band, not single-band.
+
+**Patch strategy.** `GeoCatalog + RandomSampler` over a representative subset of scenes for fitting PCA. Apply per-scene at inference.
+
+```python
+from sklearn.decomposition import PCA
+
+# === Fit PCA on a representative sample ===
+pca = gz.sklearn.fit_pixelwise(
+    estimator=PCA(n_components=10, whiten=True),
+    X_pipeline=hyperspectral_pipeline,
+    y_pipeline=None,                       # unsupervised
+    catalog=hyperspectral_catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(64, 64), length=100),
+    n_pixels=200_000,
+    nan_policy=gz.sklearn.NanPolicy(on_input="drop"),
+)
+joblib.dump(pca, "/models/pca_10.joblib")
+
+# === Apply as preprocessing in any pipeline ===
+preprocess = gz.Sequential([
+    hyperspectral_pipeline,
+    gz.sklearn.PixelwiseTransformer(
+        estimator=joblib.load("/models/pca_10.joblib"),
+        nan="mask",
+    ),
+    # Output: (10, H, W) GeoTensor — 10 PCA components
+])
+
+# Compose with anything downstream
+classify = gz.Sequential([
+    preprocess,
+    gz.sklearn.PixelwiseClassifier(estimator=clf_on_pca, nan="mask"),
+])
+```
+
+**Notes.**
+
+- The transformer’s output is `(n_components, H, W)` — geotoolz’s `FromPixelMajor` reads `n_components` from the table shape.
+- For genuine preprocessing in a *training pipeline*, prefer composing PCA into the sklearn `Pipeline` itself (Example 5) — keeps everything in one fitted artifact.
+- Beware of fitting PCA on the wrong subset: a sample drawn from cloud-free pixels of forested scenes won’t capture variance you need for shadow or urban classes.
+  The sample distribution should mirror the prediction distribution.
+
+-----
+
+## 5. Full sklearn Pipeline composition
+
+**Setting.** Soil moisture regression from Sentinel-1 backscatter + DEM features.
+The estimator is a multi-stage sklearn Pipeline: imputation → scaling → polynomial feature expansion → Ridge regression.
+The killer interop feature — the whole thing is **one Operator** on the geotoolz side.
+
+**Patch strategy.** `GeoCatalog + RandomSampler` for training.
+The Pipeline is one estimator from geotoolz’s perspective.
+
+```python
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import StandardScaler, PolynomialFeatures
+from sklearn.linear_model import Ridge
+
+sklearn_pipe = Pipeline([
+    ("imputer", SimpleImputer(strategy="median")),
+    ("scaler",  StandardScaler()),
+    ("poly",    PolynomialFeatures(degree=2, interaction_only=True)),
+    ("reg",     Ridge(alpha=1.0)),
+])
+
+# Fit the whole Pipeline as one estimator
+fitted = gz.sklearn.fit_pixelwise(
+    estimator=sklearn_pipe,
+    X_pipeline=sm_feature_pipeline,
+    y_pipeline=gz.catalog_ops.ReadLabel(label_uri_field="sm_uri", band="vwc"),
+    catalog=sm_catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=400),
+    n_pixels=800_000,
+    nan_policy=gz.sklearn.NanPolicy(
+        on_input="propagate",          # let SimpleImputer handle NaN
+        on_label="drop",
+    ),
+)
+joblib.dump(fitted, "/models/sm_pipeline.joblib")
+
+# Inference — the whole sklearn Pipeline is one Operator
+predict = gz.Sequential([
+    sm_feature_pipeline,
+    gz.sklearn.PixelwiseRegressor(
+        estimator=joblib.load("/models/sm_pipeline.joblib"),
+        nan="propagate",                # SimpleImputer at the start handles it
+    ),
+])
+```
+
+**Notes.**
+
+- `nan="propagate"` here because the first stage of the sklearn Pipeline is `SimpleImputer`, which is itself a NaN handler.
+  Setting `nan="mask"` would mask NaN *before* it reaches the imputer, defeating the imputer’s purpose.
+  This is a real subtlety: NaN policy on the wrapper interacts with NaN handling inside the sklearn Pipeline.
+- The wrapped sklearn Pipeline serialises (via joblib) as one artifact — `n_features_in_` on the Pipeline gives the *original* feature count (before polynomial expansion), so the geotoolz wrapper’s shape check works correctly.
+- Provenance: `fitted.get_params(deep=True)` records every nested estimator’s config. Hash that, store in the regulatory artifact, and you have full reproducibility of the multi-stage Pipeline.
+
+-----
+
+## 6. Per-tile classifier (local fit, local predict)
+
+**Setting.** Crop classification across an MGRS grid spanning multiple ecoregions and climate zones.
+A global model underperforms because growing seasons, atmospheric profiles, and dominant crops vary by region.
+Train one classifier per MGRS tile; dispatch on tile ID at inference.
+
+**Patch strategy.** `GeoCatalog + RandomSampler` for fitting *each tile’s model* separately.
+`Switch` for dispatch at inference.
+
+```python
+import geotoolz as gz
+from sklearn.ensemble import RandomForestClassifier
+
+# === Fit one model per tile ===
+tile_models = {}
+for tile_id in train_catalog.tiles():
+    tile_catalog = train_catalog.filter(tile=tile_id)
+    clf = gz.sklearn.fit_pixelwise(
+        estimator=RandomForestClassifier(n_estimators=200, n_jobs=-1),
+        X_pipeline=feature_pipeline,
+        y_pipeline=label_pipeline,
+        catalog=tile_catalog,
+        sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=100),
+        n_pixels=300_000,
+        nan_policy=gz.sklearn.NanPolicy(on_input="drop", on_label="drop"),
+    )
+    joblib.dump(clf, f"/models/crop_rf_{tile_id}.joblib")
+    tile_models[tile_id] = clf
+
+# === Dispatch via Switch at inference ===
+classifier_dispatch = gz.core.Switch(
+    key=lambda gt: gt.metadata["mgrs_tile"],
+    cases={
+        tile_id: gz.sklearn.PixelwiseClassifier(
+            estimator=clf, nan="mask", output_dtype="uint8",
+        )
+        for tile_id, clf in tile_models.items()
+    },
+    default=gz.core.Raise("no model for tile: {key}"),
+)
+
+predict = gz.Sequential([feature_pipeline, classifier_dispatch])
+
+# Catalog-driven inference — each scene gets routed to its tile's classifier
+gz.catalog_ops.CatalogPipeline(test_catalog, predict, n_workers=8).run()
+```
+
+**Notes.**
+
+- `Switch` reads `gt.metadata["mgrs_tile"]` — the reader must populate this from the catalog row’s metadata.
+  Most readers do, but verify with `gz.core.Tap(lambda gt: print(gt.metadata))` if dispatch isn’t firing.
+- Storage cost: one pickle per tile (could be 100+ models for a country-scale catalog).
+  Lazy-loading helps — keep `tile_models[tile_id] = path` and load inside `Switch` on first use, cached thereafter.
+- The harder question: how many tiles share enough signal that they could use *one* model?
+  Clustering tiles by some similarity metric (mean spectral signature, dominant land cover) before fitting can collapse the model registry.
+  Worth the engineering only if you have many tiles.
+
+-----
+
+## 7. Time-series crop classification
+
+**Setting.** Crop classification from Sentinel-2 monthly composites (`(C=10, T=12, H, W)`) — twelve months of features per pixel.
+The estimator sees each pixel’s full year as a `120`-dim feature vector and predicts one crop class per pixel.
+
+**Patch strategy.** `GeoCatalog + RandomSampler`, but the catalog rows reference *temporal stacks* (not individual scenes).
+Readers materialise `(C, T, H, W)` GeoTensors.
+
+```python
+import geotoolz as gz
+from sklearn.ensemble import RandomForestClassifier
+
+# === Temporal feature pipeline ===
+temporal_features = gz.Sequential([
+    gz.cloud.MaskClouds(qa_band=-1, bits=[10, 11]),    # acts per-timestep
+    gz.correction.TOAToBOA(sun_zenith_band=-2),
+    gz.temporal.LinearGapFill(),                       # interpolate cloud-masked gaps
+])
+
+# === Fit with temporal adapter ===
+clf = gz.sklearn.fit_pixelwise(
+    estimator=RandomForestClassifier(n_estimators=400, max_depth=15, n_jobs=-1),
+    X_pipeline=temporal_features,
+    y_pipeline=label_pipeline,
+    catalog=temporal_catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=300),
+    adapter=gz.sklearn.ToTemporalPixelMajor(time_handling="features"),  # (C,T,H,W) → (H*W, T*C)
+    n_pixels=500_000,
+    nan_policy=gz.sklearn.NanPolicy(on_input="drop", on_label="drop"),
+)
+joblib.dump(clf, "/models/crop_ts_rf.joblib")
+
+# === Predict ===
+predict = gz.Sequential([
+    temporal_features,
+    gz.sklearn.PixelwiseClassifier(
+        estimator=joblib.load("/models/crop_ts_rf.joblib"),
+        adapter=gz.sklearn.ToTemporalPixelMajor(time_handling="features"),
+        nan="mask",
+        output_dtype="uint8",
+    ),
+])
+```
+
+**Notes.**
+
+- **Adapter parity between fit and predict is essential.** The fit step uses `ToTemporalPixelMajor(time_handling="features")` to produce `(H*W, T*C)` training data; predict must use the *same* adapter so feature order matches.
+  Setting `time_handling="samples"` at predict would feed `(C,)` features to a model trained on `(T*C,)` — silent shape mismatch caught only by the `n_features_in_` check.
+- `LinearGapFill` fills cloud-masked timesteps so the estimator sees a complete time series.
+  Alternative: keep NaN, use a NaN-tolerant classifier like `HistGradientBoostingClassifier`.
+- For genuinely temporal models (DTW-based classifiers, shapelet learners), use `time_handling="panel"` with `PanelTable` and an `sktime`-compatible estimator.
+  That path lives in the (future) `geotoolz.sktime` integration.
+- Reducing time first (e.g., harmonic features, percentile composites) and fitting a non-temporal classifier on the reduced features is often competitive with deep temporal models — and uses the same standard `PixelwiseClassifier` path.
+
+-----
+
+## 8. Spatial cross-validation with `GridSearchCV`
+
+**Setting.** Hyperparameter tuning for the crop classifier.
+Standard k-fold CV leaks information geographically — nearby pixels are spatially correlated, so a pixel in fold 1 and a pixel in fold 2 from the same field are nearly identical, inflating CV scores.
+Need **spatial block CV**: group pixels by a coarse spatial block, then `GroupKFold` ensures all pixels in one block stay in one fold.
+
+**Patch strategy.** `GeoCatalog + RandomSampler` for training.
+CV machinery lives inside the sklearn estimator passed to `fit_pixelwise`.
+
+```python
+import geotoolz as gz
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import GridSearchCV, GroupKFold
+
+# === Fit_pixelwise extracts a spatial-block group ID per pixel ===
+# `block_band` is a band in the y_pipeline output carrying the spatial block ID.
+block_label_pipeline = gz.Sequential([
+    label_pipeline,
+    gz.spatial.BlockID(block_size_m=10_000),     # 10 km blocks → block ID band
+])
+
+# === Wrap classifier in GridSearchCV with spatial folds ===
+grid = GridSearchCV(
+    estimator=RandomForestClassifier(n_jobs=-1),
+    param_grid={
+        "n_estimators": [200, 400, 600],
+        "max_depth":    [10, 20, None],
+        "min_samples_leaf": [1, 5, 20],
+    },
+    cv=GroupKFold(n_splits=5),
+    scoring="f1_macro",
+    n_jobs=1,                    # n_jobs handled by RF, avoid nested parallelism
+    verbose=2,
+)
+
+# === Fit — fit_pixelwise passes the block ID as `groups=` ===
+fitted_grid = gz.sklearn.fit_pixelwise(
+    estimator=grid,
+    X_pipeline=feature_pipeline,
+    y_pipeline=block_label_pipeline,
+    catalog=train_catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=300),
+    n_pixels=500_000,
+    nan_policy=gz.sklearn.NanPolicy(on_input="drop", on_label="drop"),
+    group_band=1,                # band 1 of y_pipeline is the block ID
+)
+
+print(f"Best params: {fitted_grid.best_params_}")
+print(f"Best CV score: {fitted_grid.best_score_:.3f}")
+
+# Best estimator is itself fitted on the full training set
+joblib.dump(fitted_grid.best_estimator_, "/models/crop_rf_tuned.joblib")
+```
+
+**Notes.**
+
+- The `group_band` argument is how `fit_pixelwise` passes per-sample group IDs to `estimator.fit(X, y, groups=...)`.
+  The block ID is treated as an extra label channel — packaged into the `y_pipeline` output as a second band, and extracted by the fit helper.
+- Block size is a modelling choice.
+  Too small (1 km) and CV still leaks; too large (50 km) and you have too few blocks for meaningful k-fold.
+  Rule of thumb: block size ≈ 5–10× the spatial autocorrelation range of the target, often 5–20 km for vegetation.
+- For *temporal* CV (time-series classification with seasonal effects), pair with `TimeSeriesSplit` or block by year/season instead of space.
+  Same mechanism — just different group definition.
+- The fitted `GridSearchCV` object is itself an sklearn estimator.
+  The whole search wraps as one Operator at inference time — same composition story as Example 5.
+
+-----
+
+## 9. Unsupervised land-cover clustering
+
+**Setting.** No labels available.
+Want a coarse land-cover segmentation from Sentinel-2 features as an exploratory product or pre-labelling step for active learning.
+Use MiniBatchKMeans for scalability.
+
+**Patch strategy.** `GeoCatalog + RandomSampler` for fitting on a sample.
+`CatalogPipeline` for inference over the whole catalog.
+
+```python
+from sklearn.cluster import MiniBatchKMeans
+
+# === Unsupervised fit ===
+kmeans = gz.sklearn.fit_pixelwise(
+    estimator=MiniBatchKMeans(n_clusters=12, batch_size=10_000, random_state=42),
+    X_pipeline=feature_pipeline,
+    y_pipeline=None,                       # unsupervised — no labels needed
+    catalog=catalog,
+    sampler=gz.sampling.RandomSampler(chip_size=(256, 256), length=200),
+    n_pixels=500_000,
+    nan_policy=gz.sklearn.NanPolicy(on_input="drop"),
+)
+joblib.dump(kmeans, "/models/landcover_kmeans_12.joblib")
+
+# === Predict cluster IDs per pixel ===
+predict = gz.Sequential([
+    feature_pipeline,
+    gz.sklearn.PixelwiseClusterer(
+        estimator=joblib.load("/models/landcover_kmeans_12.joblib"),
+        nan="mask",
+        output_dtype="uint8",
+    ),
+])
+
+# === Bonus: cluster centroids as inspection ===
+centroids = kmeans.cluster_centers_           # (12, n_features)
+plot_centroid_spectra(centroids, feature_names=["B02", "B03", "B04", "B08", "NDVI", "NDWI"])
+```
+
+**Notes.**
+
+- `y_pipeline=None` for unsupervised.
+  `fit_pixelwise` skips the label alignment step entirely.
+- `MiniBatchKMeans` is the right choice for large catalogs — `KMeans` fits in one shot and won’t scale past a few million pixels.
+- The cluster IDs are arbitrary integers.
+  For an interpretable land-cover product, label each cluster post-hoc (inspect a sample of pixels from each cluster, assign semantic names).
+- Pair with [`Histogram`](../examples/tips_n_tricks.md#histogram) on the output to see cluster frequencies per scene — useful for detecting class imbalance and rare clusters.
+
+-----
+
+## 10. Incremental fitting for large training sets
+
+**Setting.** Training data is genuinely larger than memory — billions of labeled pixels across a continental catalog.
+Batch-fit any single estimator on all of it is infeasible.
+Use `partial_fit`-capable estimators streamed through the catalog.
+
+**Patch strategy.** `GeoCatalog + GridSampler` (deterministic coverage, multiple epochs) for fitting.
+Standard per-scene prediction at inference.
+
+```python
+import geotoolz as gz
+from sklearn.linear_model import SGDClassifier
+
+clf = gz.sklearn.fit_pixelwise_incremental(
+    estimator=SGDClassifier(
+        loss="log_loss",
+        alpha=1e-4,
+        learning_rate="optimal",
+        random_state=42,
+    ),
+    X_pipeline=feature_pipeline,
+    y_pipeline=label_pipeline,
+    catalog=continental_catalog,
+    sampler=gz.sampling.GridSampler(chip_size=(256, 256)),
+    chunk_size=10_000,                     # pixels per partial_fit call
+    classes=np.arange(N_CLASSES),          # required for SGD classifier
+    epochs=3,
+    nan_policy=gz.sklearn.NanPolicy(on_input="drop", on_label="drop"),
+    shuffle=True,                          # shuffle chips within each epoch
+)
+joblib.dump(clf, "/models/crop_sgd.joblib")
+```
+
+**Implementation sketch** (helper internals):
+
+```python
+def fit_pixelwise_incremental(*, estimator, X_pipeline, y_pipeline,
+                               catalog, sampler, chunk_size, classes,
+                               epochs, nan_policy, shuffle=True, **_):
+    for epoch in range(epochs):
+        slices = list(sampler(catalog))
+        if shuffle: random.shuffle(slices)
+        buf_X, buf_y = [], []
+        for sl in slices:
+            X_chip = X_pipeline(sl.load())
+            y_chip = y_pipeline(sl.load())
+            X, y = _to_pixel_major(X_chip), _to_pixel_major(y_chip)
+            X, y = nan_policy.apply(X, y)
+            buf_X.append(X); buf_y.append(y)
+            if sum(len(b) for b in buf_X) >= chunk_size:
+                Xc = np.concatenate(buf_X)[:chunk_size]
+                yc = np.concatenate(buf_y)[:chunk_size]
+                estimator.partial_fit(Xc, yc, classes=classes)
+                buf_X, buf_y = [], []
+        # flush final partial chunk
+        if buf_X:
+            estimator.partial_fit(np.concatenate(buf_X), np.concatenate(buf_y), classes=classes)
+    return estimator
+```
+
+**Notes.**
+
+- `classes=np.arange(N_CLASSES)` is required for classifiers — `partial_fit` can’t infer the class set from a single chunk.
+  For regressors and most transformers, omit it.
+- Epochs matter for SGD-based learners. 1 epoch is usually under-trained; 3–5 epochs is typical. Shuffle the slice order between epochs.
+- Inference uses the standard `PixelwiseClassifier`.
+  The wrapper doesn’t care whether the estimator was batch-fit or incrementally-fit — same `.predict()` interface.
+- For incremental learning that genuinely *adapts* over time (online learning with concept drift), the `partial_fit` loop runs continuously rather than for fixed epochs.
+  Out of scope for this fit helper; build on the helper’s internals directly.
+
+-----
+
+## Cross-cutting observations
+
+A few patterns recur across these examples worth naming explicitly:
+
+**Adapter parity.** The fit-time adapter and the inference-time adapter must match. The most common silent bug — using `ToTemporalPixelMajor(...="features")` to fit and `ToPixelMajor()` to predict, or different `time_handling` modes between fit and serve — produces shape-mismatched feature vectors that sklearn either rejects (best case) or silently predicts garbage on.
+Always pass the adapter as a named variable shared between fit and predict pipelines.
+
+**NaN policy asymmetry between fit and predict.** Fit-time policies usually *drop* NaN rows because you can’t learn from incomplete labels.
+Predict-time policies usually *mask* NaN rows because the output must be a complete raster with NaN written at masked positions.
+Defaults reflect this; verify when changing them.
+
+**Pre-fitted estimator as the artifact.** Across all ten examples, the estimator pickle is the durable artifact, not the operator graph.
+The graph is the *instructions* for how to apply the estimator; the estimator is the *content*.
+Both need to land in the regulatory-artifact bundle for full reproducibility, but their lifecycles differ — the graph YAML may change across deployments while the estimator stays pinned.
+
+**Feature pipeline shared across fit and predict.** The same `feature_pipeline` Operator object appears in both paths in every example.
+This is the train/serve skew prevention from the [use-cases doc](../examples/usecases.md#3-ml-training-and-inference) — violated, models silently degrade in production.
+
+**The right patch strategy is decided once per workflow.** Mixing strategies (GeoCatalog for training, xrpatcher for inference, ApplyToChips for tile serving) is fine *as long as the chip operator is identical*.
+The patch strategy determines I/O performance and scalability; the operator graph determines correctness.
+Keep them orthogonal.

--- a/projects/geotoolz/plans/readers/README.md
+++ b/projects/geotoolz/plans/readers/README.md
@@ -16,7 +16,8 @@ keywords: design, readers, sensors
 ---
 
 > **Status:** index of per-sensor reader designs.
-> **Scope:** the design of the *reader classes* for specific sensor families being migrated into `georeader` from `rs_tools`. Each per-sensor design specifies the file format, metadata parsing, calibration, and how the reader fits into one of `georeader`'s existing patterns (S2-style affine `GeoData`, or PRISMA-style raw-arrays-plus-`lons`/`lats`).
+> **Scope:** the design of the *reader classes* for specific sensor families being migrated into `georeader` from `rs_tools`.
+> Each per-sensor design specifies the file format, metadata parsing, calibration, and how the reader fits into one of `georeader`'s existing patterns (S2-style affine `GeoData`, or PRISMA-style raw-arrays-plus-`lons`/`lats`).
 > **Audience:** anyone implementing a new sensor reader in `georeader`, or trying to figure out which sensor goes with which existing pattern.
 
 ---
@@ -29,7 +30,8 @@ Per-sensor reader designs land here when:
 2. **The reader follows one of two existing patterns** ([Track A or Track B below](#the-two-tracks)) but has sensor-specific quirks worth documenting before implementation.
 3. **The work fits into one or more focused issues** rather than a single trivial PR.
 
-The companion to this directory is [`georeader/`](../georeader/) — the **reader-protocol reconciliation** design, which keeps today's `GeoData` / `GeoDataBase` Protocols and adds an `AsyncGeoData` Protocol that all readers (current and future) will conform to. That design is about the *interface*; this directory is about *concrete sensor implementations* that satisfy it.
+The companion to this directory is [`georeader/`](../georeader/) — the **reader-protocol reconciliation** design, which keeps today's `GeoData` / `GeoDataBase` Protocols and adds an `AsyncGeoData` Protocol that all readers (current and future) will conform to.
+That design is about the *interface*; this directory is about *concrete sensor implementations* that satisfy it.
 
 ---
 
@@ -53,7 +55,8 @@ The companion to this directory is [`georeader/`](../georeader/) — the **reade
 | [`geostationary.md`](geostationary.md) | GOES-R ABI, MSG SEVIRI, MTG-FCI, Himawari AHI | A for ABI/FCI (clean `+proj=geos`), B for SEVIRI/AHI (irregular file formats) |
 | [`modis.md`](modis.md) | MODIS (Aqua/Terra), VIIRS (S-NPP / NOAA-20/21), planned: AVHRR, Sentinel-3 OLCI/SLSTR, AVIRIS-NG | B (curvilinear scanners; per-pixel `lons`/`lats` is the only honest description) |
 
-Both designs share structure: User Story / Motivation / Mathematics / Target API / Example Use Cases / Subtasks / Open Design Questions. They reference each other directly because the geostationary readers were designed first and the MODIS family followed the same template.
+Both designs share structure: User Story / Motivation / Mathematics / Target API / Example Use Cases / Subtasks / Open Design Questions.
+They reference each other directly because the geostationary readers were designed first and the MODIS family followed the same template.
 
 ---
 

--- a/projects/geotoolz/plans/readers/geostationary.md
+++ b/projects/geotoolz/plans/readers/geostationary.md
@@ -22,7 +22,10 @@ keywords: design, readers, goes, seviri
 - [User Story](#user-story)
 - [Motivation](#motivation)
 - [Mathematics](#mathematics)
-- [Target API](#target-api) - [Track A — Clean `+proj=geos` affine](#track-a--clean-projgeos-affine-goes-abi-mtg-fci) - [Track B — Irregular file formats](#track-b--irregular-file-formats-seviri-ahi) - [Public bucket helpers](#public-bucket-helpers)
+- [Target API](#target-api)
+  - [Track A — Clean `+proj=geos` affine](#track-a--clean-projgeos-affine-goes-abi-mtg-fci)
+  - [Track B — Irregular file formats](#track-b--irregular-file-formats-seviri-ahi)
+  - [Public bucket helpers](#public-bucket-helpers)
 - [Example Use Cases](#example-use-cases)
 - [Subtasks](#subtasks)
 

--- a/projects/geotoolz/plans/readers/geostationary.md
+++ b/projects/geotoolz/plans/readers/geostationary.md
@@ -22,16 +22,15 @@ keywords: design, readers, goes, seviri
 - [User Story](#user-story)
 - [Motivation](#motivation)
 - [Mathematics](#mathematics)
-- [Target API](#target-api)
-  - [Track A — Clean `+proj=geos` affine](#track-a--clean-projgeos-affine-goes-abi-mtg-fci)
-  - [Track B — Irregular file formats](#track-b--irregular-file-formats-seviri-ahi)
-  - [Public bucket helpers](#public-bucket-helpers)
+- [Target API](#target-api) - [Track A — Clean `+proj=geos` affine](#track-a--clean-projgeos-affine-goes-abi-mtg-fci) - [Track B — Irregular file formats](#track-b--irregular-file-formats-seviri-ahi) - [Public bucket helpers](#public-bucket-helpers)
 - [Example Use Cases](#example-use-cases)
 - [Subtasks](#subtasks)
 
 ## User Story
 
-I’m migrating geostationary readers from `rs_tools` into `georeader`, starting with **GOES-R ABI** and **MSG SEVIRI**, with a path to **MTG-FCI** and **Himawari AHI**. The work is substantially smaller than first thought: `georeader` already owns CRS reprojection through `read.read_from_bounds` and irregular-geolocation reprojection through `griddata.read_to_crs`. What’s missing is the **reader** — the per-sensor class that opens these files, parses sensor-specific metadata, exposes calibrated radiance, and conforms to whichever existing convention (S2-style `GeoData` or PRISMA-style raw-arrays-plus-`lons`/`lats`) fits the file format on disk.
+I’m migrating geostationary readers from `rs_tools` into `georeader`, starting with **GOES-R ABI** and **MSG SEVIRI**, with a path to **MTG-FCI** and **Himawari AHI**.
+The work is substantially smaller than first thought: `georeader` already owns CRS reprojection through `read.read_from_bounds` and irregular-geolocation reprojection through `griddata.read_to_crs`.
+What’s missing is the **reader** — the per-sensor class that opens these files, parses sensor-specific metadata, exposes calibrated radiance, and conforms to whichever existing convention (S2-style `GeoData` or PRISMA-style raw-arrays-plus-`lons`/`lats`) fits the file format on disk.
 
 ## Motivation
 
@@ -44,11 +43,14 @@ Each geostationary sensor lives in its own file format with its own quirks:
 |MSG SEVIRI       |`.nat` (Native) or xRIT segments|Custom binary; needs explicit parsing |
 |Himawari AHI     |HSD segments                    |Custom binary                         |
 
-A `satpy` install can read all of these but drags in xarray/dask/pyresample and is pipeline-shaped. The `georeader`-shaped equivalent is much smaller in scope: a reader per sensor that produces either a `GeoData` (when the file’s affine is clean) or a PRISMA-like object exposing `.lons`, `.lats`, and raw arrays (when it isn’t), and lets `georeader`’s existing machinery do the rest. The motivation is to keep `georeader` consistent: one mental model for the user (`georeader.readers.X`, then `read.read_from_bounds` or `griddata.read_to_crs`), regardless of sensor.
+A `satpy` install can read all of these but drags in xarray/dask/pyresample and is pipeline-shaped.
+The `georeader`-shaped equivalent is much smaller in scope: a reader per sensor that produces either a `GeoData` (when the file’s affine is clean) or a PRISMA-like object exposing `.lons`, `.lats`, and raw arrays (when it isn’t), and lets `georeader`’s existing machinery do the rest.
+The motivation is to keep `georeader` consistent: one mental model for the user (`georeader.readers.X`, then `read.read_from_bounds` or `griddata.read_to_crs`), regardless of sensor.
 
 ## Mathematics
 
-The only math the reader itself owns is computing `.lons` and `.lats` from scan angles when the file format doesn’t already give them. This is the standard `+proj=geos` forward projection, lifted directly from the [GOES-R PUG](https://www.goes-r.gov/users/docs/PUG-main-vol1.pdf) and MSG ICD. As a private utility:
+The only math the reader itself owns is computing `.lons` and `.lats` from scan angles when the file format doesn’t already give them.
+This is the standard `+proj=geos` forward projection, lifted directly from the [GOES-R PUG](https://www.goes-r.gov/users/docs/PUG-main-vol1.pdf) and MSG ICD. As a private utility:
 
 ```python
 # georeader/readers/geostationary/_projection.py
@@ -76,15 +78,18 @@ def scan_to_geodetic(
     return lat, lon, on_disk
 ```
 
-That’s the entire math footprint inside the reader package. Beyond it, anything users need (satellite/solar zenith, local resolution, disk mask) can live in a separate `geostationary_utils` module later — **out of scope** for this design.
+That’s the entire math footprint inside the reader package.
+Beyond it, anything users need (satellite/solar zenith, local resolution, disk mask) can live in a separate `geostationary_utils` module later — **out of scope** for this design.
 
 ## Target API
 
-Two tracks fall out of the file formats. The reader user-facing surface is identical in spirit; the *implementation* differs.
+Two tracks fall out of the file formats.
+The reader user-facing surface is identical in spirit; the *implementation* differs.
 
 ### Track A — Clean `+proj=geos` affine (GOES ABI, MTG-FCI)
 
-Conforms to `GeoData` like the S2 reader. The CRS is `+proj=geos` with the right sweep axis (`x` for GOES, `y` for FCI), the transform is linear in scan-angle-projected meters, and `read.read_from_bounds` works directly through rasterio:
+Conforms to `GeoData` like the S2 reader.
+The CRS is `+proj=geos` with the right sweep axis (`x` for GOES, `y` for FCI), the transform is linear in scan-angle-projected meters, and `read.read_from_bounds` works directly through rasterio:
 
 ```python
 # georeader/readers/geostationary/abi.py
@@ -178,7 +183,8 @@ class ABI_L1b(GeoData):
 
 ### Track B — Irregular file formats (SEVIRI, AHI)
 
-Mirrors the PRISMA reader exactly. The reader does **not** conform to `GeoData`; instead it exposes raw arrays plus `.lons`/`.lats`, and users go through `griddata.read_to_crs`:
+Mirrors the PRISMA reader exactly.
+The reader does **not** conform to `GeoData`; instead it exposes raw arrays plus `.lons`/`.lats`, and users go through `griddata.read_to_crs`:
 
 ```python
 # georeader/readers/geostationary/seviri.py
@@ -238,9 +244,13 @@ geo = griddata.read_to_crs(np.moveaxis(raw, 0, 2),
 # geo: GeoTensor (2, H', W') in EPSG:3857
 ```
 
-Internally, `_projection.scan_to_geodetic` populates `lons` and `lats` once during `__init__` from the file’s scan-angle metadata. **Users never see the projection module.**
+Internally, `_projection.scan_to_geodetic` populates `lons` and `lats` once during `__init__` from the file’s scan-angle metadata.
+**Users never see the projection module.**
 
-> **A note on the HRV channel.** SEVIRI’s HRV is 1 km native versus 3 km for the other 11 channels, on a smaller and offset grid. The reader handles this by treating HRV as a separate group with its own `lons`/`lats`, similar to S2’s 10/20/60 m groups. If `bands=['HRV']`, the reader’s grid is 1 km; if `bands=['IR_108', 'HRV']` is requested with `include_hrv=True`, the reader returns two parallel arrays and lets the user choose how to combine. Mixing resolutions silently is a known footgun and we don’t want it.
+> **A note on the HRV channel.** SEVIRI’s HRV is 1 km native versus 3 km for the other 11 channels, on a smaller and offset grid.
+> The reader handles this by treating HRV as a separate group with its own `lons`/`lats`, similar to S2’s 10/20/60 m groups.
+> If `bands=['HRV']`, the reader’s grid is 1 km; if `bands=['IR_108', 'HRV']` is requested with `include_hrv=True`, the reader returns two parallel arrays and lets the user choose how to combine.
+> Mixing resolutions silently is a known footgun and we don’t want it.
 
 ### Public bucket helpers
 
@@ -346,28 +356,38 @@ def test_seviri_corner_against_icd():
 
 ### ABI L1b reader (~1 week)
 
-The first concrete reader. NetCDF parsing through rasterio (`netcdf:path:Rad`); CRS construction from CF metadata or manually from sub-sat lon and sweep axis; calibration via `Rad`‘s `scale_factor`/`add_offset` plus `kappa0` for reflectance and Planck inversion for brightness temperature. Bands at three native resolutions handled S2-style. AWS S3 URIs work through fsspec/rasterio’s GDAL `/vsis3/` driver. Tests against a small fixture file in CI.
+The first concrete reader.
+NetCDF parsing through rasterio (`netcdf:path:Rad`); CRS construction from CF metadata or manually from sub-sat lon and sweep axis; calibration via `Rad`‘s `scale_factor`/`add_offset` plus `kappa0` for reflectance and Planck inversion for brightness temperature.
+Bands at three native resolutions handled S2-style.
+AWS S3 URIs work through fsspec/rasterio’s GDAL `/vsis3/` driver.
+Tests against a small fixture file in CI.
 
 ### SEVIRI Native reader (~2 weeks)
 
-This is the bigger lift because the `.nat` format needs custom binary parsing. Two options:
+This is the bigger lift because the `.nat` format needs custom binary parsing.
+Two options:
 
 1. Leverage `eumdac` / `satpy`’s SEVIRI native reader as an internal dependency for the parsing step only and rebuild calibration ourselves.
 2. Write a from-scratch parser following the MSG Level 1.5 ICD (more work, fewer dependencies).
 
-Lean toward an optional `satpy` dependency for the parsing only — cleaner and we can always replace it. Calibration coefficients are in the file header; HRV handled as a separate grid.
+Lean toward an optional `satpy` dependency for the parsing only — cleaner and we can always replace it.
+Calibration coefficients are in the file header; HRV handled as a separate grid.
 
 ### MTG-FCI reader (~1 week)
 
-Follows ABI: NetCDF, CF metadata, similar calibration story. Quirks are FCI’s chunked layout and the L1c grid.
+Follows ABI: NetCDF, CF metadata, similar calibration story.
+Quirks are FCI’s chunked layout and the L1c grid.
 
 ### Himawari AHI HSD reader (~2 weeks)
 
-Custom binary, similar in scope to SEVIRI Native. **Defer** until ABI + SEVIRI are landed.
+Custom binary, similar in scope to SEVIRI Native.
+**Defer** until ABI + SEVIRI are landed.
 
 ### SEVIRI HRIT reader (~2 weeks)
 
-xRIT-compressed segments. The messiest of the lot. **Defer** until clear demand.
+xRIT-compressed segments.
+The messiest of the lot.
+**Defer** until clear demand.
 
 ### Public bucket helpers (~1 day per sensor)
 

--- a/projects/geotoolz/plans/readers/modis.md
+++ b/projects/geotoolz/plans/readers/modis.md
@@ -23,7 +23,10 @@ keywords: design, readers, modis, viirs
 - [User Story](#user-story)
 - [Motivation](#motivation)
 - [Mathematics: The Curvilinear Transformation](#mathematics-the-curvilinear-transformation)
-- [Target API](#target-api) - [MODIS L1B reader](#modis-l1b-reader) - [VIIRS L1B reader](#viirs-l1b-reader) - [Variations within the family](#variations-within-the-family)
+- [Target API](#target-api)
+  - [MODIS L1B reader](#modis-l1b-reader)
+  - [VIIRS L1B reader](#viirs-l1b-reader)
+  - [Variations within the family](#variations-within-the-family)
 - [Example Use Cases](#example-use-cases)
 - [Subtasks](#subtasks)
 - [Open Design Question](#open-design-question)
@@ -409,7 +412,11 @@ Three in the established style:
 
 The single biggest open design question, worth resolving before locking anything down:
 
-> **Where does `dedupe_bowtie` live?** Three options:  1. As a method on the reader (`obj.dedupe_bowtie()` returns a new reader) 2. As a free function in `_swath.py` (users call it on raw arrays) 3. As a kwarg at construction time (`MODIS_L1B(..., bowtie_dedupe=True)`)
+> **Where does `dedupe_bowtie` live?** Three options:
+>
+> 1. As a method on the reader (`obj.dedupe_bowtie()` returns a new reader)
+> 2. As a free function in `_swath.py` (users call it on raw arrays)
+> 3. As a kwarg at construction time (`MODIS_L1B(..., bowtie_dedupe=True)`)
 
 The PRISMA reader doesn't have analogous concerns so there's no precedent.
 **Instinct: the method form** — leaves the default behavior untouched (all pixels exposed), but gives users a clean opt-in for resampling pipelines that need it.

--- a/projects/geotoolz/plans/readers/modis.md
+++ b/projects/geotoolz/plans/readers/modis.md
@@ -15,28 +15,29 @@ license: CC-BY-4.0
 keywords: design, readers, modis, viirs
 ---
 
-> **Design Report** — design for MODIS, VIIRS, and related curvilinear-geolocation readers in [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader). Companion to the geostationary readers design.
+> **Design Report** — design for MODIS, VIIRS, and related curvilinear-geolocation readers in [`spaceml-org/georeader`](https://github.com/spaceml-org/georeader).
+> Companion to the geostationary readers design.
 
 ## Contents
 
 - [User Story](#user-story)
 - [Motivation](#motivation)
 - [Mathematics: The Curvilinear Transformation](#mathematics-the-curvilinear-transformation)
-- [Target API](#target-api)
-  - [MODIS L1B reader](#modis-l1b-reader)
-  - [VIIRS L1B reader](#viirs-l1b-reader)
-  - [Variations within the family](#variations-within-the-family)
+- [Target API](#target-api) - [MODIS L1B reader](#modis-l1b-reader) - [VIIRS L1B reader](#viirs-l1b-reader) - [Variations within the family](#variations-within-the-family)
 - [Example Use Cases](#example-use-cases)
 - [Subtasks](#subtasks)
 - [Open Design Question](#open-design-question)
 
 ## User Story
 
-I'm continuing the migration from `rs_tools` into `georeader` with the next family of sensors: **MODIS** on Aqua/Terra, plus its close relatives **VIIRS** (S-NPP, NOAA-20/21), and eventually **AVHRR**, **Sentinel-3 OLCI/SLSTR**, and airborne **AVIRIS-NG**. Unlike GOES/SEVIRI, none of these have a clean affine in any standard CRS — they're polar-orbiting (or airborne) curvilinear scanners whose native geometry is "this is the lat/lon of every single pixel." The PRISMA reader is the right precedent and `griddata.read_to_crs` is the right resampler, but the reader has to set things up carefully so the curvilinear → regular-grid step works correctly, especially around bowtie pixels, multi-resolution bands, and dateline crossings.
+I'm continuing the migration from `rs_tools` into `georeader` with the next family of sensors: **MODIS** on Aqua/Terra, plus its close relatives **VIIRS** (S-NPP, NOAA-20/21), and eventually **AVHRR**, **Sentinel-3 OLCI/SLSTR**, and airborne **AVIRIS-NG**.
+Unlike GOES/SEVIRI, none of these have a clean affine in any standard CRS — they're polar-orbiting (or airborne) curvilinear scanners whose native geometry is "this is the lat/lon of every single pixel." The PRISMA reader is the right precedent and `griddata.read_to_crs` is the right resampler, but the reader has to set things up carefully so the curvilinear → regular-grid step works correctly, especially around bowtie pixels, multi-resolution bands, and dateline crossings.
 
 ## Motivation
 
-MODIS is the foundational dataset of the modern remote-sensing era — 25 years of daily global coverage, 36 spectral bands, three native resolutions (250 m / 500 m / 1 km), and an enormous downstream Level-2 product family (MOD09 surface reflectance, MOD11 LST, MOD13 vegetation indices, MOD14 fires, ...). VIIRS is the operational successor (similar bands, similar geometry, NetCDF instead of HDF4). Both ship as files where the *only* honest description of geometry is per-pixel `lons`/`lats`; any attempt to fit an affine to them is a lie at the swath edges.
+MODIS is the foundational dataset of the modern remote-sensing era — 25 years of daily global coverage, 36 spectral bands, three native resolutions (250 m / 500 m / 1 km), and an enormous downstream Level-2 product family (MOD09 surface reflectance, MOD11 LST, MOD13 vegetation indices, MOD14 fires, ...).
+VIIRS is the operational successor (similar bands, similar geometry, NetCDF instead of HDF4).
+Both ship as files where the *only* honest description of geometry is per-pixel `lons`/`lats`; any attempt to fit an affine to them is a lie at the swath edges.
 
 | Sensor | Format | Geolocation | Native res. | Notes |
 |---|---|---|---|---|
@@ -46,9 +47,11 @@ MODIS is the foundational dataset of the modern remote-sensing era — 25 years 
 | Sentinel-3 OLCI/SLSTR | NetCDF | In-file `geo_coordinates` | 300 m / 500 m / 1 km | Push-broom but still curvilinear; defer |
 | AVIRIS-NG (airborne) | ENVI binary | Separate `IGM`/`GLT` files | sub-meter to ~10 m | Very long swaths; defer |
 
-`rs_tools` solved download and patching for MODIS but not the read-arbitrary-AOI problem; `satpy` solves both at the cost of a heavy dependency tree. The georeader-shaped equivalent is one reader per sensor following the PRISMA pattern, plus a small set of curvilinear utilities to handle quirks that PRISMA doesn't have.
+`rs_tools` solved download and patching for MODIS but not the read-arbitrary-AOI problem; `satpy` solves both at the cost of a heavy dependency tree.
+The georeader-shaped equivalent is one reader per sensor following the PRISMA pattern, plus a small set of curvilinear utilities to handle quirks that PRISMA doesn't have.
 
-The reader's job is, again, narrow: open the HDF/NetCDF files, parse calibration, link the geolocation file (when separate), expose `.lons`/`.lats` plus calibrated arrays and metadata, and let `griddata.read_to_crs` do the rest. The new things this design has to address that the GEO design didn't:
+The reader's job is, again, narrow: open the HDF/NetCDF files, parse calibration, link the geolocation file (when separate), expose `.lons`/`.lats` plus calibrated arrays and metadata, and let `griddata.read_to_crs` do the rest.
+The new things this design has to address that the GEO design didn't:
 
 1. **Multi-file products** (data file + separate geolocation file)
 2. **The bowtie effect** (overlapping pixels at scan edges)
@@ -58,9 +61,12 @@ The reader's job is, again, narrow: open the HDF/NetCDF files, parse calibration
 
 ## Mathematics: The Curvilinear Transformation
 
-The forward problem — pixel index $(i, j)$ → $(\varphi_{ij}, \lambda_{ij})$ — is given by the file's geolocation arrays. The backward problem is the reprojection that `griddata.read_to_crs` does, and it's worth being explicit about what's happening, because the choice of resampling method interacts with bowtie pixels in ways that matter.
+The forward problem — pixel index $(i, j)$ → $(\varphi_{ij}, \lambda_{ij})$ — is given by the file's geolocation arrays.
+The backward problem is the reprojection that `griddata.read_to_crs` does, and it's worth being explicit about what's happening, because the choice of resampling method interacts with bowtie pixels in ways that matter.
 
-Let `V[i, j, k]` be the source array of shape `(H, W, C)`, with `lons[i, j]` and `lats[i, j]` giving the geographic location of pixel `(i, j)`. For a target CRS and a target resolution `Δ`, we want a regular grid `V_dst[m, n, k]` at locations `(x_m, y_n)` in target-CRS meters. The transformation has three steps:
+Let `V[i, j, k]` be the source array of shape `(H, W, C)`, with `lons[i, j]` and `lats[i, j]` giving the geographic location of pixel `(i, j)`.
+For a target CRS and a target resolution `Δ`, we want a regular grid `V_dst[m, n, k]` at locations `(x_m, y_n)` in target-CRS meters.
+The transformation has three steps:
 
 ```python
 # Pseudocode for what griddata.read_to_crs is doing under the hood
@@ -93,13 +99,16 @@ V_dst = scipy.interpolate.griddata(
 
 Three numerical hazards show up here that the reader has to either fix or document:
 
-> **Bowtie duplicates.** The source point cloud has multiple samples for the same ground location at scan edges. Nearest-neighbor handles this gracefully (one of the duplicates wins arbitrarily) but Delaunay-based linear interpolation can produce visible seams where degenerate triangles meet.
+> **Bowtie duplicates.** The source point cloud has multiple samples for the same ground location at scan edges.
+> Nearest-neighbor handles this gracefully (one of the duplicates wins arbitrarily) but Delaunay-based linear interpolation can produce visible seams where degenerate triangles meet.
 
-> **Antimeridian crossings.** A swath might have lons of +179.8° and -179.7° in adjacent pixels; if you project naively to a CRS that doesn't wrap (Web Mercator, UTM), the swath gets stretched halfway around the world. The reader handles this by detecting the discontinuity in `.lons` and either splitting the swath or unwrapping (e.g., `lons[lons < 0] += 360` when in the eastern-hemisphere tile).
+> **Antimeridian crossings.** A swath might have lons of +179.8° and -179.7° in adjacent pixels; if you project naively to a CRS that doesn't wrap (Web Mercator, UTM), the swath gets stretched halfway around the world.
+> The reader handles this by detecting the discontinuity in `.lons` and either splitting the swath or unwrapping (e.g., `lons[lons < 0] += 360` when in the eastern-hemisphere tile).
 
 > **Off-disk / fill values.** Sentinels like `-999` in `.lats`/`.lons` must be masked before the KD-tree is built, otherwise they pull nearest-neighbor queries into nonsense.
 
-The reader does **not** implement the resampling — `griddata.read_to_crs` does — but it owns making sure the inputs to that function are clean: valid masks applied, antimeridian unwrapped or flagged, and bowtie status known. As a small utility module:
+The reader does **not** implement the resampling — `griddata.read_to_crs` does — but it owns making sure the inputs to that function are clean: valid masks applied, antimeridian unwrapped or flagged, and bowtie status known.
+As a small utility module:
 
 ```python
 # georeader/readers/curvilinear/_swath.py — internal, sensor-agnostic
@@ -130,11 +139,13 @@ def dedupe_bowtie(
     ...
 ```
 
-Users never call these directly. Readers call them from `__init__` or expose them as opt-in methods.
+Users never call these directly.
+Readers call them from `__init__` or expose them as opt-in methods.
 
 ## Target API
 
-The MODIS L1B reader follows the PRISMA template precisely. A separate geolocation file (`MOD03`/`MYD03`) is the norm at 1 km; for 500 m and 250 m the geolocation either lives inside the data file or must be derived by interpolation, and the reader handles both cases.
+The MODIS L1B reader follows the PRISMA template precisely.
+A separate geolocation file (`MOD03`/`MYD03`) is the norm at 1 km; for 500 m and 250 m the geolocation either lives inside the data file or must be derived by interpolation, and the reader handles both cases.
 
 ### MODIS L1B reader
 
@@ -261,9 +272,11 @@ class VIIRS_L1B:
 
 ### Variations within the family
 
-For Level-2 MODIS products (`MOD09`, `MOD11`, `MOD13`), the same reader pattern applies but the bands change and the calibration helpers (`to_reflectance` / `to_brightness_temperature`) become identity passes — the products are already in physical units. Implement these as separate small classes (`MODIS_L2_SurfaceReflectance`, `MODIS_LST`) that share a base mixin if duplication appears.
+For Level-2 MODIS products (`MOD09`, `MOD11`, `MOD13`), the same reader pattern applies but the bands change and the calibration helpers (`to_reflectance` / `to_brightness_temperature`) become identity passes — the products are already in physical units.
+Implement these as separate small classes (`MODIS_L2_SurfaceReflectance`, `MODIS_LST`) that share a base mixin if duplication appears.
 
-For **Sentinel-3 OLCI/SLSTR** (NetCDF, push-broom but still curvilinear due to Earth rotation during the scan), the reader is structurally identical: open file, expose `.lons`/`.lats`, calibrate, route through `griddata.read_to_crs`. Defer until MODIS and VIIRS land.
+For **Sentinel-3 OLCI/SLSTR** (NetCDF, push-broom but still curvilinear due to Earth rotation during the scan), the reader is structurally identical: open file, expose `.lons`/`.lats`, calibrate, route through `griddata.read_to_crs`.
+Defer until MODIS and VIIRS land.
 
 For **AVIRIS-NG** (airborne, ENVI format with separate IGM/GLT geolocation files), again structurally identical — the only difference is the file-parsing layer.
 
@@ -348,19 +361,28 @@ The work splits into a small curvilinear utility module, the per-sensor readers,
 
 ### Curvilinear utilities (~2 days)
 
-`georeader/readers/curvilinear/_swath.py` with `crosses_antimeridian`, `unwrap_antimeridian`, `bowtie_mask`, `dedupe_bowtie`, plus tests. These are sensor-agnostic and the only piece of new shared infrastructure. Whether to expose any of these publicly is a design decision; start internal-only and promote if external users need them.
+`georeader/readers/curvilinear/_swath.py` with `crosses_antimeridian`, `unwrap_antimeridian`, `bowtie_mask`, `dedupe_bowtie`, plus tests.
+These are sensor-agnostic and the only piece of new shared infrastructure.
+Whether to expose any of these publicly is a design decision; start internal-only and promote if external users need them.
 
 ### MODIS L1B reader (~2 weeks)
 
-The first concrete reader. HDF4 parsing through `pyhdf` (the only mature HDF4 binding); calibration coefficients live in attributes per-band; geolocation comes from the linked `MOD03` file at 1 km, and from in-file SDS at 500 m / 250 m. Three resolution variants share the class and dispatch on file name. Tests against a small fixture granule in CI. The bowtie deduplication is the one MODIS-specific footgun and gets its own test.
+The first concrete reader.
+HDF4 parsing through `pyhdf` (the only mature HDF4 binding); calibration coefficients live in attributes per-band; geolocation comes from the linked `MOD03` file at 1 km, and from in-file SDS at 500 m / 250 m.
+Three resolution variants share the class and dispatch on file name.
+Tests against a small fixture granule in CI. The bowtie deduplication is the one MODIS-specific footgun and gets its own test.
 
 ### MODIS L2 readers (~1 week each)
 
-`MODIS_L2_SurfaceReflectance` (`MOD09`), `MODIS_LST` (`MOD11`), `MODIS_VegetationIndex` (`MOD13`). These are thinner because calibration is a no-op, but each has its own band list and quality-flag conventions. Build only the ones I need first, generalize later.
+`MODIS_L2_SurfaceReflectance` (`MOD09`), `MODIS_LST` (`MOD11`), `MODIS_VegetationIndex` (`MOD13`).
+These are thinner because calibration is a no-op, but each has its own band list and quality-flag conventions.
+Build only the ones I need first, generalize later.
 
 ### VIIRS L1B reader (~2 weeks)
 
-HDF5 / NetCDF instead of HDF4 (cleaner). I-band and M-band variants in one class with a `resolution` switch like MODIS. Geolocation from `GIMGO` / `GMTCO` companion files. Tests against a small fixture.
+HDF5 / NetCDF instead of HDF4 (cleaner).
+I-band and M-band variants in one class with a `resolution` switch like MODIS. Geolocation from `GIMGO` / `GMTCO` companion files.
+Tests against a small fixture.
 
 ### Sentinel-3 OLCI/SLSTR, AVHRR, AVIRIS-NG (~1–2 weeks each)
 
@@ -387,10 +409,7 @@ Three in the established style:
 
 The single biggest open design question, worth resolving before locking anything down:
 
-> **Where does `dedupe_bowtie` live?** Three options:
->
-> 1. As a method on the reader (`obj.dedupe_bowtie()` returns a new reader)
-> 2. As a free function in `_swath.py` (users call it on raw arrays)
-> 3. As a kwarg at construction time (`MODIS_L1B(..., bowtie_dedupe=True)`)
+> **Where does `dedupe_bowtie` live?** Three options:  1. As a method on the reader (`obj.dedupe_bowtie()` returns a new reader) 2. As a free function in `_swath.py` (users call it on raw arrays) 3. As a kwarg at construction time (`MODIS_L1B(..., bowtie_dedupe=True)`)
 
-The PRISMA reader doesn't have analogous concerns so there's no precedent. **Instinct: the method form** — leaves the default behavior untouched (all pixels exposed), but gives users a clean opt-in for resampling pipelines that need it.
+The PRISMA reader doesn't have analogous concerns so there's no precedent.
+**Instinct: the method form** — leaves the default behavior untouched (all pixels exposed), but gives users a clean opt-in for resampling pipelines that need it.

--- a/projects/geotoolz/plans/types/README.md
+++ b/projects/geotoolz/plans/types/README.md
@@ -23,27 +23,42 @@ keywords: design, types, protocol
 
 ## Primer for newcomers
 
-> **ELI5.** Some Lego pieces have **unique shapes that only fit in one castle**. Others are the **standard 2×4 brick** that fits in everything. This directory is for the standard 2×4 bricks of the design — small, reusable, with one shape that lots of places need.
+> **ELI5.** Some Lego pieces have **unique shapes that only fit in one castle**.
+> Others are the **standard 2×4 brick** that fits in everything.
+> This directory is for the standard 2×4 bricks of the design — small, reusable, with one shape that lots of places need.
 
 ### What's a "type" in this directory?
 
-**What it is.** A *type* in this directory is a Python construct — usually a `Protocol`, occasionally a `@dataclass` — that defines a *shape* (what attributes/methods/fields a value must have) without owning the implementation. Types live here when more than one design references them.
+**What it is.** A *type* in this directory is a Python construct — usually a `Protocol`, occasionally a `@dataclass` — that defines a *shape* (what attributes/methods/fields a value must have) without owning the implementation.
+Types live here when more than one design references them.
 
 **How it works.** Three flavours show up:
 
-- **`typing.Protocol`** — structural typing. Any class with the right method signatures satisfies it; no inheritance required. Used for `Credential` and the reader Protocols (`GeoData` / `GeoDataBase` / `AsyncGeoData`). The static type-checker (`mypy` / `ty`) verifies conformance at the call site.
-- **`@dataclass`** — auto-generated `__init__` / `__repr__` / `__eq__`. Used for `GeoSlice`. Often `frozen=True` to make instances immutable and hashable.
+- **`typing.Protocol`** — structural typing.
+  Any class with the right method signatures satisfies it; no inheritance required.
+  Used for `Credential` and the reader Protocols (`GeoData` / `GeoDataBase` / `AsyncGeoData`).
+  The static type-checker (`mypy` / `ty`) verifies conformance at the call site.
+- **`@dataclass`** — auto-generated `__init__` / `__repr__` / `__eq__`.
+  Used for `GeoSlice`.
+  Often `frozen=True` to make instances immutable and hashable.
 - **Concrete subclasses** of a Protocol — `AzureSASCredential`, etc. Live alongside the Protocol they implement, in the same design doc.
 
-**What this means for us.** Code that takes a `Protocol` parameter (`def f(reader: GeoData)`) accepts any conforming object — no shared base class, no inheritance dance. Code that takes a `@dataclass` parameter (`def f(slice_: GeoSlice)`) gets all the dataclass machinery (immutable fields, equality, repr) for free. The patterns are deliberately small and uniform across the directory.
+**What this means for us.** Code that takes a `Protocol` parameter (`def f(reader: GeoData)`) accepts any conforming object — no shared base class, no inheritance dance.
+Code that takes a `@dataclass` parameter (`def f(slice_: GeoSlice)`) gets all the dataclass machinery (immutable fields, equality, repr) for free.
+The patterns are deliberately small and uniform across the directory.
 
 ### When does a type land here vs in a design subdir?
 
-**What it is.** The criterion for promoting a type to `plans/types/`. Three conditions, all of which must hold.
+**What it is.** The criterion for promoting a type to `plans/types/`.
+Three conditions, all of which must hold.
 
-**How it works.** A type lives here when (1) it's a public surface — users construct or pattern-match against it directly, (2) it's consumed by more than one of the major designs, and (3) it's small enough to specify in one document. Types that fail any of these stay scoped to their owning design — e.g., `GeoData` / `GeoDataBase` / `AsyncGeoData` live in `georeader/reader_protocol.md` because they're the *subject* of that design, not just incidental to it. Same logic kept `GeoCatalog` in geodatabase and `Operator` in geotoolz.
+**How it works.** A type lives here when (1) it's a public surface — users construct or pattern-match against it directly, (2) it's consumed by more than one of the major designs, and (3) it's small enough to specify in one document.
+Types that fail any of these stay scoped to their owning design — e.g., `GeoData` / `GeoDataBase` / `AsyncGeoData` live in `georeader/reader_protocol.md` because they're the *subject* of that design, not just incidental to it.
+Same logic kept `GeoCatalog` in geodatabase and `Operator` in geotoolz.
 
-**What this means for us.** This directory grows slowly. Most "types" stay in their owning subdir; the ones that end up here are the ones that flow *between* layers (`GeoSlice`, `Credential`). The `bytestore.md` doc is here too but is **not a Protocol of our own** — it documents the decision to defer cloud byte transport to upstream [`obspec`](https://github.com/developmentseed/obspec) (see [`bytestore.md`](bytestore.md)).
+**What this means for us.** This directory grows slowly.
+Most "types" stay in their owning subdir; the ones that end up here are the ones that flow *between* layers (`GeoSlice`, `Credential`).
+The `bytestore.md` doc is here too but is **not a Protocol of our own** — it documents the decision to defer cloud byte transport to upstream [`obspec`](https://github.com/developmentseed/obspec) (see [`bytestore.md`](bytestore.md)).
 
 ```{mermaid}
 flowchart LR
@@ -66,14 +81,18 @@ A type lands in this directory when **all three** are true:
 
 1. **It's a public surface** — users construct or pattern-match against it directly, not just an internal helper.
 2. **It's consumed by more than one design** — moves between layers (reader → catalog → operator) rather than being scoped to a single subsystem.
-3. **It's small enough to specify in one document** — a dataclass, a Protocol, or a small family of related primitives. Big subsystems (the reader Protocol surface, the catalog Protocol) get their own design dirs.
+3. **It's small enough to specify in one document** — a dataclass, a Protocol, or a small family of related primitives.
+   Big subsystems (the reader Protocol surface, the catalog Protocol) get their own design dirs.
 
 The georeader-side types that *aren't* here, and why:
 
-- **`GeoTensor`** — already a real implemented type in `georeader/geotensor.py`; documented in [Tutorial Ch. 1](../../georeader_tutorial/01_geotensor.md). No design doc needed.
+- **`GeoTensor`** — already a real implemented type in `georeader/geotensor.py`; documented in [Tutorial Ch. 1](../../georeader_tutorial/01_geotensor.md).
+  No design doc needed.
 - **`GeoData` / `GeoDataBase` / `AsyncGeoData`** — all live in [Reader reconciliation](../georeader/README.md) because they're the subject of that design, not just incidental to it.
 - **`GeoCatalog` Protocol** — lives in [Geodatabase](../geodatabase/README.md) for the same reason.
-- **`obspec.AsyncStore`** — the cloud-byte transport surface. It's *not* ours — we defer to upstream [`obspec`](https://github.com/developmentseed/obspec) (DevSeed). The note at [`bytestore.md`](bytestore.md) documents this decision and the small `geotoolz.io.open_store(url)` helper we ship.
+- **`obspec.AsyncStore`** — the cloud-byte transport surface.
+  It's *not* ours — we defer to upstream [`obspec`](https://github.com/developmentseed/obspec) (DevSeed).
+  The note at [`bytestore.md`](bytestore.md) documents this decision and the small `geotoolz.io.open_store(url)` helper we ship.
 
 If a type starts in another design and grows into something multiple designs reference, **promote it here** — the cleanup is the same shape as the GeoSlice promotion that motivated this directory.
 
@@ -91,9 +110,11 @@ If a type starts in another design and grows into something multiple designs ref
 
 ## Future candidates
 
-These are types that *might* land here as the geotoolz ecosystem grows. Listed for orientation, not commitment:
+These are types that *might* land here as the geotoolz ecosystem grows.
+Listed for orientation, not commitment:
 
-- **`Operator` Protocol** — if a shared base class for `geotoolz` operators turns out to be reused by other libraries (e.g., a sibling `xr_toolz`-shaped library), it'd live here. Today it's scoped to [`geotoolz.md`](../geotoolz/geotoolz.md).
+- **`Operator` Protocol** — if a shared base class for `geotoolz` operators turns out to be reused by other libraries (e.g., a sibling `xr_toolz`-shaped library), it'd live here.
+  Today it's scoped to [`geotoolz.md`](../geotoolz/geotoolz.md).
 - **A `Chip` or `Window` reconciliation type** — if `GeoSlice`, `rasterio.windows.Window`, and `slices.create_windows` outputs end up needing a unified shape.
 - **A `Sensor` / `Mission` metadata struct** — if sensor-preset operators ([geotoolz.md §1.2](../geotoolz/geotoolz.md)) need to share a structured description of band layout, calibration constants, etc. Today this lives ad-hoc inside each reader (e.g., `BANDS_S2`, `BANDS_S2_L2A`).
 
@@ -111,12 +132,23 @@ When a candidate becomes a real design, it lands here as a sibling to `geoslice.
 
 ## Open questions, gotchas, and warnings
 
-The cross-cutting types are the load-bearing ones — when they're wrong, every downstream design ripples. Things to watch:
+The cross-cutting types are the load-bearing ones — when they're wrong, every downstream design ripples.
+Things to watch:
 
-- **`Credential.apply()` per-call vs `apply_to_os_environ()` mutation.** The design distinguishes pure (returns a dict) vs mutating (writes `os.environ`) modes. Per-reader isolation only works if every reader consumes the per-call dict; the env-var mode is a backwards-compat hatch, not the recommended path. Audit each reader on the reconciliation path to make sure it accepts the per-call dict.
-- **`obspec` API stability.** `obspec` is the upstream Protocol (DevSeed); `obstore` is the reference implementation. Both are pre-1.0. Our `geotoolz.io.open_store(...)` returns `obspec.AsyncStore`, so any breaking change there ripples through `AsyncGeoTIFFReader`. Pin a minor range and bump deliberately.
+- **`Credential.apply()` per-call vs `apply_to_os_environ()` mutation.** The design distinguishes pure (returns a dict) vs mutating (writes `os.environ`) modes.
+  Per-reader isolation only works if every reader consumes the per-call dict; the env-var mode is a backwards-compat hatch, not the recommended path.
+  Audit each reader on the reconciliation path to make sure it accepts the per-call dict.
+- **`obspec` API stability.** `obspec` is the upstream Protocol (DevSeed); `obstore` is the reference implementation.
+  Both are pre-1.0. Our `geotoolz.io.open_store(...)` returns `obspec.AsyncStore`, so any breaking change there ripples through `AsyncGeoTIFFReader`.
+  Pin a minor range and bump deliberately.
 - **`GeoSlice` time-axis convention.** `GeoSlice.interval` is a `pd.Interval`; the slice can be spatial-only (no interval) or spatial+temporal. Document the discriminated-union behaviour clearly so samplers and stitchers don't trip over the optional time dimension.
-- **Sampler API stability.** `random_geo_sampler` / `grid_geo_sampler` are bigger than they look — they couple `GeoSlice`, the catalog, and the inference loop. Treat their signatures as v0.1 public API; bump `_v2` if the shape needs to change rather than mutating in place.
-- **`stitch_predictions` reduction semantics.** Average vs first-write-wins vs max-vote — pick a default, document the alternatives, expose a `method=` knob. Without this, every user reinvents stitching.
-- **DuckDB credential bridge.** Reading cloud GeoParquet from DuckDB needs `httpfs` configured with credentials. The `Credential` Protocol should provide a `to_duckdb_secret()` adapter so users don't configure auth twice. Out-of-scope for v0.1, in-scope for the geodatabase Phase 2 design — flag the dependency.
-- **Future-candidate types are not commitments.** `Operator` Protocol, `Chip`/`Window`, `Sensor`/`Mission` are listed for orientation. Each lands here only when a second design references it. Resist promoting speculative types — they're cheap to add later, expensive to retract.
+- **Sampler API stability.** `random_geo_sampler` / `grid_geo_sampler` are bigger than they look — they couple `GeoSlice`, the catalog, and the inference loop.
+  Treat their signatures as v0.1 public API; bump `_v2` if the shape needs to change rather than mutating in place.
+- **`stitch_predictions` reduction semantics.** Average vs first-write-wins vs max-vote — pick a default, document the alternatives, expose a `method=` knob.
+  Without this, every user reinvents stitching.
+- **DuckDB credential bridge.** Reading cloud GeoParquet from DuckDB needs `httpfs` configured with credentials.
+  The `Credential` Protocol should provide a `to_duckdb_secret()` adapter so users don't configure auth twice.
+  Out-of-scope for v0.1, in-scope for the geodatabase Phase 2 design — flag the dependency.
+- **Future-candidate types are not commitments.** `Operator` Protocol, `Chip`/`Window`, `Sensor`/`Mission` are listed for orientation.
+  Each lands here only when a second design references it.
+  Resist promoting speculative types — they're cheap to add later, expensive to retract.

--- a/projects/geotoolz/plans/types/bytestore.md
+++ b/projects/geotoolz/plans/types/bytestore.md
@@ -16,20 +16,28 @@ keywords: design, types, transport, obspec
 ---
 
 > **Parent:** [README.md](README.md) — Core types.
-> **Status:** **revised 2026-05-09** — collapsed from a full Protocol design into a one-page passthrough note. See §"Why the rewrite" below.
-> **Scope:** how readers in `geotoolz` get bytes from cloud object stores. Short answer: we use [`obspec`](https://github.com/developmentseed/obspec) and ship a tiny `open_store(url)` factory. We do *not* define our own `ByteStore` Protocol.
+> **Status:** **revised 2026-05-09** — collapsed from a full Protocol design into a one-page passthrough note.
+> See §"Why the rewrite" below.
+> **Scope:** how readers in `geotoolz` get bytes from cloud object stores.
+> Short answer: we use [`obspec`](https://github.com/developmentseed/obspec) and ship a tiny `open_store(url)` factory.
+> We do *not* define our own `ByteStore` Protocol.
 
 ---
 
 ## Summary
 
-[`obspec`](https://github.com/developmentseed/obspec) is the upstream typed Protocol for object-store byte access — `Store` (sync) and `AsyncStore` (async) with `get`, `get_range`, `get_ranges`, `put`, `list`. It's by DevSeed, designed around the `obstore` API, and is the same Protocol that [`async-geotiff`](https://github.com/developmentseed/async-geotiff) consumes for its `GeoTIFF.open(path, store=...)` call.
+[`obspec`](https://github.com/developmentseed/obspec) is the upstream typed Protocol for object-store byte access — `Store` (sync) and `AsyncStore` (async) with `get`, `get_range`, `get_ranges`, `put`, `list`.
+It's by DevSeed, designed around the `obstore` API, and is the same Protocol that [`async-geotiff`](https://github.com/developmentseed/async-geotiff) consumes for its `GeoTIFF.open(path, store=...)` call.
 
-We don't need a parallel Protocol of our own. Concretely:
+We don't need a parallel Protocol of our own.
+Concretely:
 
-- [`AsyncGeoTIFFReader`](../georeader/reader_async_geotiff.md) accepts a `store: obspec.AsyncStore | None` kwarg and forwards it straight to `async_geotiff.GeoTIFF.open(path, store=store)`. The Rust core handles range requests, coalescing, decoding off the event loop.
-- [`RasterioReader`](reader_rasterio.md) is unchanged on the bytes side — it routes through GDAL VSI / fsspec / a user-supplied `opener=` callback. There is no `store=` kwarg.
-- The [`Credential`](credentials.md) Protocol exposes small `to_obstore_*_store()` helpers that build a real `obstore.S3Store` / `GCSStore` / `AzureStore`. Those satisfy `obspec.AsyncStore` because `obstore` is the reference implementation of the `obspec` Protocol.
+- [`AsyncGeoTIFFReader`](../georeader/reader_async_geotiff.md) accepts a `store: obspec.AsyncStore | None` kwarg and forwards it straight to `async_geotiff.GeoTIFF.open(path, store=store)`.
+  The Rust core handles range requests, coalescing, decoding off the event loop.
+- [`RasterioReader`](reader_rasterio.md) is unchanged on the bytes side — it routes through GDAL VSI / fsspec / a user-supplied `opener=` callback.
+  There is no `store=` kwarg.
+- The [`Credential`](credentials.md) Protocol exposes small `to_obstore_*_store()` helpers that build a real `obstore.S3Store` / `GCSStore` / `AzureStore`.
+  Those satisfy `obspec.AsyncStore` because `obstore` is the reference implementation of the `obspec` Protocol.
 
 We ship one helper of our own: a `geotoolz.io.open_store(url, *, prefer="auto")` factory that picks an `obstore` backend from the URL scheme. ~30 LOC; not a Protocol.
 
@@ -37,11 +45,15 @@ We ship one helper of our own: a `geotoolz.io.open_store(url, *, prefer="auto")`
 
 ## Why the rewrite
 
-The earlier draft of this doc proposed a full `ByteStore` Protocol with sync + async method pairs and two adapter classes (`ObstoreByteStore`, `FsspecByteStore`). On review (2026-05-09), it was clear that:
+The earlier draft of this doc proposed a full `ByteStore` Protocol with sync + async method pairs and two adapter classes (`ObstoreByteStore`, `FsspecByteStore`).
+On review (2026-05-09), it was clear that:
 
-1. **`obspec` is the upstream Protocol.** Defining our own duplicates the surface and forces consumers to learn two names for the same concept. `async-geotiff` already consumes `obspec` natively.
-2. **`async-geotiff` does the work, not us.** Earlier drafts of [`reader_async_geotiff.md`](../georeader/reader_async_geotiff.md) planned a private `_cog_helpers.py` module with IFD walk, tile-fetch math, and decompression dispatch. All of that is already in `async-geotiff` (and its Rust dep `async-tiff`). Our reader is a thin adapter over `GeoTIFF.open` and `overview.read(window=...)` — there is no place where we need to call `store.get_ranges_async(...)` ourselves.
-3. **`fsspec` doesn't need a `ByteStore` adapter from us.** Sync `RasterioReader` already takes an `fs=` shortcut for fsspec backends; that path is untouched. We're not asking `RasterioReader` to use `obspec`.
+1. **`obspec` is the upstream Protocol.** Defining our own duplicates the surface and forces consumers to learn two names for the same concept.
+   `async-geotiff` already consumes `obspec` natively.
+2. **`async-geotiff` does the work, not us.** Earlier drafts of [`reader_async_geotiff.md`](../georeader/reader_async_geotiff.md) planned a private `_cog_helpers.py` module with IFD walk, tile-fetch math, and decompression dispatch. All of that is already in `async-geotiff` (and its Rust dep `async-tiff`).
+   Our reader is a thin adapter over `GeoTIFF.open` and `overview.read(window=...)` — there is no place where we need to call `store.get_ranges_async(...)` ourselves.
+3. **`fsspec` doesn't need a `ByteStore` adapter from us.** Sync `RasterioReader` already takes an `fs=` shortcut for fsspec backends; that path is untouched.
+   We're not asking `RasterioReader` to use `obspec`.
 4. **No second async raw-byte reader is on the roadmap.** The original "`AsyncGeoTIFFReader` plus future raw-byte readers will share `ByteStore`" framing was speculative; collapsing the speculative `LazyCOGReader` (see [`georeader/README.md` open question §3](../georeader/README.md#3-deferred-a-sync-gdal-free-geotensor-reader)) removed the only second consumer.
 
 Net: a 419-line design doc became a one-page passthrough note.
@@ -77,14 +89,17 @@ def open_store(
     ...
 ```
 
-That's the entire `geotoolz` surface for cloud byte access. `obspec.AsyncStore` is the type; `obstore` is the implementation we recommend; `open_store` is convenience.
+That's the entire `geotoolz` surface for cloud byte access.
+`obspec.AsyncStore` is the type; `obstore` is the implementation we recommend; `open_store` is convenience.
 
 ### What we do **not** ship
 
 - A `ByteStore` Protocol of our own.
 - An `ObstoreByteStore` wrapper (`obstore.S3Store` already satisfies `obspec.AsyncStore` directly).
-- An `FsspecByteStore` adapter. fsspec users go through `RasterioReader(fs=fs)` for sync reads. There is no async-from-fsspec path through `geotoolz`; if someone needs that later, the right answer is probably `obspec-fsspec` (community shim) or pull `obspec.AsyncStore` shapes directly from fsspec async backends — neither lives in our package.
-- A `prefer="fsspec"` mode. We don't have a path that consumes fsspec for async reads.
+- An `FsspecByteStore` adapter. fsspec users go through `RasterioReader(fs=fs)` for sync reads.
+  There is no async-from-fsspec path through `geotoolz`; if someone needs that later, the right answer is probably `obspec-fsspec` (community shim) or pull `obspec.AsyncStore` shapes directly from fsspec async backends — neither lives in our package.
+- A `prefer="fsspec"` mode.
+  We don't have a path that consumes fsspec for async reads.
 
 ---
 
@@ -121,7 +136,9 @@ No `get_range_async` calls in our code; no semaphore; no decompression dispatch.
 
 ### `RasterioReader` — unchanged
 
-`RasterioReader` keeps its existing `opener=` / `fs=` / `rio_open_kwargs=` knobs (see [`reader_protocol.md`](../georeader/reader_protocol.md) §"The three bytes paths"). It does **not** consume `obspec`. Mixing GDAL VSI's libcurl with an `obspec.Store` would mean wrapping the store in a Python file-like callback, which defeats the point — for fast cloud reads use `AsyncGeoTIFFReader`.
+`RasterioReader` keeps its existing `opener=` / `fs=` / `rio_open_kwargs=` knobs (see [`reader_protocol.md`](../georeader/reader_protocol.md) §"The three bytes paths").
+It does **not** consume `obspec`.
+Mixing GDAL VSI's libcurl with an `obspec.Store` would mean wrapping the store in a Python file-like callback, which defeats the point — for fast cloud reads use `AsyncGeoTIFFReader`.
 
 ---
 
@@ -139,12 +156,20 @@ No `get_range_async` calls in our code; no semaphore; no decompression dispatch.
 
 ### 1. Do we ever need a sync `obspec.Store` consumer?
 
-`obspec` defines both `Store` (sync) and `AsyncStore` (async). `AsyncGeoTIFFReader` only needs the async surface. If a future need arises (e.g. a sync notebook helper that reads one COG chip at a time without entering an event loop), we could add a `sync_open_store(url)` companion. Not on the roadmap.
+`obspec` defines both `Store` (sync) and `AsyncStore` (async).
+`AsyncGeoTIFFReader` only needs the async surface.
+If a future need arises (e.g. a sync notebook helper that reads one COG chip at a time without entering an event loop), we could add a `sync_open_store(url)` companion.
+Not on the roadmap.
 
 ### 2. Should `open_store` fall back to fsspec on unsupported schemes?
 
-No (current pick). If `prefer="auto"` hits `ftp://` it raises and the user is told to use `RasterioReader(fs=...)` instead. Reason: there's no `obspec` path that wraps fsspec async backends in our package, so silently returning something that doesn't work with `AsyncGeoTIFFReader` is worse than a clear error. Revisit if a community `obspec-fsspec` shim becomes mature.
+No (current pick).
+If `prefer="auto"` hits `ftp://` it raises and the user is told to use `RasterioReader(fs=...)` instead.
+Reason: there's no `obspec` path that wraps fsspec async backends in our package, so silently returning something that doesn't work with `AsyncGeoTIFFReader` is worse than a clear error.
+Revisit if a community `obspec-fsspec` shim becomes mature.
 
 ### 3. Where does `open_store` live?
 
-Tentative: `geotoolz/io.py`. Could equally live in `geotoolz/_stores.py` or directly on `AsyncGeoTIFFReader` as a classmethod. Pick during implementation.
+Tentative: `geotoolz/io.py`.
+Could equally live in `geotoolz/_stores.py` or directly on `AsyncGeoTIFFReader` as a classmethod.
+Pick during implementation.

--- a/projects/geotoolz/plans/types/bytestore.md
+++ b/projects/geotoolz/plans/types/bytestore.md
@@ -34,7 +34,7 @@ Concretely:
 
 - [`AsyncGeoTIFFReader`](../georeader/reader_async_geotiff.md) accepts a `store: obspec.AsyncStore | None` kwarg and forwards it straight to `async_geotiff.GeoTIFF.open(path, store=store)`.
   The Rust core handles range requests, coalescing, decoding off the event loop.
-- [`RasterioReader`](reader_rasterio.md) is unchanged on the bytes side — it routes through GDAL VSI / fsspec / a user-supplied `opener=` callback.
+- [`RasterioReader`](../georeader/reader_rasterio.md) is unchanged on the bytes side — it routes through GDAL VSI / fsspec / a user-supplied `opener=` callback.
   There is no `store=` kwarg.
 - The [`Credential`](credentials.md) Protocol exposes small `to_obstore_*_store()` helpers that build a real `obstore.S3Store` / `GCSStore` / `AzureStore`.
   Those satisfy `obspec.AsyncStore` because `obstore` is the reference implementation of the `obspec` Protocol.

--- a/projects/geotoolz/plans/types/credentials.md
+++ b/projects/geotoolz/plans/types/credentials.md
@@ -23,11 +23,14 @@ keywords: design, types, credentials, auth
 
 ## Summary
 
-Today, credentials for `RasterioReader` flow through process environment variables. The pattern works (GDAL picks them up automatically) but every project that uses `georeader` re-implements the env-var setup logic — `mars_data_ops/utils/filesystem.py` is ~800 lines of "read from a config file, set the right env vars, optionally fetch a managed-identity token first." The duplication is real and the surface is awkward.
+Today, credentials for `RasterioReader` flow through process environment variables.
+The pattern works (GDAL picks them up automatically) but every project that uses `georeader` re-implements the env-var setup logic — `mars_data_ops/utils/filesystem.py` is ~800 lines of "read from a config file, set the right env vars, optionally fetch a managed-identity token first." The duplication is real and the surface is awkward.
 
-This design proposes a typed `Credential` Protocol with concrete subclasses per cloud / auth mode, plus a `from_config(...)` helper for the config-file pattern. Readers (`RasterioReader`, future `AsyncGeoTIFFReader`) accept a `credential=` kwarg that applies the credential's env vars (or, in the fsspec / opener paths, threads the credential through the relevant constructor) without forcing global state.
+This design proposes a typed `Credential` Protocol with concrete subclasses per cloud / auth mode, plus a `from_config(...)` helper for the config-file pattern.
+Readers (`RasterioReader`, future `AsyncGeoTIFFReader`) accept a `credential=` kwarg that applies the credential's env vars (or, in the fsspec / opener paths, threads the credential through the relevant constructor) without forcing global state.
 
-The today-pattern (set env vars once, construct readers anywhere) keeps working — the proposed `Credential` is opt-in. Users who don't construct one get GDAL's existing env-var behaviour for free.
+The today-pattern (set env vars once, construct readers anywhere) keeps working — the proposed `Credential` is opt-in.
+Users who don't construct one get GDAL's existing env-var behaviour for free.
 
 ---
 
@@ -35,43 +38,70 @@ The today-pattern (set env vars once, construct readers anywhere) keeps working 
 
 Three pressures make a typed credential surface worth doing:
 
-1. **Every project re-implements the env-var setup.** [`mars_data_ops/utils/filesystem.py`](../../georeader_tutorial/03_rasterio_reader.md) is the canonical example: ~800 lines of `os.environ[...] = ...` plus auth-priority logic plus a config-file entry point. The same code appears (slightly differently) in every downstream pipeline that touches Azure storage. Promoting it into `georeader` eliminates the duplication and gives the package a stable credential API.
+1. **Every project re-implements the env-var setup.** [`mars_data_ops/utils/filesystem.py`](../../georeader_tutorial/03_rasterio_reader.md) is the canonical example: ~800 lines of `os.environ[...] = ...` plus auth-priority logic plus a config-file entry point.
+   The same code appears (slightly differently) in every downstream pipeline that touches Azure storage.
+   Promoting it into `georeader` eliminates the duplication and gives the package a stable credential API.
 
-2. **Global env-var state is ergonomically awkward.** Two `RasterioReader` instances reading from two Azure accounts in one process have to clobber `AZURE_STORAGE_ACCOUNT` between calls or fall through to the [HTTPS-embedded-SAS workaround](../../georeader_tutorial/03_rasterio_reader.md#mode-3--https-with-embedded-sas-fallback). Tests that want to swap credentials require `monkeypatch.setenv` instead of constructor kwargs. Per-reader credential isolation would solve both.
+2. **Global env-var state is ergonomically awkward.** Two `RasterioReader` instances reading from two Azure accounts in one process have to clobber `AZURE_STORAGE_ACCOUNT` between calls or fall through to the [HTTPS-embedded-SAS workaround](../../georeader_tutorial/03_rasterio_reader.md#mode-3--https-with-embedded-sas-fallback).
+   Tests that want to swap credentials require `monkeypatch.setenv` instead of constructor kwargs.
+   Per-reader credential isolation would solve both.
 
-3. **Managed-identity tokens expire.** The current pattern fetches a token once at startup via `DefaultAzureCredential` and writes it to `AZURE_STORAGE_ACCESS_TOKEN`. If the process runs longer than the token TTL (~1 hour by default), reads start failing with 401 and the user has no in-package recourse. A typed credential that knows how to refresh would handle this transparently.
+3. **Managed-identity tokens expire.** The current pattern fetches a token once at startup via `DefaultAzureCredential` and writes it to `AZURE_STORAGE_ACCESS_TOKEN`.
+   If the process runs longer than the token TTL (~1 hour by default), reads start failing with 401 and the user has no in-package recourse.
+   A typed credential that knows how to refresh would handle this transparently.
 
-The status quo absorbs each of these by re-implementing the same fix every time. A typed `Credential` lets the package own the answer once.
+The status quo absorbs each of these by re-implementing the same fix every time.
+A typed `Credential` lets the package own the answer once.
 
 ---
 
 ## Primer for newcomers
 
-> **ELI5.** A static credential is like a **key that always opens the door**. A dynamic credential (managed identity) is like a **guest pass the building issues you for one hour** — secure, but you have to ask for a new one when it expires. The `Credential` Protocol says "I don't care which kind you have; just hand me something I can use to unlock the door," and quietly handles the renewal if you have a guest pass.
+> **ELI5.** A static credential is like a **key that always opens the door**.
+> A dynamic credential (managed identity) is like a **guest pass the building issues you for one hour** — secure, but you have to ask for a new one when it expires.
+> The `Credential` Protocol says "I don't care which kind you have; just hand me something I can use to unlock the door," and quietly handles the renewal if you have a guest pass.
 
 ### Cloud auth — static vs dynamic credentials
 
-**What it is.** Two broad classes of cloud credential. **Static**: a fixed string (or pair of strings) that's valid until rotated — e.g., AWS access key + secret, an Azure SAS token, a GCS service-account JSON file. **Dynamic**: a credential that's minted on demand and expires after some TTL — e.g., AWS STS session tokens, Azure managed-identity bearer tokens, OIDC JWTs.
+**What it is.** Two broad classes of cloud credential. **Static**: a fixed string (or pair of strings) that's valid until rotated — e.g., AWS access key + secret, an Azure SAS token, a GCS service-account JSON file.
+**Dynamic**: a credential that's minted on demand and expires after some TTL — e.g., AWS STS session tokens, Azure managed-identity bearer tokens, OIDC JWTs.
 
-**How it works.** Static credentials sit in a config file or environment variable; the cloud SDK signs requests with them directly. Dynamic credentials require an upstream call to mint: `azure.identity.DefaultAzureCredential().get_token(...)` reaches the IMDS endpoint (a host-local HTTP service that talks to the cloud control plane), gets a short-lived bearer token, and you sign requests with that. The TTL is typically 1 hour — after that, you need a refresh.
+**How it works.** Static credentials sit in a config file or environment variable; the cloud SDK signs requests with them directly.
+Dynamic credentials require an upstream call to mint: `azure.identity.DefaultAzureCredential().get_token(...)` reaches the IMDS endpoint (a host-local HTTP service that talks to the cloud control plane), gets a short-lived bearer token, and you sign requests with that.
+The TTL is typically 1 hour — after that, you need a refresh.
 
-**What this means for us.** The `Credential` Protocol's two subclass families reflect this split. Static creds (`AzureSASCredential`, `AWSStaticCredential`, `GCSServiceAccountCredential`) have a no-op `refresh()`. Dynamic creds (`AzureManagedIdentityCredential`, `AWSProfileCredential`-with-SSO) have a real `refresh()` that re-fetches the token. Same `apply()` surface; different lifecycle underneath.
+**What this means for us.** The `Credential` Protocol's two subclass families reflect this split.
+Static creds (`AzureSASCredential`, `AWSStaticCredential`, `GCSServiceAccountCredential`) have a no-op `refresh()`.
+Dynamic creds (`AzureManagedIdentityCredential`, `AWSProfileCredential`-with-SSO) have a real `refresh()` that re-fetches the token.
+Same `apply()` surface; different lifecycle underneath.
 
 ### Process environment variables (the GDAL pattern)
 
-**What it is.** GDAL — the C library that reads cloud rasters — discovers credentials from `os.environ`. Set `AWS_ACCESS_KEY_ID` (or `AZURE_STORAGE_SAS_TOKEN`, etc.) before opening a file, and GDAL just works. There's no API call to "configure GDAL with credentials."
+**What it is.** GDAL — the C library that reads cloud rasters — discovers credentials from `os.environ`.
+Set `AWS_ACCESS_KEY_ID` (or `AZURE_STORAGE_SAS_TOKEN`, etc.) before opening a file, and GDAL just works.
+There's no API call to "configure GDAL with credentials."
 
-**How it works.** Inside `RasterioReader`, the code does `with rasterio.Env(**rio_env_options): rasterio.open(path)`. `rasterio.Env(...)` is a context manager that snapshots `os.environ`, overlays the provided keys, opens GDAL with that environment, then restores on exit. GDAL's libcurl reads `AWS_*`, `AZURE_STORAGE_*`, `GOOGLE_APPLICATION_CREDENTIALS` from the env and signs HTTP requests accordingly.
+**How it works.** Inside `RasterioReader`, the code does `with rasterio.Env(**rio_env_options): rasterio.open(path)`.
+`rasterio.Env(...)` is a context manager that snapshots `os.environ`, overlays the provided keys, opens GDAL with that environment, then restores on exit.
+GDAL's libcurl reads `AWS_*`, `AZURE_STORAGE_*`, `GOOGLE_APPLICATION_CREDENTIALS` from the env and signs HTTP requests accordingly.
 
-**What this means for us.** The today-pattern (set env vars at app startup) works because `rasterio.Env(...)` inherits the process env. The proposed pattern (`Credential.apply(env)`) merges credential keys into a per-call dict that's passed to `rasterio.Env(**dict)` — same C-side mechanism, different Python-side scoping. Per-reader isolation flows from this: two readers with two different `apply()`-ed dicts don't see each other's credentials.
+**What this means for us.** The today-pattern (set env vars at app startup) works because `rasterio.Env(...)` inherits the process env.
+The proposed pattern (`Credential.apply(env)`) merges credential keys into a per-call dict that's passed to `rasterio.Env(**dict)` — same C-side mechanism, different Python-side scoping.
+Per-reader isolation flows from this: two readers with two different `apply()`-ed dicts don't see each other's credentials.
 
 ### Managed identity (IMDS)
 
-**What it is.** Azure-specific: when code runs inside Azure compute (VM, AKS pod, Function), the platform exposes a metadata endpoint (`http://169.254.169.254/metadata/identity/...`) that mints bearer tokens. The code asks the endpoint for a token; the platform authenticates the request based on the compute's assigned identity. AWS has the equivalent (`http://169.254.169.254/latest/meta-data/iam/...`), GCP too.
+**What it is.** Azure-specific: when code runs inside Azure compute (VM, AKS pod, Function), the platform exposes a metadata endpoint (`http://169.254.169.254/metadata/identity/...`) that mints bearer tokens.
+The code asks the endpoint for a token; the platform authenticates the request based on the compute's assigned identity.
+AWS has the equivalent (`http://169.254.169.254/latest/meta-data/iam/...`), GCP too.
 
-**How it works.** `azure.identity.DefaultAzureCredential()` walks a chain (env vars → managed identity → developer CLI auth → ...) and uses whichever auth mode succeeds. In production-on-Azure, that's almost always managed identity — no static credentials in the deployed code. The token comes back as `JWT_string` + `expires_on` (a Unix timestamp).
+**How it works.** `azure.identity.DefaultAzureCredential()` walks a chain (env vars → managed identity → developer CLI auth → ...) and uses whichever auth mode succeeds.
+In production-on-Azure, that's almost always managed identity — no static credentials in the deployed code.
+The token comes back as `JWT_string` + `expires_on` (a Unix timestamp).
 
-**What this means for us.** `AzureManagedIdentityCredential.apply()` calls `get_token(...)`, caches the result, and returns env vars. The cache is keyed on the scope (`https://storage.azure.com/.default`); if the cached token is within 60 seconds of expiry, `apply()` triggers a refresh first. Long-running processes don't silently fail at the 1-hour mark.
+**What this means for us.** `AzureManagedIdentityCredential.apply()` calls `get_token(...)`, caches the result, and returns env vars.
+The cache is keyed on the scope (`https://storage.azure.com/.default`); if the cached token is within 60 seconds of expiry, `apply()` triggers a refresh first.
+Long-running processes don't silently fail at the 1-hour mark.
 
 ```{mermaid}
 sequenceDiagram
@@ -95,11 +125,17 @@ sequenceDiagram
 
 ### Bearer tokens and TTL
 
-**What it is.** A *bearer token* is a credential where possession of the token (without further proof) authorises the holder. JWT strings, Azure access tokens, OAuth access tokens are all bearer tokens. TTL (time-to-live) is the deliberately short validity window — typically 1 hour — that limits exposure if the token leaks.
+**What it is.** A *bearer token* is a credential where possession of the token (without further proof) authorises the holder.
+JWT strings, Azure access tokens, OAuth access tokens are all bearer tokens.
+TTL (time-to-live) is the deliberately short validity window — typically 1 hour — that limits exposure if the token leaks.
 
-**How it works.** The token is sent with each request as `Authorization: Bearer <token>`. The server validates the signature against the issuer's public key (no shared secret needed). When TTL expires, requests start failing with 401 Unauthorized; the client must request a new token from the issuer (e.g., refresh via IMDS).
+**How it works.** The token is sent with each request as `Authorization: Bearer <token>`.
+The server validates the signature against the issuer's public key (no shared secret needed).
+When TTL expires, requests start failing with 401 Unauthorized; the client must request a new token from the issuer (e.g., refresh via IMDS).
 
-**What this means for us.** The "401-retry-with-refresh" pattern in [`reader_rasterio.md`](../georeader/reader_rasterio.md) Proposal 2 exists because bearer tokens fail mid-pipeline. Catching one 401, calling `credential.refresh()`, retrying once — that's the standard fix. The `Credential` Protocol carries a `refresh()` method specifically for this; static creds implement it as a no-op.
+**What this means for us.** The "401-retry-with-refresh" pattern in [`reader_rasterio.md`](../georeader/reader_rasterio.md) Proposal 2 exists because bearer tokens fail mid-pipeline.
+Catching one 401, calling `credential.refresh()`, retrying once — that's the standard fix.
+The `Credential` Protocol carries a `refresh()` method specifically for this; static creds implement it as a no-op.
 
 ```{mermaid}
 stateDiagram-v2
@@ -118,29 +154,40 @@ stateDiagram-v2
 
 ## Goals
 
-- **A `Credential` Protocol** that wraps the "apply this credential to a process / reader before opening files" operation. Concrete subclasses per cloud / auth mode.
+- **A `Credential` Protocol** that wraps the "apply this credential to a process / reader before opening files" operation.
+  Concrete subclasses per cloud / auth mode.
 - **Per-cloud helpers** for the common construction patterns: `AzureSASCredential`, `AzureManagedIdentityCredential`, `AWSStaticCredential`, `AWSProfileCredential`, `GCSServiceAccountCredential`.
 - **A `from_config(...)` factory** that reads a config object (configparser, dict, dataclass) and returns the right credential subclass.
-- **Refresh-aware tokens.** Credentials backed by short-lived tokens know how to refresh on demand. Reader integration is wired through [`reader_rasterio.md`](../georeader/reader_rasterio.md).
-- **Backward compatibility.** The today-pattern (set env vars, construct reader, GDAL picks them up) keeps working unchanged. The new `Credential` types are opt-in.
+- **Refresh-aware tokens.** Credentials backed by short-lived tokens know how to refresh on demand.
+  Reader integration is wired through [`reader_rasterio.md`](../georeader/reader_rasterio.md).
+- **Backward compatibility.** The today-pattern (set env vars, construct reader, GDAL picks them up) keeps working unchanged.
+  The new `Credential` types are opt-in.
 
 ---
 
 ## Non-goals
 
 - **Replacing `azure-identity` / `boto3` / `google-auth`.** The credential subclasses *wrap* SDK credential objects; they don't reimplement them.
-- **Authoring a config file format.** `from_config(...)` accepts whatever shape the user has — configparser, dict, pydantic model — and reads from named keys. No new schema.
-- **Changing how GDAL reads credentials.** GDAL still reads from process env vars in the GDAL-VSI path. The `Credential` Protocol is the *Python* side of the boundary; it sets the env vars and refreshes tokens, but the actual cred consumption is GDAL's job.
+- **Authoring a config file format.** `from_config(...)` accepts whatever shape the user has — configparser, dict, pydantic model — and reads from named keys.
+  No new schema.
+- **Changing how GDAL reads credentials.** GDAL still reads from process env vars in the GDAL-VSI path.
+  The `Credential` Protocol is the *Python* side of the boundary; it sets the env vars and refreshes tokens, but the actual cred consumption is GDAL's job.
 - **Credential storage / vault integration.** This design is about the in-process API. Where the credential strings come from (config file, environment, vault, AWS Secrets Manager, …) is the user's call.
 
 ---
 
 ## Constraints
 
-- **Env vars are GDAL's contract.** GDAL reads cloud credentials from environment variables — there's no per-call credential argument in libcurl's GDAL integration. The package crosses that boundary in two ways: `Credential.apply_to_os_environ()` mutates `os.environ` (the today-pattern, set globals at startup) and `Credential.apply(env)` returns a fresh dict the reader merges into `rasterio.Env(**env)` (per-call, per-reader isolation). Both ultimately feed GDAL's libcurl through the env-var mechanism; they differ only in whether the env scope is process-global or per-call.
-- **`apply()` is pure; `apply_to_os_environ()` mutates.** The Protocol design uses two methods so callers can choose. Per-reader isolation in `RasterioReader(credential=...)` uses `apply()` and merges into the local `rasterio.Env(...)` — no `os.environ` mutation, no global-state collisions between readers in one process.
-- **Per-reader isolation works on every bytes path.** GDAL-VSI gets a per-call env dict via `rasterio.Env(**apply(env))`. fsspec gets credentials inside its filesystem constructor. Custom openers close over their own credential. None of these touch `os.environ`.
-- **Refresh logic lives at the reader layer**, not in the `Credential` itself. The `Credential` knows *how* to refresh (`refresh()` method, which may also be invoked internally by `apply()` if the credential's TTL is near-expiry); the reader decides *when* to retry on a 401 (one refresh + one retry, then propagate). This split keeps the credential testable in isolation.
+- **Env vars are GDAL's contract.** GDAL reads cloud credentials from environment variables — there's no per-call credential argument in libcurl's GDAL integration.
+  The package crosses that boundary in two ways: `Credential.apply_to_os_environ()` mutates `os.environ` (the today-pattern, set globals at startup) and `Credential.apply(env)` returns a fresh dict the reader merges into `rasterio.Env(**env)` (per-call, per-reader isolation).
+  Both ultimately feed GDAL's libcurl through the env-var mechanism; they differ only in whether the env scope is process-global or per-call.
+- **`apply()` is pure; `apply_to_os_environ()` mutates.** The Protocol design uses two methods so callers can choose.
+  Per-reader isolation in `RasterioReader(credential=...)` uses `apply()` and merges into the local `rasterio.Env(...)` — no `os.environ` mutation, no global-state collisions between readers in one process.
+- **Per-reader isolation works on every bytes path.** GDAL-VSI gets a per-call env dict via `rasterio.Env(**apply(env))`. fsspec gets credentials inside its filesystem constructor.
+  Custom openers close over their own credential. None of these touch `os.environ`.
+- **Refresh logic lives at the reader layer**, not in the `Credential` itself.
+  The `Credential` knows *how* to refresh (`refresh()` method, which may also be invoked internally by `apply()` if the credential's TTL is near-expiry); the reader decides *when* to retry on a 401 (one refresh + one retry, then propagate).
+  This split keeps the credential testable in isolation.
 - **The today-pattern can't break.** Existing `os.environ['AZURE_STORAGE_*'] = ...` code keeps working — `RasterioReader()` without a `credential=` kwarg inherits from `os.environ` exactly as today.
 
 ---
@@ -185,7 +232,8 @@ class Credential(Protocol):
         ...
 ```
 
-The Protocol is `runtime_checkable` so user code can `isinstance(x, Credential)` for the duck-typed case. Concrete implementations don't need to inherit — any class with the three methods satisfies the Protocol structurally.
+The Protocol is `runtime_checkable` so user code can `isinstance(x, Credential)` for the duck-typed case.
+Concrete implementations don't need to inherit — any class with the three methods satisfies the Protocol structurally.
 
 ---
 
@@ -362,7 +410,8 @@ def from_config(
     ...
 ```
 
-Implementation detail: this dispatches on `section` to the right per-cloud helper, which then reads the right named keys. Same auth-priority logic as `mars_data_ops/utils/filesystem.py:617-703`, just promoted to the package.
+Implementation detail: this dispatches on `section` to the right per-cloud helper, which then reads the right named keys.
+Same auth-priority logic as `mars_data_ops/utils/filesystem.py:617-703`, just promoted to the package.
 
 ---
 
@@ -387,7 +436,8 @@ class RasterioReader(GeoData):
 
 Now per-reader isolation works for the GDAL-VSI path: at the moment `rasterio.Env(...)` is constructed, the credential's env vars are merged into the `rio_env_options` dict (not into `os.environ` globally), so two readers with two different credentials don't collide.
 
-The fsspec path (`fs=fsspec_fs`) and the opener path (`opener=callable`) take credentials through their respective objects' constructors and ignore the `credential=` kwarg if both are given. See [`reader_rasterio.md`](../georeader/reader_rasterio.md) for the full integration spec including refresh-on-401 retry and SAS-fallback rewriting.
+The fsspec path (`fs=fsspec_fs`) and the opener path (`opener=callable`) take credentials through their respective objects' constructors and ignore the `credential=` kwarg if both are given.
+See [`reader_rasterio.md`](../georeader/reader_rasterio.md) for the full integration spec including refresh-on-401 retry and SAS-fallback rewriting.
 
 ---
 
@@ -407,47 +457,63 @@ The fsspec path (`fs=fsspec_fs`) and the opener path (`opener=callable`) take cr
 
 ### 1. Where does `Credential` live — in `georeader` core or as a `[creds]` extra?
 
-The Azure / AWS / GCS subclasses each pull a real SDK (`azure-identity`, `boto3`, `google-auth`). Hard deps would balloon the install footprint. Three options:
+The Azure / AWS / GCS subclasses each pull a real SDK (`azure-identity`, `boto3`, `google-auth`).
+Hard deps would balloon the install footprint.
+Three options:
 
-- **Hard deps** — every install gets all three SDKs. Simplest, biggest install.
-- **`[creds]` extra** — `pip install georeader-spaceml[creds]` enables the typed credentials. Default users keep using env vars manually.
-- **Per-cloud extras** — `[azure-creds]`, `[aws-creds]`, `[gcs-creds]`. Most surgical; most complicated to document.
+- **Hard deps** — every install gets all three SDKs.
+  Simplest, biggest install.
+- **`[creds]` extra** — `pip install georeader-spaceml[creds]` enables the typed credentials.
+  Default users keep using env vars manually.
+- **Per-cloud extras** — `[azure-creds]`, `[aws-creds]`, `[gcs-creds]`.
+  Most surgical; most complicated to document.
 
-**Tentative pick: `[creds]` extra** (single optional dep that pulls all three SDKs). Per-cloud extras if install-size complaints arrive.
+**Tentative pick: `[creds]` extra** (single optional dep that pulls all three SDKs).
+Per-cloud extras if install-size complaints arrive.
 
 ### 2. Should `apply_to_os_environ` be the default `apply` method?
 
-The two-method shape (`apply` returns dict, `apply_to_os_environ` mutates global) is for the per-reader isolation case (which uses `apply`) and the today-pattern case (which uses `apply_to_os_environ`). Could collapse to one method that takes a destination dict:
+The two-method shape (`apply` returns dict, `apply_to_os_environ` mutates global) is for the per-reader isolation case (which uses `apply`) and the today-pattern case (which uses `apply_to_os_environ`).
+Could collapse to one method that takes a destination dict:
 
 ```python
 def apply(self, env: dict[str, str] | None = os.environ) -> dict[str, str]: ...
 ```
 
-Default to `os.environ`, override with `{}` for isolation. Cleaner API, but `os.environ` is mutable global state and using it as a default is a bit of a smell.
+Default to `os.environ`, override with `{}` for isolation.
+Cleaner API, but `os.environ` is mutable global state and using it as a default is a bit of a smell.
 
 **Tentative pick: keep two methods.** The two callsites have genuinely different intentions; one method with a magical default obscures that.
 
 ### 3. Refresh policy — automatic or explicit?
 
-Reader-level refresh on 401 is the obvious answer. Open questions:
+Reader-level refresh on 401 is the obvious answer.
+Open questions:
 
 - **How many retries?** One refresh + one retry is the standard pattern.
 - **Backoff?** Probably no — refresh is fast and retry should be immediate.
-- **Should `apply()` auto-refresh expired tokens, or wait for a 401?** Auto-refresh in `apply()` is cheaper (avoids the 401 round-trip) but requires the credential to know its TTL. Wait-for-401 is simpler but slower on the failure path. The `AzureManagedIdentityCredential` snippet above auto-refreshes; could be relaxed.
+- **Should `apply()` auto-refresh expired tokens, or wait for a 401?** Auto-refresh in `apply()` is cheaper (avoids the 401 round-trip) but requires the credential to know its TTL. Wait-for-401 is simpler but slower on the failure path.
+  The `AzureManagedIdentityCredential` snippet above auto-refreshes; could be relaxed.
 
 ### 4. STS session token / OIDC for AWS
 
-AWS via SSO / STS / OIDC is increasingly common in modern enterprises. The `AWSProfileCredential` above handles this via `boto3.Session`, but the actual refresh is delegated to boto3's own logic. Whether to expose a more explicit `AWSSSOCredential` / `AWSOIDCCredential` is open — depends on how often users want to construct these directly vs going through profile-based config.
+AWS via SSO / STS / OIDC is increasingly common in modern enterprises.
+The `AWSProfileCredential` above handles this via `boto3.Session`, but the actual refresh is delegated to boto3's own logic.
+Whether to expose a more explicit `AWSSSOCredential` / `AWSOIDCCredential` is open — depends on how often users want to construct these directly vs going through profile-based config.
 
 ### 5. Should a `from_env_vars()` constructor exist?
 
-For symmetry with the today-pattern: read whatever's currently in `os.environ`, return the appropriate credential object. Useful for "I've already set env vars; now wrap that as a typed object so my downstream code is consistent." Probably worth adding. Tentative shape: `AzureSASCredential.from_env()`, `AWSStaticCredential.from_env()`, etc. — class methods that read the canonical env vars.
+For symmetry with the today-pattern: read whatever's currently in `os.environ`, return the appropriate credential object.
+Useful for "I've already set env vars; now wrap that as a typed object so my downstream code is consistent." Probably worth adding.
+Tentative shape: `AzureSASCredential.from_env()`, `AWSStaticCredential.from_env()`, etc. — class methods that read the canonical env vars.
 
 ---
 
 ## Alternatives considered
 
-- **Just promote `mars_data_ops/filesystem.py` verbatim.** Rejected: that module is Azure-only, written before the package needed cross-cloud credential support, and tightly coupled to a specific config-file format. A typed Protocol is more flexible.
+- **Just promote `mars_data_ops/filesystem.py` verbatim.** Rejected: that module is Azure-only, written before the package needed cross-cloud credential support, and tightly coupled to a specific config-file format.
+  A typed Protocol is more flexible.
 - **Use `azure-identity` / `boto3` / `google-auth` credential objects directly.** Rejected: each SDK has its own credential type with its own API. The point of the `Credential` Protocol is to give a single surface; user code shouldn't have to branch on which SDK is in play.
 - **Use `fsspec.AbstractFileSystem` as the credential carrier.** Rejected: that's the fsspec-path credential locus, but it doesn't help GDAL-VSI users. fsspec is one of three paths, not the universal answer.
-- **Don't bother — keep the env-var pattern.** Rejected: the duplication is real and the multi-account / refresh-token cases are unsolved. A typed Protocol is the smallest API surface that fixes both.
+- **Don't bother — keep the env-var pattern.** Rejected: the duplication is real and the multi-account / refresh-token cases are unsolved.
+  A typed Protocol is the smallest API surface that fixes both.

--- a/projects/geotoolz/plans/types/geoslice.md
+++ b/projects/geotoolz/plans/types/geoslice.md
@@ -23,13 +23,16 @@ keywords: design, types, sampler, geoslice
 
 ## Summary
 
-A `GeoSlice` is a **bounded request for data** — a bbox, a time interval, a target resolution, and a CRS. It is the unit of work that catalogs produce, that loaders consume, and that operators (in `geotoolz`) compose against. The three sampler/stitch primitives are the canonical producers and consumer:
+A `GeoSlice` is a **bounded request for data** — a bbox, a time interval, a target resolution, and a CRS. It is the unit of work that catalogs produce, that loaders consume, and that operators (in `geotoolz`) compose against.
+The three sampler/stitch primitives are the canonical producers and consumer:
 
 - `random_sampler(catalog, chip_size, ...)` → iterator of `GeoSlice` for ML training.
 - `grid_sampler(catalog, chip_size, ...)` → iterator of `GeoSlice` for tiled inference.
 - `stitch(predictions, slices, ...)` → reverses the chip operation back into a single output raster.
 
-Today, all four live in `jej_vc_snippets/sampler.py` (~1400 LOC). The [Geodatabase Phase 1 design](../geodatabase/geocatalog.md) proposes promoting them into `georeader.samplers`. This document gives that promotion its own attention so the dataclass invariants, the sampler math, and the stitch reductions are specified in one place rather than scattered across other designs.
+Today, all four live in `jej_vc_snippets/sampler.py` (~1400 LOC).
+The [Geodatabase Phase 1 design](../geodatabase/geocatalog.md) proposes promoting them into `georeader.samplers`.
+This document gives that promotion its own attention so the dataclass invariants, the sampler math, and the stitch reductions are specified in one place rather than scattered across other designs.
 
 ---
 
@@ -37,49 +40,74 @@ Today, all four live in `jej_vc_snippets/sampler.py` (~1400 LOC). The [Geodataba
 
 Three reasons this deserves its own design doc rather than a section inside the catalog plan:
 
-1. **It's the inter-layer contract.** Catalogs produce `GeoSlice`s. Loaders consume them. `geotoolz.sampling.GridSampler` wraps `grid_sampler`; `geotoolz.inference.ApplyToChips` consumes the iterator and `stitch`es predictions. Six designs reference `GeoSlice`; none was the right home to fully specify it.
+1. **It's the inter-layer contract.** Catalogs produce `GeoSlice`s.
+   Loaders consume them.
+   `geotoolz.sampling.GridSampler` wraps `grid_sampler`; `geotoolz.inference.ApplyToChips` consumes the iterator and `stitch`es predictions.
+   Six designs reference `GeoSlice`; none was the right home to fully specify it.
 
-2. **The math is non-trivial and easy to get wrong.** Random-sampler weighting has a documented bias when tile sizes are heterogeneous. Grid-sampler stride math has subtle edge-case behaviour at the trailing row/column. Stitch's four reduction modes (`average` / `max` / `first` / `last`) each have different ordering semantics. Putting it all in one place makes it auditable.
+2. **The math is non-trivial and easy to get wrong.** Random-sampler weighting has a documented bias when tile sizes are heterogeneous.
+   Grid-sampler stride math has subtle edge-case behaviour at the trailing row/column.
+   Stitch's four reduction modes (`average` / `max` / `first` / `last`) each have different ordering semantics.
+   Putting it all in one place makes it auditable.
 
-3. **`GeoSlice` overlaps with two other concepts** — `rasterio.windows.Window` (pixel-space rectangle) and `slices.create_windows` (chunking generator). Reconciling the three is a design decision in its own right, not a footnote in another doc.
+3. **`GeoSlice` overlaps with two other concepts** — `rasterio.windows.Window` (pixel-space rectangle) and `slices.create_windows` (chunking generator).
+   Reconciling the three is a design decision in its own right, not a footnote in another doc.
 
 ---
 
 ## Primer for newcomers
 
-> **ELI5.** A `GeoSlice` is a **delivery slip**: it says where (bbox), when (time), at what zoom (resolution), and in what coordinate system (CRS). The catalog writes the slip; the loader reads it; whoever's in between never has to ask "wait, which file did this come from?" — the slip has everything they need.
+> **ELI5.** A `GeoSlice` is a **delivery slip**: it says where (bbox), when (time), at what zoom (resolution), and in what coordinate system (CRS).
+> The catalog writes the slip; the loader reads it; whoever's in between never has to ask "wait, which file did this come from?" — the slip has everything they need.
 
 ### Frozen dataclasses (immutability)
 
-**What it is.** A `@dataclass(frozen=True)` is a Python class with auto-generated `__init__` / `__repr__` / `__eq__` *and* a guarantee that its attributes can't be mutated after construction. Trying to assign a new value to a field raises `FrozenInstanceError`.
+**What it is.** A `@dataclass(frozen=True)` is a Python class with auto-generated `__init__` / `__repr__` / `__eq__` *and* a guarantee that its attributes can't be mutated after construction.
+Trying to assign a new value to a field raises `FrozenInstanceError`.
 
-**How it works.** The `@dataclass` decorator inspects type annotations and synthesises the constructor. `frozen=True` adds `__setattr__` and `__delattr__` overrides that raise. The instance is also hashable by default (because nothing can change), which lets you use it as a dict key or set member.
+**How it works.** The `@dataclass` decorator inspects type annotations and synthesises the constructor.
+`frozen=True` adds `__setattr__` and `__delattr__` overrides that raise.
+The instance is also hashable by default (because nothing can change), which lets you use it as a dict key or set member.
 
-**What this means for us.** `GeoSlice` is frozen so that once constructed, it can be passed across function boundaries, stored in caches, used as a dict key for "slices I've already processed," etc. Code that wants to *change* a slice creates a new one (`dataclasses.replace(slice_, bounds=new_bounds)`) — explicit by design. Mutable units of work flowing between layers are a recipe for bugs.
+**What this means for us.** `GeoSlice` is frozen so that once constructed, it can be passed across function boundaries, stored in caches, used as a dict key for "slices I've already processed," etc. Code that wants to *change* a slice creates a new one (`dataclasses.replace(slice_, bounds=new_bounds)`) — explicit by design.
+Mutable units of work flowing between layers are a recipe for bugs.
 
 ### `pd.Interval` and `IntervalIndex`
 
-**What it is.** A `pd.Interval(start, end, closed='both')` is pandas's typed representation of a time range. Combined into an `IntervalIndex`, you get fast "find all rows whose interval overlaps this query interval" queries — the temporal counterpart to a spatial R-tree.
+**What it is.** A `pd.Interval(start, end, closed='both')` is pandas's typed representation of a time range.
+Combined into an `IntervalIndex`, you get fast "find all rows whose interval overlaps this query interval" queries — the temporal counterpart to a spatial R-tree.
 
-**How it works.** Each interval is an immutable object with a `closed` policy (`'both'`, `'left'`, `'right'`, `'neither'`). Standard set ops (`overlaps`, `contains`) are vectorised at the IntervalIndex level. Scales cleanly: 10k intervals → microseconds per query. Same primitive used inside catalogs to filter by time.
+**How it works.** Each interval is an immutable object with a `closed` policy (`'both'`, `'left'`, `'right'`, `'neither'`).
+Standard set ops (`overlaps`, `contains`) are vectorised at the IntervalIndex level.
+Scales cleanly: 10k intervals → microseconds per query.
+Same primitive used inside catalogs to filter by time.
 
-**What this means for us.** `GeoSlice.interval` is a `pd.Interval`, not a `(tmin, tmax)` tuple, because the catalog stores intervals the same way and "does this slice's interval overlap any catalog row?" is a single function call (no manual min/max gymnastics). Convention is `closed='both'` everywhere — both endpoints inclusive.
+**What this means for us.** `GeoSlice.interval` is a `pd.Interval`, not a `(tmin, tmax)` tuple, because the catalog stores intervals the same way and "does this slice's interval overlap any catalog row?" is a single function call (no manual min/max gymnastics).
+Convention is `closed='both'` everywhere — both endpoints inclusive.
 
 ### `pyproj.CRS` (vs string EPSG codes)
 
-**What it is.** `pyproj.CRS` is a typed CRS object that knows its EPSG code, WKT representation, axis order, datum shifts, and reprojection rules. Compared to a bare `"EPSG:4326"` string, it carries semantic information.
+**What it is.** `pyproj.CRS` is a typed CRS object that knows its EPSG code, WKT representation, axis order, datum shifts, and reprojection rules.
+Compared to a bare `"EPSG:4326"` string, it carries semantic information.
 
-**How it works.** Constructed from `"EPSG:32630"`, a WKT string, or a `pyproj.CRS.from_epsg(32630)` call. Carries methods for axis-order checking, transformation parameter lookup, and "is this CRS equivalent to that one" comparisons. Reprojection to/from another CRS goes through `pyproj.Transformer`.
+**How it works.** Constructed from `"EPSG:32630"`, a WKT string, or a `pyproj.CRS.from_epsg(32630)` call.
+Carries methods for axis-order checking, transformation parameter lookup, and "is this CRS equivalent to that one" comparisons.
+Reprojection to/from another CRS goes through `pyproj.Transformer`.
 
-**What this means for us.** `GeoSlice.crs` is a `pyproj.CRS`, not a string, so two slices in slightly different CRS representations (e.g., `EPSG:32630` vs full WKT for the same UTM zone) can be compared sensibly. The package's `compare_crs(a, b)` helper does the right thing across the various forms.
+**What this means for us.** `GeoSlice.crs` is a `pyproj.CRS`, not a string, so two slices in slightly different CRS representations (e.g., `EPSG:32630` vs full WKT for the same UTM zone) can be compared sensibly.
+The package's `compare_crs(a, b)` helper does the right thing across the various forms.
 
 ### "Unit of work" between layers
 
 **What it is.** A small, immutable, self-contained value that flows from a *producer* (catalog, sampler) to a *consumer* (loader, operator) across a function boundary, carrying everything the consumer needs to do its job — no further reference to the producer required.
 
-**How it works.** `GeoSlice` has four fields: `bounds` (where in space), `interval` (when in time), `resolution` (at what pixel size), `crs` (in which coordinate system). That's enough for a loader to fetch a chip without consulting the catalog or the sampler again. The producer hands you a slice; you do whatever; you hand the result downstream. No hidden state.
+**How it works.** `GeoSlice` has four fields: `bounds` (where in space), `interval` (when in time), `resolution` (at what pixel size), `crs` (in which coordinate system).
+That's enough for a loader to fetch a chip without consulting the catalog or the sampler again.
+The producer hands you a slice; you do whatever; you hand the result downstream.
+No hidden state.
 
-**What this means for us.** The pattern decouples layers cleanly. A `random_sampler` doesn't know which loader will consume the slice; a `read_geoslice(slice)` method doesn't know whether the slice came from a sampler, a manual user query, or a JSON config. Same `GeoSlice` shape; many producers and consumers; no coupling beyond the type.
+**What this means for us.** The pattern decouples layers cleanly.
+A `random_sampler` doesn't know which loader will consume the slice; a `read_geoslice(slice)` method doesn't know whether the slice came from a sampler, a manual user query, or a JSON config. Same `GeoSlice` shape; many producers and consumers; no coupling beyond the type.
 
 ```{mermaid}
 sequenceDiagram
@@ -113,20 +141,25 @@ sequenceDiagram
 
 ## Non-goals
 
-- **Defining the `GeoCatalog` Protocol** — that's [Geodatabase](../geodatabase/README.md). This doc only describes how catalogs *produce* `GeoSlice` via the samplers.
+- **Defining the `GeoCatalog` Protocol** — that's [Geodatabase](../geodatabase/README.md).
+  This doc only describes how catalogs *produce* `GeoSlice` via the samplers.
 - **Defining the loader contract** — loaders that take a `GeoSlice` and return a `GeoTensor` are part of the catalog/reader designs.
 - **Owning the model-loop helper.** The old `run_inference_with_grid_sampler` is deliberately not promoted; `geotoolz.inference.ApplyToChips` is the sanctioned successor.
-- **Async samplers.** All three primitives are sync. An async iterator variant is plausible but lands later if needed.
+- **Async samplers.** All three primitives are sync.
+  An async iterator variant is plausible but lands later if needed.
 
 ---
 
 ## Constraints
 
 - **`GeoSlice.crs` is `pyproj.CRS`-shaped.** Matches the rest of `georeader`; no string-only or EPSG-int-only constraint.
-- **Time intervals are `pd.Interval`-shaped.** Matches the catalog's `IntervalIndex`. `closed='both'` is the convention everywhere.
+- **Time intervals are `pd.Interval`-shaped.** Matches the catalog's `IntervalIndex`.
+  `closed='both'` is the convention everywhere.
 - **`GeoSlice` is immutable.** `frozen=True` dataclass — slices are passed across function boundaries and shouldn't be mutated in flight.
-- **`stitch` produces a `GeoTensor`**, not a bare ndarray. Carrying CRS/transform through is non-negotiable; otherwise the result isn't georeferenced.
-- **No torch in the core path.** `random_sampler` returns an `Iterator[GeoSlice]`, not a `DataLoader`. ML adapters can be built on top.
+- **`stitch` produces a `GeoTensor`**, not a bare ndarray.
+  Carrying CRS/transform through is non-negotiable; otherwise the result isn't georeferenced.
+- **No torch in the core path.** `random_sampler` returns an `Iterator[GeoSlice]`, not a `DataLoader`.
+  ML adapters can be built on top.
 
 ---
 
@@ -172,10 +205,14 @@ class GeoSlice:
 
 ### Invariants
 
-- `bounds` is `(xmin, ymin, xmax, ymax)` with `xmin < xmax` and `ymin < ymax`. Antimeridian-crossing bboxes are forbidden at the slice level — split before constructing.
-- `interval.closed == "both"`. Half-open intervals are accepted by `pd.Interval` but rejected here for consistency with the catalog's `IntervalIndex`.
-- `resolution` is positive in both axes. The sign of the y-resolution is **not** flipped — slices store positive resolutions and the `transform` property handles the y-axis sign.
-- `(bounds, resolution)` is consistent: `(xmax - xmin) / x_res` and `(ymax - ymin) / y_res` should round to integers within `PIXEL_PRECISION = 3` decimal digits. Producers (samplers) guarantee this; loaders may assume it.
+- `bounds` is `(xmin, ymin, xmax, ymax)` with `xmin < xmax` and `ymin < ymax`.
+  Antimeridian-crossing bboxes are forbidden at the slice level — split before constructing.
+- `interval.closed == "both"`.
+  Half-open intervals are accepted by `pd.Interval` but rejected here for consistency with the catalog's `IntervalIndex`.
+- `resolution` is positive in both axes.
+  The sign of the y-resolution is **not** flipped — slices store positive resolutions and the `transform` property handles the y-axis sign.
+- `(bounds, resolution)` is consistent: `(xmax - xmin) / x_res` and `(ymax - ymin) / y_res` should round to integers within `PIXEL_PRECISION = 3` decimal digits.
+  Producers (samplers) guarantee this; loaders may assume it.
 
 ### Why `GeoSlice` and not `Window` or `slice`?
 
@@ -187,7 +224,9 @@ class GeoSlice:
 | Carries resolution | no | no | yes |
 | Use for | within-file extraction | array slicing | inter-layer contract |
 
-`GeoSlice` exists because the inter-layer contract needs all four. A `Window` is what a loader produces *from* a `GeoSlice` once it knows the source file's transform. A Python `slice` is what `slices.create_windows` ([Tutorial Ch. 6](../../georeader_tutorial/06_slices.md)) emits inside a single file, with no geographic meaning.
+`GeoSlice` exists because the inter-layer contract needs all four.
+A `Window` is what a loader produces *from* a `GeoSlice` once it knows the source file's transform.
+A Python `slice` is what `slices.create_windows` ([Tutorial Ch. 6](../../georeader_tutorial/06_slices.md)) emits inside a single file, with no geographic meaning.
 
 ### Conversion to/from `Window`
 
@@ -225,7 +264,8 @@ def random_sampler(
 ) -> Iterator[GeoSlice]: ...
 ```
 
-- `catalog` is consulted via `iter_rows()` (Phase 1) or a streaming cursor (Phase 2). The sampler doesn't materialise the full catalog.
+- `catalog` is consulted via `iter_rows()` (Phase 1) or a streaming cursor (Phase 2).
+  The sampler doesn't materialise the full catalog.
 - `length=None` means "infinite iterator"; downstream code uses `itertools.islice` to bound.
 - `roi` / `toi` filter the catalog before sampling.
 - `units="pixels"` interprets `chip_size` in pixels; `units="crs"` in CRS units (relevant for cross-resolution catalogs).
@@ -234,7 +274,8 @@ def random_sampler(
 
 ### Area-weighted sampling math
 
-Default `weight="area"`. Tiles big enough to fit a chip are kept; each surviving tile gets weight proportional to its area:
+Default `weight="area"`.
+Tiles big enough to fit a chip are kept; each surviving tile gets weight proportional to its area:
 
 $$
 w_i = \frac{(x_{\max,i} - x_{\min,i}) \cdot (y_{\max,i} - y_{\min,i})}{\sum_j A_j}
@@ -251,15 +292,21 @@ The timestamp is sampled uniformly (in seconds) inside the tile's interval and a
 
 ### The weighting bias (open question)
 
-Area-weighted sampling pushes samples *toward* large tiles. For uniform-density imagery this is what you want — every pixel has equal probability of being sampled. For tiled mosaics with one giant tile and many small ones, it over-samples the giant tile.
+Area-weighted sampling pushes samples *toward* large tiles.
+For uniform-density imagery this is what you want — every pixel has equal probability of being sampled.
+For tiled mosaics with one giant tile and many small ones, it over-samples the giant tile.
 
 Three options:
 
-- **`weight="area"` (default)** — what's described above. Right for uniform imagery.
-- **`weight="uniform"`** — each tile has equal probability regardless of size. Right for tiled mosaics where each tile represents one "scene" and you want balanced training data.
-- **`weight=callable`** — user-supplied function over the catalog row. Maximum flexibility; rarely needed.
+- **`weight="area"` (default)** — what's described above.
+  Right for uniform imagery.
+- **`weight="uniform"`** — each tile has equal probability regardless of size.
+  Right for tiled mosaics where each tile represents one "scene" and you want balanced training data.
+- **`weight=callable`** — user-supplied function over the catalog row.
+  Maximum flexibility; rarely needed.
 
-The proposal is to expose `weight={"area", "uniform"}` and document the bias. See [parent README §Open questions](README.md) for the unresolved decision on whether `callable` is worth adding in v1.
+The proposal is to expose `weight={"area", "uniform"}` and document the bias.
+See [parent README §Open questions](README.md) for the unresolved decision on whether `callable` is worth adding in v1.
 
 ---
 
@@ -292,18 +339,22 @@ n_{\text{cols}} = \left\lceil \frac{W - w}{s_x} \right\rceil + 1, \qquad
 n_{\text{rows}} = \left\lceil \frac{H - h}{s_y} \right\rceil + 1
 $$
 
-Final-row/column chips are **shifted** (not truncated) so chip size stays exact across the grid. Total chip count = sum over tiles. Matches the standard sliding-window convention used by `xrpatcher` / `xbatcher`.
+Final-row/column chips are **shifted** (not truncated) so chip size stays exact across the grid.
+Total chip count = sum over tiles.
+Matches the standard sliding-window convention used by `xrpatcher` / `xbatcher`.
 
 ### Reconciliation with `slices.create_windows`
 
-[`slices.create_windows`](../../georeader_tutorial/06_slices.md) does the same stride math but at the pixel level inside a single file. The relationship:
+[`slices.create_windows`](../../georeader_tutorial/06_slices.md) does the same stride math but at the pixel level inside a single file.
+The relationship:
 
 | Layer | Function | Input | Output |
 |---|---|---|---|
 | Inter-file (catalog) | `grid_sampler` | catalog + chip size in CRS units | iterator of `GeoSlice` |
 | Intra-file (one raster) | `slices.create_windows` | `(H, W)` shape + chip size in pixels | iterator of `Window` |
 
-`grid_sampler` calls into the catalog to find tiles; for each tile it can either reimplement stride math itself or convert the tile's bounds into a `(H, W)` shape and delegate to `create_windows`, then convert each `Window` back to a `GeoSlice`. The implementation detail is open; the two functions stay separately useful at their respective scopes.
+`grid_sampler` calls into the catalog to find tiles; for each tile it can either reimplement stride math itself or convert the tile's bounds into a `(H, W)` shape and delegate to `create_windows`, then convert each `Window` back to a `GeoSlice`.
+The implementation detail is open; the two functions stay separately useful at their respective scopes.
 
 ---
 
@@ -321,7 +372,8 @@ def stitch(
 ) -> GeoTensor: ...
 ```
 
-- `predictions[i]` is the model output for `slices[i]`. Same length, same order.
+- `predictions[i]` is the model output for `slices[i]`.
+  Same length, same order.
 - `roi` is optional — clips the output to a polygon footprint.
 - Returns a `GeoTensor` with transform/CRS derived from the union of the slices' bounds and the assumed-uniform resolution.
 
@@ -343,9 +395,11 @@ row = int((ymax - slice_.bounds[3]) / y_res)   # y-flip: rows count from north d
 
 ### Order-dependence
 
-`first` and `last` are **order-dependent** by definition — they reduce based on the iteration order of `predictions`. `average` and `max` are order-independent.
+`first` and `last` are **order-dependent** by definition — they reduce based on the iteration order of `predictions`.
+`average` and `max` are order-independent.
 
-For deterministic pipelines, sort `slices` by `(slice_.bounds, slice_.interval.left)` before passing. The samplers don't guarantee a stable order — `random_sampler` is intentionally random; `grid_sampler` iterates tiles in catalog order, which depends on the backend.
+For deterministic pipelines, sort `slices` by `(slice_.bounds, slice_.interval.left)` before passing.
+The samplers don't guarantee a stable order — `random_sampler` is intentionally random; `grid_sampler` iterates tiles in catalog order, which depends on the backend.
 
 ---
 
@@ -380,29 +434,42 @@ Every arrow is sync in this proposal. The async equivalent (using `AsyncGeoData.
 
 ### 1. `weight=callable` in `random_sampler`
 
-Section above proposes `weight={"area", "uniform"}` for v1. A callable variant (`weight=lambda row: ...`) is requested by some users for stratified sampling but adds API surface. Defer to v2 or include now? **Tentative pick: defer.**
+Section above proposes `weight={"area", "uniform"}` for v1. A callable variant (`weight=lambda row: ...`) is requested by some users for stratified sampling but adds API surface.
+Defer to v2 or include now?
+**Tentative pick: defer.**
 
 ### 2. `GeoSlice` antimeridian policy
 
-The invariants require `xmin < xmax`. Antimeridian-crossing AOIs are forbidden at the slice level. Where does the split happen?
+The invariants require `xmin < xmax`.
+Antimeridian-crossing AOIs are forbidden at the slice level.
+Where does the split happen?
 
 - **At the producer** (sampler refuses to emit antimeridian-crossing slices, splits internally).
 - **At the consumer** (loader detects and splits the read into two).
 - **At a higher level** (reject antimeridian-crossing inputs entirely with a clear error).
 
-[`window_utils.bounds_to_windows`](../../georeader_tutorial/04_window_utils.md) currently handles this in the loader path by returning a list of windows. Whether `GeoSlice` should mirror that or refuse outright is a judgement call.
+[`window_utils.bounds_to_windows`](../../georeader_tutorial/04_window_utils.md) currently handles this in the loader path by returning a list of windows.
+Whether `GeoSlice` should mirror that or refuse outright is a judgement call.
 
 ### 3. `GeoSlice.dims` for higher-rank slices
 
-Today's `shape` returns `(h, w)`. For 4D `(t, b, h, w)` chips, do we want a `dims` property? The number of channels can be inferred from the catalog row + loader, not from the slice itself. **Tentative pick: keep slices 2D-shaped; let downstream code assemble multi-dim chunks.**
+Today's `shape` returns `(h, w)`.
+For 4D `(t, b, h, w)` chips, do we want a `dims` property?
+The number of channels can be inferred from the catalog row + loader, not from the slice itself.
+**Tentative pick: keep slices 2D-shaped; let downstream code assemble multi-dim chunks.**
 
 ### 4. `stitch` default for `method`
 
-`average` is the proposal default. For probability-output models this is *wrong* — averaging probabilities pre-softmax gives the wrong posterior. For most practical cases users want `last` (faster, no allocation of the counts array) or `average` (smoother). Pick: keep `average` as default, document the gotcha. **Tentative pick: keep `average`.**
+`average` is the proposal default.
+For probability-output models this is *wrong* — averaging probabilities pre-softmax gives the wrong posterior.
+For most practical cases users want `last` (faster, no allocation of the counts array) or `average` (smoother).
+Pick: keep `average` as default, document the gotcha.
+**Tentative pick: keep `average`.**
 
 ### 5. Time semantics in `stitch`
 
-`stitch` produces a single `GeoTensor` from many slices. If those slices have different `interval` fields (likely, when stitching predictions across time), what does the output's `interval` become?
+`stitch` produces a single `GeoTensor` from many slices.
+If those slices have different `interval` fields (likely, when stitching predictions across time), what does the output's `interval` become?
 
 - **Union of all input intervals** — semantically defensible.
 - **Drop the time field** — the output is spatial; time is no longer meaningful.
@@ -415,6 +482,9 @@ Today's `shape` returns `(h, w)`. For 4D `(t, b, h, w)` chips, do we want a `dim
 ## Alternatives considered
 
 - **Use `BoundingBox` from torchgeo.** Rejected: brings a torch dependency into the inter-layer contract; doesn't carry resolution; carries time only optionally.
-- **Reuse `rasterio.windows.Window`.** Rejected: `Window` is pixel-space and CRS-agnostic. Cross-CRS catalogs would need conversion at every layer boundary.
-- **Use a STAC `Item` as the unit of work.** Rejected: too heavy. STAC items carry rich asset metadata that the inter-layer contract doesn't need; forcing every slice to be STAC-shaped pulls in a JSON-schema dep.
-- **Skip the dataclass; pass `(bounds, interval, resolution, crs)` as a tuple.** Rejected: the sampler/loader/stitch surface is wide enough that a positional tuple becomes a bug magnet. Field names matter.
+- **Reuse `rasterio.windows.Window`.** Rejected: `Window` is pixel-space and CRS-agnostic.
+  Cross-CRS catalogs would need conversion at every layer boundary.
+- **Use a STAC `Item` as the unit of work.** Rejected: too heavy.
+  STAC items carry rich asset metadata that the inter-layer contract doesn't need; forcing every slice to be STAC-shaped pulls in a JSON-schema dep.
+- **Skip the dataclass; pass `(bounds, interval, resolution, crs)` as a tuple.** Rejected: the sampler/loader/stitch surface is wide enough that a positional tuple becomes a bug magnet.
+  Field names matter.


### PR DESCRIPTION
## Summary

Two-commit PR against `main`. Both touch `projects/geotoolz/` only.

### Commit 1 — `docs(geotoolz): add sklearn + skimage ecosystem bridge plans`

Two new sub-design pairs spec how `geotoolz` reaches into the long-tail of the SciPy stack without re-implementing it. Each ships as a (design, examples) pair under its own subdirectory and is wired into the site TOC under *Plans → geotoolz*.

| Bridge | Design | Examples | What it wraps |
|---|---|---|---|
| **scikit-image** | [`skimage/design_skimage.md`](projects/geotoolz/plans/geotoolz/skimage/design_skimage.md) | [`skimage/examples_skimage.md`](projects/geotoolz/plans/geotoolz/skimage/examples_skimage.md) | `PerBand` / `MultiBand` / `Func` wrappers with axis-aware HWC/CHW adapters, dtype-range safety (`float [0,1]` ↔ `uint8 [0,255]`), and NaN masking/restoration. Examples: SAR speckle reduction, cloud-mask post-processing, CLAHE, edge detection, superpixel segmentation, inpainting, GLCM textures, blob detection, image registration. |
| **scikit-learn** | [`sklearn/design_sklearn.md`](projects/geotoolz/plans/geotoolz/sklearn/design_sklearn.md) | [`sklearn/examples_sklearn.md`](projects/geotoolz/plans/geotoolz/sklearn/examples_sklearn.md) | One `PixelTable` bridging type plus shape adapters (spatial-pixelwise, spatiotemporal-pixelwise, chipwise) and four estimator wrappers (Classifier / Regressor / Transformer / Clusterer). NaN strategy taxonomy. Fitting stays out of the operator graph. Works for any `BaseEstimator`-protocol library (sklearn, xgboost, lightgbm, catboost, imbalanced-learn). Examples: crop classification, chipwise inference, biomass regression, pixel-wise PCA, full sklearn `Pipeline`, per-tile classifier, time-series classification, spatial CV, unsupervised clustering, incremental fitting. |

All four files use MyST frontmatter matching the existing `geotoolz.md` style, with a Status/Scope/Audience blockquote callout. Cross-link targets resolved (`../examples/usecases.md`, `../examples/tips_n_tricks.md`, sibling `design_*.md` ↔ `examples_*.md`). `myst.yml` grows two new sub-sections; the geotoolz README grows an "Ecosystem bridges" section linking both pairs.

### Commit 2 — `style(geotoolz): adopt one-sentence-per-line semantic line breaks`

Reformat every markdown file under `projects/geotoolz/` (39 files in this commit, all prior content) to **ventilated prose**: one sentence per line, no mid-sentence hard wraps.

**Why.** A one-word edit to a paragraph currently produces a multi-line diff because the rewrap kicks in across the whole paragraph. With semantic line breaks, a one-sentence change is a one-line diff — review, blame, and cherry-pick become cleaner. The convention also makes prose easier to reorder.

**Mechanically applied** by a Python script that unwraps continuation lines then splits on sentence boundaries with protection for abbreviations (`e.g.` / `i.e.` / `etc.` / `vs.` / `cf.` / `Dr.` / `Fig.` / `Sec.` / `pp.` / `Inc.` / `Ltd.` / …), decimals (`1.5`), URL dots, dotted identifiers (`geotoolz.foo.bar`), and personal initials. The split only fires when the punctuation is preceded by a lowercase letter or a closing bracket/quote (so `Step 1.` and `U.S.A.` don't trigger).

**Untouched:** YAML frontmatter, fenced code blocks, block math (`$$…$$`), tables, MyST directives, block-level HTML, headings, horizontal rules.

**Diff:** +3254 / −1779 lines. Heavily hard-wrapped files expand (e.g. `plans/geotoolz/geotoolz.md` +361 lines); partially-ventilated files shrink. Verified via `npx mystmd build --html`: all 205 page JSONs build cleanly; frontmatter / code-fence / math-block / table counts match the pre-reformat originals exactly.

The rule is durable in my agent memory so future edits to anything under `research_notebook/projects/geotoolz/` follow this style from the first draft.

## Test plan

- [ ] `npx mystmd start --clean` and verify all geotoolz pages render
- [ ] Open the four new bridge pages in the site nav (Plans → geotoolz → scikit-image bridge / scikit-learn bridge) and verify frontmatter + cross-links resolve
- [ ] Spot-check the ventilated-prose reformat by opening any reformatted file (e.g. `plans/geotoolz/geotoolz.md`) — prose lines should be single sentences; tables / code / math blocks should be byte-identical to before
- [ ] Optional: pick a paragraph somewhere in geotoolz docs, make a one-word edit, and confirm the diff is one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)