### PR TITLE
docs(geotoolz): add spatiotemporal data + operators tutorials

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -123,6 +123,10 @@ project:
           children:
             - file: projects/geotoolz/geostack_notes.md
             - file: projects/geotoolz/operational_attribution.md
+            - title: Tutorials
+              children:
+                - file: projects/geotoolz/tutorials/spatiotemporal_data.md
+                - file: projects/geotoolz/tutorials/spatiotemporal_operators.md
             - title: Plans
               children:
                 - title: geotoolz

--- a/projects/geotoolz/tutorials/spatiotemporal_data.md
+++ b/projects/geotoolz/tutorials/spatiotemporal_data.md
@@ -1,0 +1,992 @@
+---
+title: Spatiotemporal data
+subject: geotoolz tutorial
+subtitle: Shapes, coordinates, and geometry of the world that arrives at your operator
+short_title: Spatiotemporal data
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: tutorial, geotoolz, data, shapes, coordinates, geometry, xarray, einx, jaxtyping
+---
+
+> **Status:** Draft.
+> **Scope:** A conceptual tutorial — pseudocode only, no executable cells.
+> **Audience:** Anyone wrapping geophysical / EO data for downstream operators and trying to think about *what arrives at the operator and what travels alongside it.*
+
+Operators get all the attention.
+But every operator is downstream of a more basic question: *what does the data look like, what coordinates does it carry, and what geometric topology does it sit on?*
+This tutorial is the data-side companion to [Spatiotemporal operators](spatiotemporal_operators.md).
+
+The two tutorials share a vocabulary — the canonical tensor `[S, T, V, X]`, the named-dim convention, and `einx` / `xarray` / `jaxtyping` for typing.
+This one walks how the data *gets* to that shape, what coordinates it brings with it, and how the underlying geometry (point, line, polygon, raster, multi-polygon) governs which operators can run on it.
+
+The framing is at heart *physical*: every axis of the data tensor carries a different scale, every coordinate is a hook for an operator to bind to, and every geometric primitive is a different statement about what the world delivered.
+Getting the data shape, coordinates, and geometry right is upstream of every operator-side choice — and in practice, it is where most pipelines live or die.
+
+---
+
+## 1. The canonical tensor `[S, T, V, X]`
+
+Almost every geophysical / EO array can be flattened into four conceptual axes.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                                             │
+│         S   ── samples       (scenes, events, batch)        │
+│         T   ── time          (timesteps within a sample)    │
+│         V   ── variables     (channels: T, p, q, R, G, NIR) │
+│         X   ── space         (pixels, points, mesh nodes)   │
+│                                                             │
+│              ┌──────────────────────────┐                   │
+│              │       arr[S, T, V, X]    │                   │
+│              └──────────────────────────┘                   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+`X` is "space" in the abstract sense — it can be:
+
+- a single flat axis of points (`N`),
+- a structured spatial grid (`H, W` or `D, H, W`),
+- an unstructured mesh (nodes + an adjacency / KDTree off-array).
+
+For most of the tutorial we write `X` as a single axis and note where structure matters.
+
+We type our arrays with [jaxtyping](https://github.com/google/jaxtyping) and name dimensions explicitly with [xarray](https://docs.xarray.dev/) so that every reshape is auditable.
+
+```python
+from jaxtyping import Float, Array
+import xarray as xr
+import einx
+
+Field = Float[Array, "S T V X"]
+```
+
+The named-dims version, for the same physical quantity:
+
+```python
+da: xr.DataArray  # dims = ("sample", "time", "variable", "space")
+```
+
+`einx.rearrange` patterns are written against these names, not positional indices, so the reshape *reads* as the intent.
+
+---
+
+## 2. Building up to `[S, T, V, X]` — the data you actually meet
+
+Real datasets rarely arrive at `[S, T, V, X]`.
+They start as a single time series, or a single spatial field, and the canonical tensor is *constructed* — by stacking, ensembling, windowing, or patching.
+This section walks the construction so that every later mention of "the `S` axis" or "the `T` axis" has a concrete geophysical referent.
+
+We use six base shapes, ordered by how many physical axes they expose, and then three operations that synthesise an `S` axis on top.
+
+---
+
+### 2.1 Stage 0 — `[T]` — univariate time series
+
+One variable, one location, sampled over time.
+The simplest geophysical signal there is.
+
+```
+        time →
+        ┌────────────────────────────┐
+arr     │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+        └────────────────────────────┘
+```
+
+```python
+arr:    Float[Array, "T"]
+coords = {
+    "time": Float[Array, "T"],     # datetime64 or seconds-since-epoch
+}
+da:     xr.DataArray               # dims = ("time",)
+# geometry: point (one fixed location, see §4.2)
+```
+
+**Examples.**
+A single tide gauge's hourly sea level (Brest, Sydney), one Argo float's daily SST record, the Mauna Loa monthly CO₂ time series, a borehole's groundwater level, a single PM₂.₅ sensor, one eddy-covariance flux tower's NEE record.
+Anything you'd plot as a single line chart.
+
+**Operators that live here.**
+Trend estimation, change-point detection, harmonic decomposition, autoregressive modelling, peaks-over-threshold extremes — all of classical univariate time-series analysis.
+
+---
+
+### 2.2 Stage 1 — `[T, V]` — multivariate time series
+
+Same location, same time grid, several variables.
+
+```
+        time →
+   T   ┌────────────────────────────┐
+   p   │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+   q   │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+   u   │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+       └────────────────────────────┘
+```
+
+```python
+arr:    Float[Array, "T V"]
+coords = {
+    "time":     Float[Array, "T"],
+    "variable": Str[Array,   "V"],   # variable names (or band IDs, depths)
+}
+da:     xr.DataArray                 # dims = ("time", "variable")
+# geometry: point
+```
+
+**Examples.**
+A weather station record (T, RH, P, wind, precip), a hyperspectral pixel time series (B1…B224), a multi-gas flask-sample record (CO₂, CH₄, N₂O), a multi-depth soil-moisture profile at one station, a single MODIS pixel through all spectral bands.
+
+**Operators that live here.**
+Cross-correlation of variables, vector autoregression (VAR), canonical correlation analysis, multivariate extreme-event detection, copula-based dependence modelling.
+The `V` axis is where channel-mixing happens; `T` is where temporal context lives.
+
+---
+
+### 2.3 Stage 2 — `[X]` — univariate spatial field
+
+One variable, one snapshot in time, sampled over space.
+
+```
+              W →
+       H   ┌─────────────────┐
+       ↓   │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+           │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+           │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+           └─────────────────┘
+```
+
+```python
+arr:    Float[Array, "H W"]                # structured grid
+arr:    Float[Array, "N"]                  # unstructured mesh / point cloud
+coords = {
+    "lat": Float[Array, "H"],              # static — fixed for the lifetime of the data
+    "lon": Float[Array, "W"],
+    # unstructured variant:
+    # "lat": Float[Array, "N"], "lon": Float[Array, "N"]
+}
+da:     xr.DataArray                       # dims = ("y", "x")  or  ("lat", "lon")
+# geometry: raster (structured) or point set (unstructured)
+```
+
+**Examples.**
+A single Landsat NDVI map, an SRTM 30 m DEM tile, a snapshot of MERRA-2 surface temperature at one timestamp, a one-orbit TROPOMI XCH₄ scene, an ICESat-2 single-track elevation profile.
+
+**Operators that live here.**
+Edge detection, morphology, segmentation, spatial smoothing, kriging interpolation, hot-spot detection (Getis-Ord G*, local Moran's I).
+This is `skimage`-shaped territory.
+
+---
+
+### 2.4 Stage 3 — `[V, X]` — multivariate spatial field
+
+Several variables, one snapshot, sampled over space.
+The canonical "remote-sensing scene".
+
+```
+                 W →
+       V   ┌─────────────────┐
+  channel  │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │  per channel
+   stack   │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+           │ ▓ ▓ ▓ ▓ ▓ ▓ ▓ ▓ │
+           └─────────────────┘
+```
+
+```python
+arr:    Float[Array, "V H W"]
+coords = {
+    "variable": Str[Array,   "V"],
+    "lat":      Float[Array, "H"],
+    "lon":      Float[Array, "W"],
+}
+da:     xr.DataArray             # dims = ("band", "y", "x")
+# geometry: raster
+```
+
+**Examples.**
+A multispectral scene (Landsat 8: 11 bands), a hyperspectral cube (PRISMA, EnMAP, EMIT: 200+ bands), a multi-variable ERA5 surface snapshot (T2, U10, V10, TP, SSR), a single SAR polarimetric image (VV + VH).
+
+**Operators that live here.**
+Spectral unmixing, supervised classification, principal-component compression, band-ratio indices (NDVI, NDWI, NBR), atmospheric correction, cloud masking.
+
+---
+
+### 2.5 Stage 4 — `[T, X]` — univariate spatiotemporal
+
+One variable, a sequence of snapshots — the basic geophysical "video".
+
+```
+         time →
+                                   each frame is a flat field
+
+  t1: ┌────────┐     t2: ┌────────┐     t3: ┌────────┐
+      │ ▓ ▓ ▓ ▓│         │ ▓ ▓ ▓ ▓│         │ ▓ ▓ ▓ ▓│   ...
+      │ ▓ ▓ ▓ ▓│         │ ▓ ▓ ▓ ▓│         │ ▓ ▓ ▓ ▓│
+      └────────┘         └────────┘         └────────┘
+```
+
+```python
+arr:    Float[Array, "T H W"]
+coords = {
+    "time": Float[Array, "T"],
+    "lat":  Float[Array, "H"],     # static if regular grid
+    "lon":  Float[Array, "W"],
+    # dynamic-grid variant (e.g. swath data):
+    # "lat": Float[Array, "T H W"], "lon": Float[Array, "T H W"]
+}
+da:     xr.DataArray               # dims = ("time", "y", "x")
+# geometry: raster (structured) or point cloud per t (swath)
+```
+
+**Examples.**
+A monthly NDVI time series over Africa, daily SST over the Pacific, hourly precipitation-radar mosaics over a river basin, an Argo gridded temperature stack at one depth level, daily MODIS LST.
+
+**Operators that live here.**
+Per-pixel trend, change detection, optical flow, object tracking, Kalman-style state estimation, persistence forecasts, video segmentation.
+
+---
+
+### 2.6 Stage 5 — `[T, V, X]` — multivariate spatiotemporal
+
+The most common datacube in modern Earth-system science.
+
+```
+       V  ┌──┐   ┌──┐   ┌──┐
+  per    │T1│   │T2│   │T3│   ...      a stack of (T, V) snapshots
+ channel └──┘   └──┘   └──┘             each cell is a 2-D field
+```
+
+```python
+arr:    Float[Array, "T V H W"]
+coords = {
+    "time":     Float[Array, "T"],
+    "variable": Str[Array,   "V"],
+    "lat":      Float[Array, "H"],     # static
+    "lon":      Float[Array, "W"],
+}
+da:     xr.DataArray                   # dims = ("time", "variable", "y", "x")
+# geometry: raster
+```
+
+**Examples.**
+ERA5 reanalysis (decades of hourly data, dozens of variables, global grid), CMIP6 model output, a satellite analysis-ready datacube (ARD), a multi-channel SAR time series, an atmospheric-chemistry assimilation product (CAMS), a multispectral monthly mosaic (Sentinel-2 L2A monthly composites).
+
+**Operators that live here.**
+Almost anything you'd run on the canonical tensor *except* operations along an ensemble axis.
+This is `xarray`'s and `Pangeo`'s native shape; most operational EO pipelines never leave it.
+
+---
+
+### 2.7 Stage 6 — `[S, T, V, X]` — the canonical tensor
+
+The `S` axis is the *bookkeeping* axis: independent (or quasi-independent) realisations of a `[T, V, X]` cube.
+
+```python
+arr:    Float[Array, "S T V H W"]
+coords = {
+    "member":   Int[Array,   "S"],     # ensemble member ID, window start, or patch position
+    "time":     Float[Array, "T"],
+    "variable": Str[Array,   "V"],
+    "lat":      Float[Array, "H"],
+    "lon":      Float[Array, "W"],
+}
+da:     xr.DataArray                   # dims = ("member", "time", "variable", "y", "x")
+# geometry: raster (× S)
+```
+
+`S` is rarely a single natural data axis.
+It is almost always *manufactured* by one of three operations: **simulation**, **windowing**, or **patching**.
+Each construction creates an `S` axis with different semantics — *and reshapes the coord pack along with it*.
+The dependency-game logic in [Spatiotemporal operators §3](spatiotemporal_operators.md) hinges on which construction you used.
+
+---
+
+### 2.8 `S` from simulation — ensembles
+
+Run a numerical model (or a stochastic forecast) `N` times with perturbed initial conditions, parameters, or boundary forcings.
+The `S` axis indexes the realisations.
+
+```
+                                arr[s=0, T, V, X]
+   simulation runs              arr[s=1, T, V, X]
+       ↓                        arr[s=2, T, V, X]
+                                   …
+       run 0                    arr[s=N, T, V, X]
+       run 1
+       run 2          S becomes a *probability* axis —
+        …             reductions over S compute mean,
+       run N          variance, quantiles, EnKF analysis.
+```
+
+**Real instances.**
+ECMWF / GFS / NCEP ensemble forecasts (51 / 31 / 21 members), GraphCast and Pangu-Weather ensembles, the CMIP6 multi-model archive (`S` indexes models *and* runs), EnKF / EnSRF data-assimilation ensembles, Lagrangian particle back-trajectory ensembles (FLEXPART, HYSPLIT), perturbed-parameter climate-sensitivity sweeps.
+
+```python
+def from_ensemble(
+    runs: list[Float[Array, "T V H W"]],
+) -> Float[Array, "S T V H W"]:
+    return einx.rearrange("s ... -> s ...", jnp.stack(runs))
+```
+
+**Semantics: exchangeable.**
+The members are realisations of the *same* physics under stochastic perturbation; reductions over `S` are well-defined moments.
+This is the `S` axis the dependency-game logic implicitly assumes.
+
+**Coord transform: a new axis appears.**
+The `time`, `lat`, `lon` arrays are *shared* across all members — they do not gain an `S` dimension.
+A single new coord, `member` (shape `[S]`), is added.
+Operators reducing over `S` (ensemble mean, spread, EnKF analysis) only ever touch this one new coord.
+
+---
+
+### 2.9 `S` from windowing — local-in-time slicing
+
+Slice a long `[T, V, X]` cube into overlapping or non-overlapping temporal windows.
+The `S` axis indexes window starts.
+
+```
+   one long [T, V, X] series:
+      ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+      └──┘                              window 1
+         └──┘                           window 2  (stride s)
+            └──┘                        window 3
+               └──┘                     window 4   ──►  arr[S, T_w, V, X]
+                  └──┘                                      ↑       ↑
+                                                      window idx  window length
+```
+
+**Real instances.**
+30-day rolling NDVI windows for phenology classification, 1-second seismic-waveform windows for earthquake / explosion classification, daily-rolling rainfall windows for flood-onset detection, attention-context windows for transformer-based forecasts, lookback windows for autoregressive sea-ice forecasts.
+
+```python
+def windowed(
+    arr: Float[Array, "T V H W"], win: int, stride: int,
+) -> Float[Array, "S T_w V H W"]:
+    # einx supports strided unfolding via constraint patterns;
+    # production code may use jax.numpy.lib.stride_tricks.sliding_window_view.
+    return einx.rearrange(
+        "(s_pos win) v h w -> s_pos win v h w",
+        sliding_view(arr, axis=0, window=win, stride=stride),
+        win=win,
+    )
+```
+
+**Semantics: chronologically ordered, not exchangeable.**
+Adjacent windows share data; reductions over `S` are *not* iid means.
+Operators must either treat `S` as a sequence axis (RNN / transformer), enforce non-overlap, or honestly inflate the effective-sample-size correction.
+
+**Coord transform: `time` gains an `S` axis.**
+Each window has its own time stamps, so `coords["time"]` becomes shape `[S, T_w]` (and overlapping windows share values across rows — a redundant-coord fact that downstream code must respect).
+`lat` and `lon` remain unchanged because windowing is purely temporal.
+Window-relative time (e.g., "lag-from-window-start") is a useful *derived* feature, often added as a second time-coord.
+
+---
+
+### 2.10 `S` from patching — local-in-space slicing
+
+Slice a single large `[T, V, H, W]` field into overlapping or non-overlapping spatial patches.
+The `S` axis indexes patch positions.
+
+```
+   one large [V, H, W] field:                arr[S, T, V, H_p, W_p]
+   ┌──────────────────────────┐                     ↑      ↑     ↑
+   │  ┌──┐ ┌──┐ ┌──┐ ┌──┐    │   patches            S    patch  patch
+   │  └──┘ └──┘ └──┘ └──┘    │   ─────►        position idx     size
+   │  ┌──┐ ┌──┐ ┌──┐ ┌──┐    │
+   │  └──┘ └──┘ └──┘ └──┘    │
+   └──────────────────────────┘
+```
+
+**Real instances.**
+64×64 patches for CNN training on Sentinel-2 (the BigEarthNet / EuroSAT standard), 256×256 patches for FNO / U-Net training on ERA5, sliding-window plume-detection crops on hyperspectral cubes, patch-based denoisers (BM3D, Noise2Self), tile-based foundation-model embedding (Prithvi: 224×224 tiles).
+
+```python
+def patched(
+    arr: Float[Array, "T V H W"], patch: int,
+) -> Float[Array, "S T V H_p W_p"]:
+    return einx.rearrange(
+        "t v (nh ph) (nw pw) -> (nh nw) t v ph pw",
+        arr, ph=patch, pw=patch,
+    )
+```
+
+**Semantics: spatially ordered, not exchangeable.**
+Adjacent patches share pixels if overlapping; reductions over `S` aggregate spatially (mosaicking, voting) rather than averaging realisations.
+
+**Coord transform: `lat` and `lon` gain an `S` axis.**
+Each patch occupies its own coordinate sub-rectangle, so `coords["lat"]` becomes shape `[S, H_p]` and `coords["lon"]` becomes shape `[S, W_p]`.
+Patch-relative pixel offsets (`y_in_patch`, `x_in_patch`) are useful derived coords for translation-equivariant operators.
+The patch's *origin* in the parent field — `(lat0[S], lon0[S])` — is the bookkeeping you need to reassemble outputs back into a single mosaic.
+
+---
+
+### 2.11 Why this matters for the dependency game
+
+The dependency table in [Spatiotemporal operators §3](spatiotemporal_operators.md) treats `S` as the iid-samples axis, in the spirit of the sklearn contract.
+That contract is exactly right for **ensemble** `S` — the members really are exchangeable.
+It is **violated** by windows and patches, because adjacent slices share data.
+
+This is the silent failure mode behind most EO-benchmark "good results that don't generalise":
+
+- Train / test split drawn at random over *overlapping patches* → optimistic test F1 by 0.05–0.10.
+- Hyperparameter selection on shuffled windows of a single river → false claims of model skill.
+- EnKF run with too few ensemble members + reused windows → underestimated forecast variance.
+
+When you reach for `S` in any operator, pause and ask: *which construction made this axis, and is the operator's reduction semantically valid for that construction?*
+The construction is upstream of every other choice in the dependency game.
+
+---
+
+## 3. Coordinates — what travels alongside the data
+
+Until now we have written `[T]` and `[X]` as bare integer-indexed axes.
+In practice every axis carries a *coordinate array* of physical units — datetimes, latitudes, longitudes, elevations, viewing angles, member IDs.
+Coordinates are not decoration; they are first-class data that operators consume.
+A GP kernel takes positions, a transformer takes positional encodings, a variogram takes spatial lags, a harmonic regression takes time-as-real, a phenology classifier takes day-of-year features.
+This section lays out the coord taxonomy and shows how it interlocks with the operator-side dependency game.
+
+---
+
+### 3.1 The four-quadrant taxonomy
+
+Coordinates split along two independent axes — *raw vs feature* and *static vs dynamic*.
+
+|              | **static** (fixed in time)             | **dynamic** (time-varying)                              |
+|--------------|----------------------------------------|---------------------------------------------------------|
+| **raw**      | DEM `(y[H], x[W])`, GHCN station lat/lon, mooring `(lat, lon)` | satellite swath `lat[T,H,W]`, drifter `(lat[S,T], lon[S,T])`, satellite ground track |
+| **feature**  | elevation, distance-to-coast, biome, slope/aspect, climate zone | solar zenith angle, viewing geometry, ground speed, advected-source position |
+
+*Raw* coords are how the data is *indexed*: they answer "where / when is this measurement?"
+*Feature* coords are how operators *consume* coords: derived quantities (elevation, day-of-year sine, solar geometry) that enter the operator as additional inputs.
+*Static* coords have shapes that do not include `T` or `S` — they broadcast across the data tensor.
+*Dynamic* coords align with `T` (and possibly `S`) — they travel with the data.
+
+The four quadrants are not exclusive; a single product usually has coords in several quadrants at once.
+A Sentinel-2 ARD scene has raw-static `(lat, lon)` (the ARD grid) and raw-dynamic per-pixel `solar_zenith[T, H, W]` (every overpass differs).
+A drifter has raw-dynamic `(lat[T], lon[T])` and feature-dynamic `(speed[T], heading[T])`.
+
+---
+
+### 3.2 Time coords — raw vs feature
+
+Operators consume time differently, so coords have to support both views simultaneously.
+
+**Raw time.**
+A `datetime64` array, or a float array of seconds-since-epoch / days-since-reference.
+This is what GP kernels (`Exp[-|t - t'| / L]`) and harmonic-regression basis matrices consume.
+
+**Feature time.**
+Cyclic encodings (sine and cosine of day-of-year, hour-of-day, day-of-week), Fourier-time features for periodic-aware models, transformer-style sinusoidal positional encodings, "time since last event" for spike / event data.
+
+```python
+def cyclic_time(
+    t: Float[Array, "T"], period: float,
+) -> Float[Array, "T 2"]:
+    phase = 2 * jnp.pi * t / period
+    return einx.rearrange(
+        "t, t -> t two", jnp.cos(phase), jnp.sin(phase),
+    )
+
+# typical pack carried alongside the data tensor:
+time_coords = {
+    "time":            t,                                  # Float[Array, "T"]
+    "doy_cyc":         cyclic_time(doy, period=365.25),    # Float[Array, "T 2"]
+    "hour_cyc":        cyclic_time(hour, period=24),       # Float[Array, "T 2"]
+    "year_progress":   year_fraction(t),                   # Float[Array, "T"]
+}
+```
+
+The same operator family changes meaning depending on which time coord it consumes.
+A per-pixel detrend with `t` as a column gives a slope-and-intercept (the fit-local / predict-local cell of the dependency game).
+A per-pixel detrend with `(doy_cos, doy_sin)` columns added gives a slope-plus-seasonal-cycle removal — the basis of the BFAST / CCDC family of change-detection algorithms.
+
+---
+
+### 3.3 Space coords — static vs dynamic
+
+This is where the taxonomy matters most for compute.
+
+**Static** — coords fixed for the lifetime of the data.
+
+```python
+positions: Float[Array, "X 2"]                      # (lat, lon) per pixel
+covariance = gp_kernel(positions, positions)        # compute ONCE — broadcast over T, S
+```
+
+Examples: a DEM grid, a fixed gauge network (GHCN, ICOADS), an ocean mooring, a single-orbit ARD product, a polar-stereographic ice grid, an unstructured but time-invariant mesh.
+Operators that consume static coords amortise the cost: KDTrees, GP kernel matrices, mesh adjacency, distance-to-coast features — all built once.
+
+**Dynamic** — coords that change with `T` (and possibly `S`).
+
+```python
+positions: Float[Array, "T X 2"]                            # swath / mesh moves with time
+covariance_t = jax.vmap(gp_kernel)(positions, positions)    # rebuild per timestep — expensive
+```
+
+Examples: an Argo float trajectory `(lat[S, T], lon[S, T])`, a surface drifter `(lat[T], lon[T])`, GPS-tagged animal tracks, satellite L2 swaths (every TROPOMI / EMIT overpass has a different lat/lon footprint), pollution sources advected by wind, deformable-mesh PDE solver coordinates.
+
+The static / dynamic distinction is *the* governing choice for the cost of any spatially-aware operator.
+A static-coord kriging interpolator is `O(N²)` once.
+A dynamic-coord kriging interpolator is `O(N²)` per timestep — and `T` is often 10⁴–10⁶.
+This is why most large-scale operational pipelines reproject dynamic-coord swath data onto a static grid first; the cost is paid in resampling rather than in every downstream operator.
+
+---
+
+### 3.4 Structured vs unstructured
+
+A second cross-cutting distinction: are the coords on a regular grid?
+
+**Structured.**
+Coords are implicit — `x = arange(W)`, `y = arange(H)` — and the data shape `[H, W]` already encodes neighborhood.
+You can use `skimage`, FFT-based filters, and convolutions without ever materialising the coord arrays.
+
+**Unstructured.**
+Coords are explicit — every node carries its own `(lat, lon, elevation, …)` — and neighborhood must be looked up via a KDTree, mesh adjacency, or graph.
+`skimage` does not apply; you need graph-based operators or mesh-aware ops.
+
+This is the bridge to §4 (geometry): structured coords are *raster*; unstructured coords are *point set / mesh / vector*.
+The static / dynamic distinction governs whether the neighborhood index can be precomputed once or must be rebuilt per timestep.
+
+---
+
+### 3.5 Real-world example matrix
+
+| Product / source            | Time coords        | Space coords          | Coord quadrant                |
+|-----------------------------|--------------------|-----------------------|-------------------------------|
+| ERA5 surface reanalysis     | hourly datetime    | regular 0.25° grid    | static, structured            |
+| Sentinel-2 ARD (cloud-opt.) | per-scene datetime | regular 10 m UTM grid | static, structured            |
+| TROPOMI L2 swath            | per-pixel datetime | irregular `lat[T,X]`  | dynamic, unstructured         |
+| EMIT L2 hyperspectral       | per-pixel datetime | irregular `lat[T,X]`  | dynamic, unstructured         |
+| Argo float profile          | per-cycle datetime | `(lat[S,T], lon[S,T])`| dynamic, point set            |
+| Surface drifter (GDP)       | per-fix datetime   | `(lat[T], lon[T])`    | dynamic, single point         |
+| GHCN-D station network      | daily datetime     | fixed `(lat, lon)`    | static, point set             |
+| SRTM 30 m DEM               | —                  | regular grid          | static, structured (no `T`)   |
+| Eddy-covariance (FLUXNET)   | half-hourly        | fixed point           | static, point                 |
+| GraphCast 0.25° forecast    | 6-hourly datetime  | regular grid          | static, structured            |
+| ICOADS marine obs.          | per-report datetime| `(lat[N], lon[N])`    | dynamic, scattered point set  |
+| Lagrangian particle ensemble| per-step datetime  | `(lat[S,T], lon[S,T])`| dynamic, point cloud per `t`  |
+
+The patterns: optical / radar / reanalysis products on regular grids are *static-structured*; satellite L2 swaths and in-situ platforms are *dynamic-unstructured*; gauge networks are *static-unstructured-point-set*; particle ensembles are the most demanding — *dynamic-unstructured-and-S-axis*.
+
+---
+
+### 3.6 How coords interact with the dependency game
+
+Walk through the four cells of the operator-side dependency game (see [Spatiotemporal operators §3](spatiotemporal_operators.md)) with the coord lens:
+
+- **Fit-global / predict-global** (EOF, climatology) — usually *coord-free* in the algorithm itself.
+  The parameter tensor is indexed in pixel-space; coords just label the output for the user.
+  EOF doesn't care whether the underlying grid is structured or not, as long as you don't permute pixels between fit and predict.
+- **Fit-global / predict-local** (KMeans, retrievals, foundation-model embeddings) — usually no spatial coord, but *time-of-year features* often enter as quantile-mapping conditioning, and *solar-geometry features* enter atmospheric-correction LUTs.
+  Static-structured products are the easy case; dynamic-unstructured swaths force per-pixel coord-aware lookup.
+- **Fit-local / predict-local** (per-pixel detrend, harmonic fit, BFAST/CCDC) — *raw time* is a column of the regression basis matrix.
+  Spatial coords are usually ignored unless you regularise across pixels.
+- **Fit-local / predict-global** (variograms, Moran's I, basin/national totals) — *raw spatial coords* are essential.
+  The operator is *built on* lags; without coords there is no operator.
+  Static coords let you precompute lag bins; dynamic coords force per-timestep recomputation.
+
+The pattern is clear: as you move from *global-global* toward *local-global*, coords become more central, and the static / dynamic distinction becomes more decisive.
+
+**Design implication for `geotoolz`.**
+An operator that consumes coords cannot be wrapped as a function of `[S, T, V, X]` alone.
+Its real signature is
+
+```python
+class Operator(eqx.Module):
+    def __call__(
+        self,
+        data:   Float[Array, "S T V H W"],
+        coords: dict[str, Array],
+    ) -> tuple[Float[Array, "..."], dict[str, Array]]:
+        ...
+```
+
+Both `data` and `coords` flow through every operator, and `Sequential` must thread both.
+Operators that *only* consume `data` can ignore the coord pack (the framework passes it through unchanged); operators that *transform* the coord pack (a reprojection, a patch construction, a rolling-window construction) must return a new pack alongside the new `data`.
+
+This is why the `S`-axis constructions in §2.8–§2.10 and the static / dynamic distinction in §3.3 belong in the same conceptual frame: they are *all coord-pack transforms*.
+A coord-aware operator framework lets you compose them; a coord-blind one (sklearn, raw skimage) reduces them to ad-hoc reshape boilerplate that you have to reinvent for every pipeline.
+
+---
+
+## 4. Geometry — how the world delivers data, how the operator demands it
+
+Coordinates are values on an axis.
+Geometry is *what topology those values describe*.
+Two arrays of `(lat, lon)` pairs of the same shape can be a regular grid, a scattered point set, the vertices of a polygon ring, or the fixes of a drifter trajectory — and the operator that consumes them must respect which one it is.
+
+This section lays out the five geometric primitives, the four operations that bridge them, and why "raster" — the special case where geometry is a regular tessellation — is the case the operator-side tutorial focuses on.
+
+---
+
+### 4.1 The geometry hierarchy
+
+Five primitives, ordered by "structure available for fast operators."
+
+| Primitive       | Dim | Examples                                               | Why it matters                            |
+|-----------------|-----|--------------------------------------------------------|-------------------------------------------|
+| **Point**       | 0   | weather station, Argo float, eddy-covariance tower, plume source, gauge, buoy | how *observations* arrive                |
+| **Line**        | 1   | ship cruise track, satellite ground track, ICESat-2 transect, river network, flight line, animal track | how *transects and trajectories* arrive |
+| **Polygon**     | 2   | agricultural field, lake, fire perimeter, protected area, urban tract | how *parcels and AOIs* are defined      |
+| **Multi-polygon** | 2 | country, watershed, EEZ, HydroSHEDS basin, climate zone (Köppen) | how the *administrative and relationship* world is encoded |
+| **Raster**      | 2 (regular)  | every satellite scene, reanalysis grid, DEM, gridded climatology | **why fast operators exist** — regular tessellation makes neighborhood lookup O(1) |
+
+```
+   point         line          polygon            multi-polygon         raster
+                                                                      
+     •          •──•          •────•             •──•   •──•         ┌─┬─┬─┬─┐
+                  \           │    │             │  │   │  │         ├─┼─┼─┼─┤
+                   •──•       │    │             •──•   •──•         ├─┼─┼─┼─┤
+                              •────•                                 ├─┼─┼─┼─┤
+                                                                      └─┴─┴─┴─┘
+```
+
+The hierarchy reads bottom-up: a *raster* IS a *polygon* (its bounding box) discretised on a regular tessellation; a *polygon* is a closed *line*; a *line* is an ordered sequence of *points*; a *point* is the atomic primitive.
+Multi-polygon is a *collection* of polygons (with optional holes), often with attributes attached (country code, watershed ID, parcel owner).
+
+The progression also tracks computational cost: each step *down* the hierarchy adds explicit topology that must be carried alongside the data; each step *up* (toward raster) buys regularity that the operator can exploit.
+
+---
+
+### 4.2 Per-primitive deep dive
+
+#### Point — how observations arrive
+
+A 0-dimensional location with a value (or a time series of values) attached.
+
+```python
+data:   Float[Array, "N V"]                 # N points, V variables per point
+coords = {"lat": Float[Array, "N"],
+          "lon": Float[Array, "N"]}
+# topology: none — points are atomic
+```
+
+**Examples.**
+GHCN-D weather stations, FLUXNET eddy-covariance towers, Argo floats (per cycle), ocean moorings, surface drifters (per fix), tide gauges, methane plume source locations from TROPOMI, lightning strikes, earthquake epicentres.
+
+**Operators.**
+KDTree-based neighborhood lookup, kriging with explicit positions, GP regression, KNN / radius-neighbours interpolation, point-pattern statistics (Ripley's K, nearest-neighbor distance distribution).
+
+**Coord plumbing.**
+Coords are explicit arrays of shape `[N]` (or `[N, T]` if dynamic).
+Adding a point means appending to *both* the data array and the coord arrays.
+
+---
+
+#### Line — how transects and trajectories arrive
+
+An ordered sequence of points, often with associated times.
+Lines are how *moving platforms* deliver data.
+
+```python
+data:    Float[Array, "T V"]                # values along the line at each fix
+coords = {"lat":  Float[Array, "T"],
+          "lon":  Float[Array, "T"],
+          "time": Float[Array, "T"]}
+topology = {"segment_ids": Int[Array, "T"]}  # which fixes belong to which segment
+```
+
+**Examples.**
+Ship cruise tracks (CTD casts along a transect), satellite ground tracks (ICESat-2 ATL06 elevation profiles), airborne flight lines (AVIRIS hyperspectral surveys), animal tracks (GPS collars), river networks (linestrings between confluences), seismic acquisition lines.
+
+**Operators.**
+Path integration (cumulative distance / elevation gain), along-track filtering, transect interpolation (kriging-along-line), graph operators on river networks (flow-routing, headwater identification), trajectory clustering.
+
+**Coord plumbing.**
+Coords are dynamic (they change along the line), but the *connectivity* (which point follows which) is also part of the topology.
+A line with no segment IDs is just a point set; the segment IDs are what make it a line.
+
+---
+
+#### Polygon — how parcels and AOIs are defined
+
+A closed region of space, defined by a ring (or rings, with holes) of vertex coordinates.
+
+```python
+vertices = Float[Array, "Nv 2"]                  # ring of (lat, lon) pairs
+topology = {
+    "exterior_start":   0,
+    "exterior_length":  Nv_ext,
+    "hole_starts":      Int[Array, "Nh"],
+    "hole_lengths":     Int[Array, "Nh"],
+}
+data:    Float[Array, "V"]                       # value(s) attached to the polygon
+```
+
+**Examples.**
+Agricultural fields (CAP / LPIS parcels), lakes (HydroLAKES), fire perimeters (MTBS, Canadian NBAC), protected areas (WDPA), urban census tracts, building footprints (Microsoft / Google open buildings).
+
+**Operators.**
+Zonal statistics (mean / sum of a raster *inside* a polygon), spatial joins (which point falls inside which polygon?), buffering (polygon ± a distance), geometric set ops (union, intersection, difference), area / perimeter computations, point-in-polygon queries.
+
+**Coord plumbing.**
+Vertices are coordinates; topology is the ring-closure metadata.
+A polygon's value lives in `[V]` (one value per polygon) or `[T, V]` (time-varying), separate from the vertex coords — *the data is on the polygon, not on its vertices*.
+
+---
+
+#### Multi-polygon — how the administrative and relationship world is encoded
+
+A collection of polygons (each possibly with holes), tied together as a single conceptual unit, often with attributes.
+
+```python
+vertices = Float[Array, "Nv 2"]                  # all vertices of all polygons
+topology = {
+    "polygon_starts":   Int[Array, "Np"],        # offset of each polygon's exterior
+    "polygon_lengths":  Int[Array, "Np"],
+    "hole_starts":      Int[Array, "Nh"],
+    "hole_lengths":     Int[Array, "Nh"],
+    "polygon_in_unit":  Int[Array, "Np"],        # which conceptual unit each polygon belongs to
+    "attribute":        Str[Array, "Nu"],        # e.g. country code, basin ID
+}
+data:    Float[Array, "Nu V"]                    # value(s) per unit (Nu units)
+```
+
+**Examples.**
+Countries (Natural Earth, GADM), watersheds (HydroSHEDS, HUC), exclusive economic zones (EEZ, Marine Regions), administrative regions (NUTS, FIPS), climate zones (Köppen-Geiger), ecoregions (WWF), oil-and-gas basins (Permian, Sahara, North Sea), drainage basins (Greenland, Antarctica ice-sheet drainage).
+
+**Operators.**
+Hierarchical zonal statistics (national → continental aggregation), spatial joins between hierarchies (which parcel is in which municipality is in which country?), contiguity-based spatial regression, multi-resolution mosaicking, jurisdiction-aware operators (national greenhouse-gas inventories, basin-aggregated water budgets).
+
+**Coord plumbing.**
+The hierarchy is encoded in the topology fields — `polygon_in_unit` says which polygon belongs to which conceptual unit (Greece's many islands all belong to "Greece").
+Attributes (`country_code`, `basin_name`) are how the multi-polygon connects to *non-spatial* data — and is what makes multi-polygons the natural geometry for the *relationship* world (every administrative join is a multi-polygon spatial join).
+
+---
+
+#### Raster — why fast operators exist
+
+A 2-D regular tessellation of a rectangular domain, defined by an affine transform plus pixel values.
+
+```python
+data:    Float[Array, "V H W"]                   # value(s) at each cell
+affine:  Float[Array, "6"]                       # (dx, 0, x0, 0, dy, y0)
+# coords are IMPLICIT:
+#   lon[w] = x0 + dx * w        for w in range(W)
+#   lat[h] = y0 + dy * h        for h in range(H)
+```
+
+**Examples.**
+Every satellite scene (Landsat, Sentinel-2, MODIS, VIIRS), every reanalysis grid (ERA5, MERRA-2, JRA-55), every DEM (SRTM, Copernicus DEM, ASTER GDEM), every gridded climatology (CHIRPS, WorldClim), every analysis-ready datacube product (ARD, Open Data Cube), every regular-grid PDE-model output (CMIP6, GraphCast).
+
+**Operators.**
+*Everything* — convolutions, FFTs, finite differences, separable filters, morphology, segmentation, U-Net, ConvLSTM, FNO, CNN classifiers, all of `skimage`, all of standard CNN-based ML.
+
+**Coord plumbing.**
+Coords are *not stored*; they are derived on demand from the six numbers of the affine transform.
+This is the critical advantage: a 10,000 × 10,000 raster carries 6 numbers of geometry; a 10,000-point unstructured cloud at the same resolution carries 20,000 numbers of geometry (lat + lon per point).
+For a `[T, V, H, W]` cube with `T = 10,000` timesteps, the saving is the difference between *six* numbers and *twenty billion* numbers of dynamic-coord storage.
+
+---
+
+### 4.3 The four operations between geometries
+
+The bridges that make heterogeneous pipelines possible.
+Every real EO / geo pipeline is a sequence of these four operations interleaved with operators.
+
+| Operation     | Direction          | Real example                                                 |
+|---------------|--------------------|--------------------------------------------------------------|
+| **Rasterise** | vector → raster    | burn watershed polygons onto a 30 m grid for zonal masking    |
+| **Vectorise** | raster → vector    | extract flood-extent polygons from a classified flood map     |
+| **Sample**    | raster → points    | query MERRA-2 temperature at every GHCN station location      |
+| **Aggregate** | raster → polygon scalar | mean NDVI per country, methane budget per oil-and-gas basin |
+
+#### Rasterise
+
+Convert a vector geometry (point / line / polygon / multi-polygon) into a raster mask, label image, or burned-value image.
+
+```python
+def rasterise(
+    vertices: Float[Array, "Nv 2"],
+    topology: dict,
+    affine:   Float[Array, "6"],
+    shape:    tuple[int, int],
+) -> Int[Array, "H W"]:
+    # production: rasterio.features.rasterize, gdal_rasterize, affine + ray casting
+    ...
+```
+
+**When you reach for it.**
+Building zonal masks (one mask per administrative unit), encoding training labels for semantic segmentation (polygon labels → pixel labels), discretising a continuous geometry for use in a PDE solver.
+
+#### Vectorise
+
+Extract vector geometries from a labelled raster — the inverse of rasterise.
+
+```python
+def vectorise(
+    labels:   Int[Array, "H W"],
+    affine:   Float[Array, "6"],
+) -> tuple[Float[Array, "Nv 2"], dict]:
+    # production: rasterio.features.shapes, OpenCV findContours, scikit-image marching_squares
+    ...
+```
+
+**When you reach for it.**
+Turning a CNN's segmentation output into polygons for parcel-level reporting, extracting flood polygons from a flood-classification raster, extracting cloud-shadow shapes from a cloud-mask raster.
+
+#### Sample
+
+Read raster values at point or line locations.
+
+```python
+def sample(
+    raster:    Float[Array, "V H W"],
+    affine:    Float[Array, "6"],
+    points:    Float[Array, "N 2"],   # query (lat, lon)
+) -> Float[Array, "N V"]:
+    # using einx.get_at on the index computed from the affine:
+    h_idx = ((points[:, 0] - affine[5]) / affine[4]).astype(int)
+    w_idx = ((points[:, 1] - affine[2]) / affine[0]).astype(int)
+    return einx.get_at("v [h w], n -> n v", raster, h_idx * raster.shape[2] + w_idx)
+```
+
+**When you reach for it.**
+Querying ERA5 at every weather-station location for ML feature extraction, sampling a DEM along a flight track, getting per-pixel solar-zenith at scattered observation points.
+
+#### Aggregate
+
+Reduce raster values inside a polygon (or per-polygon for a multi-polygon) to a scalar (or per-band vector).
+
+```python
+def aggregate(
+    raster:    Float[Array, "V H W"],
+    affine:    Float[Array, "6"],
+    masks:     Bool[Array, "Np H W"],   # one mask per polygon (from rasterise)
+    op:        str = "mean",
+) -> Float[Array, "Np V"]:
+    return einx.reduce("v [h w], np [h w] -> np v", raster, masks, op=op)
+```
+
+**When you reach for it.**
+Per-country emissions inventories (national methane / CO₂ budgets), per-basin water-storage trends from GRACE, per-municipality deforestation rates, per-watershed precipitation accumulations, parcel-level mean NDVI for crop-yield estimation.
+
+This operation is the geometric form of the *fit-local / predict-global* cell of the dependency game (see [Spatiotemporal operators §3.4](spatiotemporal_operators.md)) — it is *the* operator that turns raster heterogeneity into administrative-world deliverables.
+
+---
+
+### 4.4 Why raster makes everything fast
+
+A short callout for what regular tessellation actually buys you.
+
+- **Neighborhood lookup is O(1) integer arithmetic.**
+  No KDTree, no graph traversal — just `arr[h-1:h+2, w-1:w+2]`.
+- **Convolutions, FFTs, separable filters, multigrid** all apply directly without coordinate-aware wrapping.
+- **Coords don't need to be carried per pixel** — six numbers of affine replace `2·H·W` numbers of explicit lat/lon.
+- **The neighborhood strategies of `KNN` vs `Radius`** (the central concern of the non-raster operator literature) collapse to fixed-stencil convolution — there is one canonical neighborhood per cell.
+- **Storage and I/O are cheap** — Cloud-Optimised GeoTIFF, Zarr chunking, tile pyramids all assume regular tessellation.
+- **Ecosystem support is enormous** — `xarray`, `rasterio`, `gdal`, `rioxarray`, `xarray-spatial`, `dask-image`, every CNN library; the alternative paths (graph / mesh / point) have orders of magnitude less tooling.
+
+This is *why* production EO pipelines reproject swath, point, and polygon data onto a common raster grid as the very first step.
+The cost is the resampling / rasterisation step; the benefit is that every downstream operator becomes a cheap raster op.
+
+It is also why the companion [Spatiotemporal operators](spatiotemporal_operators.md) tutorial focuses on *raster* operators specifically — not because the others don't exist, but because the raster case is where the dependency-game framework has the cleanest shape and the operators have the cleanest cost model.
+Graph and mesh operators are a future tutorial.
+
+---
+
+### 4.5 The two failure modes
+
+The choice of *when* to convert between geometries is the single most consequential pipeline decision.
+Both directions of error are common.
+
+**Rasterise too early.**
+A 3-metre methane plume on a 10-metre grid is gone — its peak concentration and its precise location are smeared across pixels.
+A parcel boundary on a 30-metre grid is uncertain by ±15 m on every side, which is enough to misattribute crop yields between adjacent fields.
+An extreme rainfall event recorded at a single gauge, rasterised to a 1° grid, becomes a watershed-mean that no longer represents an extreme at all.
+
+This is the wrong call when *the geometry is the deliverable* — when the user wants per-parcel, per-station, or per-event answers.
+
+**Rasterise too late.**
+A pipeline that carries Argo floats as point geometry into a per-pixel GP kernel re-pays an `O(N²)` build at every step.
+A pipeline that keeps satellite swaths in their native irregular grid through every downstream operator forces every reader, every resampler, every ML stage to handle dynamic-unstructured data.
+The cumulative cost can be 10–100× the cost of an early reprojection.
+
+This is the wrong call when *geometry is the substrate* — when the user wants gridded fields for ML, or when downstream operators are universally raster-centric.
+
+The right rule of thumb is: **convert at the deliverable boundary, not before, not after**.
+If your downstream is a CNN, rasterise immediately upstream of it.
+If your downstream is a per-station report, keep points until the end.
+If your downstream is per-watershed bookkeeping, aggregate into the multi-polygon at the last possible moment.
+
+---
+
+### 4.6 Geometry × dependency game
+
+Walk the four cells of the operator-side dependency game (see [Spatiotemporal operators §3](spatiotemporal_operators.md)) through the geometric lens:
+
+| Cell                       | Natural geometry                          | Why                                                     |
+|----------------------------|-------------------------------------------|---------------------------------------------------------|
+| Fit-global / predict-global | raster (or coord-free)                    | parameter tensor is index-space; geometry is decoration |
+| Fit-global / predict-local  | raster (per pixel) or point (per station) | per-pixel retrieval is geometry-agnostic                |
+| Fit-local / predict-local   | raster (per pixel) or point (per gauge)   | each unit gets its own model                            |
+| Fit-local / predict-global  | **multi-polygon**                         | "one number per administrative region" is the natural shape — countries, basins, watersheds, EEZs |
+
+Multi-polygon is the geometry that the *fit-local / predict-global* cell was waiting for.
+National methane budgets, basin water-storage trends, ice-sheet mass balance per drainage basin, deforestation per municipality — all of these *are* fit-local-predict-global operators whose deliverable lives on a multi-polygon coverage.
+
+This cross-tabulation also explains why most real EO pipelines look the same:
+
+1. **Reproject** dynamic / unstructured input data onto a static raster grid.
+2. **Run** raster-shaped operators (CNN / FNO / per-pixel ML / climatology) with one of the four dependency-game cells.
+3. **Aggregate** results into a multi-polygon coverage to produce the deliverable (national / basin / parcel statistics).
+
+Steps 1 and 3 are geometry transforms; step 2 is the operator.
+Splitting them cleanly is what makes pipelines composable; conflating them is what makes them brittle.
+
+---
+
+### 4.7 Design implication for `geotoolz`
+
+Promotes the coord-aware operator signature from §3.6 to a *geometry-aware* one:
+
+```python
+class Operator(eqx.Module):
+    def __call__(
+        self,
+        data:     Array,
+        coords:   dict[str, Array],
+        topology: Geometry,           # Point | Line | Polygon | MultiPolygon | Raster
+    ) -> tuple[Array, dict, Geometry]:
+        ...
+```
+
+The four operations of §4.3 are exactly the operators that *change* the `topology` field:
+
+- `Rasterise: Point | Line | Polygon | MultiPolygon → Raster`
+- `Vectorise: Raster → Polygon | MultiPolygon`
+- `Sample:    Raster → Point`
+- `Aggregate: Raster + MultiPolygon → MultiPolygon-with-values`
+
+Most operators *preserve* the topology field — it flows through unchanged.
+The four bridging operations are the special class that transforms it.
+
+This is also how `Sequential` becomes a *typed* pipeline.
+An operator that produces a `Point` output can only feed an operator that consumes `Point` (or any operator that consumes "anything").
+The same algebra as scientific units in xarray — type-checked composition rather than ad-hoc reshape boilerplate.
+
+For now, [Spatiotemporal operators](spatiotemporal_operators.md) focuses on the case where the topology field is `Raster` throughout — which is most of operational EO and most of the operator-learning literature.
+Future tutorials will lift the restriction.
+
+---
+
+## 5. Closing — how this connects
+
+This tutorial covered three layers of *what arrives at an operator*:
+
+- **Shape** (§2) — the canonical tensor `[S, T, V, X]` and the build-up from univariate time series; the three constructions of the `S` axis (ensembling, windowing, patching) and what they imply about reductions.
+- **Coordinates** (§3) — the four-quadrant taxonomy (raw vs feature, static vs dynamic), the cost asymmetry of static vs dynamic, the bridge to the operator's coord-aware signature.
+- **Geometry** (§4) — the five-primitive hierarchy (point / line / polygon / multi-polygon / raster), the four bridging operations, why raster is the fast case, and the geometry-aware operator signature.
+
+Each layer adds structure that the operator can exploit — and adds constraints the operator must respect.
+Picking the right shape, coords, and geometry is upstream of every operator-side decision in [Spatiotemporal operators](spatiotemporal_operators.md).
+
+The companion tutorial assumes everything from this one as background.
+Read it next if you want to see how the dependency game (fit-scope × predict-scope), the physics of locality, and the reshape contracts (sklearn / skimage / ConvLSTM / EOF) play out on raster data.

--- a/projects/geotoolz/tutorials/spatiotemporal_data.md
+++ b/projects/geotoolz/tutorials/spatiotemporal_data.md
@@ -61,12 +61,17 @@ For most of the tutorial we write `X` as a single axis and note where structure 
 We type our arrays with [jaxtyping](https://github.com/google/jaxtyping) and name dimensions explicitly with [xarray](https://docs.xarray.dev/) so that every reshape is auditable.
 
 ```python
-from jaxtyping import Float, Array
+from typing import Sequence
+import jax
+import jax.numpy as jnp
+from jaxtyping import Float, Int, Bool, Array
 import xarray as xr
 import einx
 
 Field = Float[Array, "S T V X"]
 ```
+
+Numeric coord arrays use `jaxtyping` (`Float`, `Int`, `Bool`); string coords (variable names, country codes, basin IDs) are typed as `Sequence[str]` since `jaxtyping` does not cover string dtypes.
 
 The named-dims version, for the same physical quantity:
 
@@ -135,7 +140,7 @@ Same location, same time grid, several variables.
 arr:    Float[Array, "T V"]
 coords = {
     "time":     Float[Array, "T"],
-    "variable": Str[Array,   "V"],   # variable names (or band IDs, depths)
+    "variable": Sequence[str],       # variable names of length V (or band IDs, depths)
 }
 da:     xr.DataArray                 # dims = ("time", "variable")
 # geometry: point
@@ -202,7 +207,7 @@ The canonical "remote-sensing scene".
 ```python
 arr:    Float[Array, "V H W"]
 coords = {
-    "variable": Str[Array,   "V"],
+    "variable": Sequence[str],       # variable names of length V
     "lat":      Float[Array, "H"],
     "lon":      Float[Array, "W"],
 }
@@ -267,7 +272,7 @@ The most common datacube in modern Earth-system science.
 arr:    Float[Array, "T V H W"]
 coords = {
     "time":     Float[Array, "T"],
-    "variable": Str[Array,   "V"],
+    "variable": Sequence[str],       # variable names of length V
     "lat":      Float[Array, "H"],     # static
     "lon":      Float[Array, "W"],
 }
@@ -293,7 +298,7 @@ arr:    Float[Array, "S T V H W"]
 coords = {
     "member":   Int[Array,   "S"],     # ensemble member ID, window start, or patch position
     "time":     Float[Array, "T"],
-    "variable": Str[Array,   "V"],
+    "variable": Sequence[str],       # variable names of length V
     "lat":      Float[Array, "H"],
     "lon":      Float[Array, "W"],
 }
@@ -304,7 +309,7 @@ da:     xr.DataArray                   # dims = ("member", "time", "variable", "
 `S` is rarely a single natural data axis.
 It is almost always *manufactured* by one of three operations: **simulation**, **windowing**, or **patching**.
 Each construction creates an `S` axis with different semantics — *and reshapes the coord pack along with it*.
-The dependency-game logic in [Spatiotemporal operators §3](spatiotemporal_operators.md) hinges on which construction you used.
+The dependency-game logic in [Spatiotemporal operators §3](spatiotemporal_operators.md#operators-dependency-game) hinges on which construction you used.
 
 ---
 
@@ -429,7 +434,7 @@ The patch's *origin* in the parent field — `(lat0[S], lon0[S])` — is the boo
 
 ### 2.11 Why this matters for the dependency game
 
-The dependency table in [Spatiotemporal operators §3](spatiotemporal_operators.md) treats `S` as the iid-samples axis, in the spirit of the sklearn contract.
+The dependency table in [Spatiotemporal operators §3](spatiotemporal_operators.md#operators-dependency-game) treats `S` as the iid-samples axis, in the spirit of the sklearn contract.
 That contract is exactly right for **ensemble** `S` — the members really are exchangeable.
 It is **violated** by windows and patches, because adjacent slices share data.
 
@@ -509,6 +514,7 @@ A per-pixel detrend with `(doy_cos, doy_sin)` columns added gives a slope-plus-s
 
 ---
 
+(coords-static-dynamic)=
 ### 3.3 Space coords — static vs dynamic
 
 This is where the taxonomy matters most for compute.
@@ -577,9 +583,10 @@ The patterns: optical / radar / reanalysis products on regular grids are *static
 
 ---
 
+(coords-dependency-game)=
 ### 3.6 How coords interact with the dependency game
 
-Walk through the four cells of the operator-side dependency game (see [Spatiotemporal operators §3](spatiotemporal_operators.md)) with the coord lens:
+Walk through the four cells of the operator-side dependency game (see [Spatiotemporal operators §3](spatiotemporal_operators.md#operators-dependency-game)) with the coord lens:
 
 - **Fit-global / predict-global** (EOF, climatology) — usually *coord-free* in the algorithm itself.
   The parameter tensor is indexed in pixel-space; coords just label the output for the user.
@@ -744,7 +751,7 @@ topology = {
     "hole_starts":      Int[Array, "Nh"],
     "hole_lengths":     Int[Array, "Nh"],
     "polygon_in_unit":  Int[Array, "Np"],        # which conceptual unit each polygon belongs to
-    "attribute":        Str[Array, "Nu"],        # e.g. country code, basin ID
+    "attribute":        Sequence[str],           # length Nu, e.g. country code, basin ID
 }
 data:    Float[Array, "Nu V"]                    # value(s) per unit (Nu units)
 ```
@@ -868,7 +875,7 @@ def aggregate(
 **When you reach for it.**
 Per-country emissions inventories (national methane / CO₂ budgets), per-basin water-storage trends from GRACE, per-municipality deforestation rates, per-watershed precipitation accumulations, parcel-level mean NDVI for crop-yield estimation.
 
-This operation is the geometric form of the *fit-local / predict-global* cell of the dependency game (see [Spatiotemporal operators §3.4](spatiotemporal_operators.md)) — it is *the* operator that turns raster heterogeneity into administrative-world deliverables.
+This operation is the geometric form of the *fit-local / predict-global* cell of the dependency game (see [Spatiotemporal operators §3.4](spatiotemporal_operators.md#operators-local-global)) — it is *the* operator that turns raster heterogeneity into administrative-world deliverables.
 
 ---
 
@@ -920,7 +927,7 @@ If your downstream is per-watershed bookkeeping, aggregate into the multi-polygo
 
 ### 4.6 Geometry × dependency game
 
-Walk the four cells of the operator-side dependency game (see [Spatiotemporal operators §3](spatiotemporal_operators.md)) through the geometric lens:
+Walk the four cells of the operator-side dependency game (see [Spatiotemporal operators §3](spatiotemporal_operators.md#operators-dependency-game)) through the geometric lens:
 
 | Cell                       | Natural geometry                          | Why                                                     |
 |----------------------------|-------------------------------------------|---------------------------------------------------------|

--- a/projects/geotoolz/tutorials/spatiotemporal_operators.md
+++ b/projects/geotoolz/tutorials/spatiotemporal_operators.md
@@ -1,0 +1,841 @@
+---
+title: Spatiotemporal operators
+subject: geotoolz tutorial
+subtitle: The dependency game on raster `[samples, time, variables, space]` data
+short_title: Spatiotemporal operators
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations:
+      - UNEP
+      - IMEO
+      - MARS
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: tutorial, geotoolz, spatiotemporal, operators, raster, xarray, einx, sklearn, skimage
+---
+
+> **Status:** Draft, raster-focused.
+> **Scope:** A conceptual tutorial — pseudocode only, no executable cells.
+> **Audience:** Researchers building operators on geophysical / EO tensors and trying to decide *which axes their operator depends on.*
+> **Companion:** [Spatiotemporal data](spatiotemporal_data.md) covers the data side — shapes, coordinates, and geometry.
+> Read it first if you want the build-up of the canonical tensor `[S, T, V, X]`, the coord taxonomy (raw vs feature, static vs dynamic), or the geometry primitives (point / line / polygon / multi-polygon / raster).
+> This tutorial assumes that material as background and focuses on **raster** operators.
+> Graph and mesh operators are deferred to a future tutorial.
+
+The single hardest question when wrapping an operator for spatiotemporal data is not "what does it compute" but "what does it depend on."
+The same algorithm — say, a linear regression — becomes a *climatology*, a *bias correction*, a *detrending*, or a *kriging covariance* depending entirely on which axes you fit over and which axes you keep free.
+This tutorial walks the design space.
+
+We use a single running data shape — `[samples, time, variables, space]` — and ask the same question of every operator: *which axes does it reduce, and which axes does its parameter tensor span?*
+Answer that, and the rest follows: how to reshape, how to wrap it for sklearn / skimage / a graph operator, and whether it preserves physical locality.
+
+The framing is at heart *physical*, not algorithmic.
+Every axis of the data tensor carries a different scale (ensemble realizations, time, state variables, space), and each geophysical phenomenon couples only a subset of those scales over a characteristic range.
+ENSO couples `X` and `T` globally across the equatorial Pacific; a methane plume couples them locally over a few kilometres and a few hours; a per-pixel NDVI trend couples `T` over decades and `X` not at all.
+Picking an operator's scope is therefore picking a hypothesis about which scales the physics is stationary in — and getting it wrong does not just slow training, it produces a parameter tensor that cannot represent the phenomenon at all.
+
+---
+
+## 1. The canonical tensor `[S, T, V, X]`
+
+Almost every geophysical / EO array can be flattened into four conceptual axes.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                                             │
+│         S   ── samples       (scenes, events, batch)        │
+│         T   ── time          (timesteps within a sample)    │
+│         V   ── variables     (channels: T, p, q, R, G, NIR) │
+│         X   ── space         (pixels, points, mesh nodes)   │
+│                                                             │
+│              ┌──────────────────────────┐                   │
+│              │       arr[S, T, V, X]    │                   │
+│              └──────────────────────────┘                   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+`X` is "space" in the abstract sense — it can be:
+
+- a single flat axis of points (`N`),
+- a structured spatial grid (`H, W` or `D, H, W`),
+- an unstructured mesh (nodes + an adjacency / KDTree off-array).
+
+For most of the tutorial we write `X` as a single axis and note where structure matters.
+
+We type our arrays with [jaxtyping](https://github.com/google/jaxtyping) and name dimensions explicitly with [xarray](https://docs.xarray.dev/) so that every reshape is auditable.
+
+```python
+from jaxtyping import Float, Array
+import xarray as xr
+import einx
+
+Field = Float[Array, "S T V X"]
+```
+
+The named-dims version, for the same physical quantity:
+
+```python
+da: xr.DataArray  # dims = ("sample", "time", "variable", "space")
+```
+
+`einx.rearrange` patterns are written against these names, not positional indices, so the reshape *reads* as the intent.
+
+For the build-up of how real datasets reach this canonical shape — univariate time series, the three constructions of `S` (ensembling, windowing, patching), the coord pack that travels alongside, and the geometric primitives that underlie it all — see the data-side companion [Spatiotemporal data](spatiotemporal_data.md).
+This tutorial assumes the input is a `Raster`-topology tensor with a static `(lat, lon)` coord pack; the operator-side dependency game then has its cleanest shape.
+
+---
+
+### 1.1 What an "operator" depends on
+
+An operator has two scopes that are independent and worth naming.
+
+**Fit scope.**
+Which axes does the operator *reduce over* when estimating its parameters?
+A linear regression's slope is a number; what makes it "global" or "local" is whether that slope was computed by reducing over all pixels (global), or just one pixel's time series (local), or just one window (windowed-local).
+
+**Predict scope.**
+Which axes does the *output* span?
+A clustering model can be fit globally but predict per-pixel labels.
+EOF can be fit globally and predict either per-sample mode amplitudes or per-pixel modes — different scopes, same fit.
+
+The shape of the parameter tensor tells you both at once.
+A parameter tensor of shape `(K, V)` means *fit reduced `T`, `S`, `X`; predict ranges over whatever survives.*
+A parameter tensor of shape `(2, V, X)` (slope + intercept per pixel per variable) means *fit reduced `S, T`; predict is per-pixel.*
+
+This framing is what the rest of the tutorial uses.
+*The operator's parameter tensor shape, not its algorithm, dictates how to wrap it.*
+
+---
+
+### 1.2 Why local vs global is a physics question
+
+Geophysical processes carry *characteristic length and time scales* — `L_c` and `T_c` — that set the range over which they are coherent.
+These scales are not preferences; they are imposed by the underlying physics: the Rossby radius of deformation, gravity-wave dispersion, photochemical lifetimes, plant phenology, advective transport speeds, soil-hydraulic conductivity, and so on.
+A satellite scene is therefore not a featureless tensor.
+It is a superposition of phenomena, each one stationary over its own range of scales and nonstationary outside it.
+
+This matters because an operator's parameter tensor *is itself an assumption about stationarity*.
+A parameter tensor of shape `(K, V)` says: *the relationship I'm encoding does not vary with `S`, `T`, or `X`*.
+A parameter tensor of shape `(2, V, X)` says: *the relationship varies with `X`, but is stationary in `S` and `T`*.
+If the underlying physics is *not* stationary in the axes your operator assumed away, the operator cannot represent it — no amount of training data fixes the structural mistake.
+
+A few characteristic geophysical scales worth keeping in mind:
+
+| Phenomenon                                | `L_c` (space)         | `T_c` (time)        | Natural fit scope                |
+|-------------------------------------------|-----------------------|---------------------|----------------------------------|
+| ENSO / NAO / PDO modes                    | 1,000–10,000 km       | months–decades      | global in `X`, global in `T`     |
+| Synoptic weather systems (cyclones)       | ~1,000 km             | days                | global in `X`, local in `T`      |
+| Tropical cyclones                         | 100–1,000 km          | days                | local in `X`, local in `T`       |
+| Mesoscale ocean eddies                    | 10–100 km             | weeks               | local                            |
+| Mesoscale convective systems              | ~100 km               | hours               | local in `X`, local in `T`       |
+| Methane / CO₂ / NO₂ plumes                | 0.1–10 km             | hours               | local                            |
+| Sea-surface salinity (E−P pattern)        | 1,000s of km          | seasons             | global background + local eddies |
+| Vegetation phenology (biome scale)        | 10–1,000 km           | seasons             | local-by-biome                   |
+| Agricultural fields, plant canopies       | 10–100 m              | weeks               | local                            |
+| Soil-moisture variability                 | 10 m – 10 km          | days                | local                            |
+| Topographic illumination correction       | 30–100 m              | hours               | local                            |
+| Land-surface diurnal temperature cycle    | 100 m – 10 km         | 24 h                | local                            |
+| Barotropic tides                          | 1,000s of km          | hours               | global in `X`, sinusoidal in `T` |
+| Global mean sea-level rise                | planet-scale          | decades             | global                           |
+| Ice-sheet mass-balance trends             | 100 km – continental  | years–decades       | local-pooled to global           |
+
+Three rules of thumb fall out of this table, and they govern every later section of the tutorial:
+
+1. **An operator that aims at a phenomenon must be global along axes where the phenomenon has scales comparable to the data extent.**
+   ENSO cannot be captured by a local fit — there is no smaller subdomain that contains it.
+2. **An operator must be local along axes where the phenomenon's scale is small compared to the data extent.**
+   A methane plume detector that pools the whole scene to estimate its background has just averaged the plume into the surroundings.
+3. **When two phenomena overlap (background + perturbation, climate + weather, biome + pixel), the operator must be a *composition*: global in the scales of the background, local in the scales of the perturbation.**
+   This is why most useful EO pipelines are not single operators but `Sequential` of operators with mismatched scopes — the *composition* expresses the scale separation.
+
+This last point is also why pure machine-learning "scaling laws" can mislead in geoscience.
+More data does not help if the *scope* is wrong, because the parameter tensor is in the wrong shape to represent the phenomenon.
+Picking `(fit_scope, predict_scope)` is therefore a physical modelling choice, on the same footing as picking a closure scheme in a turbulence model — the parameter tensor's axes encode an assumption about which scales the physics is stationary in.
+
+---
+
+
+## 2. The reshape game
+
+Every ecosystem has a preferred shape and a fixed assumption about what each axis means.
+You can almost always get into that shape with one `einx.rearrange`, but the *cost* of the reshape — what locality you lose — is the part that matters.
+
+### 2.1 sklearn — `(N, F)`
+
+sklearn's iron rule: rows are iid samples, columns are features.
+There is no notion of geometry; once you flatten in, sklearn assumes everything is exchangeable.
+
+```python
+def to_sklearn(arr: Float[Array, "S T V X"]) -> Float[Array, "S F"]:
+    return einx.rearrange("s t v x -> s (t v x)", arr)
+```
+
+```
+[S, T, V, X]                         [S, F=T·V·X]
+┌──────────┐                         ┌──────────────┐
+│ ▓ ▓ ▓ ▓  │   einx.rearrange        │ ▓▓▓▓▓▓▓▓▓▓   │
+│ ▓ ▓ ▓ ▓  │   "s t v x -> s (t v x)"│ ▓▓▓▓▓▓▓▓▓▓   │
+│ ▓ ▓ ▓ ▓  │ ──────────────────────► │ ▓▓▓▓▓▓▓▓▓▓   │
+└──────────┘                         └──────────────┘
+```
+
+The cost: every spatial / temporal neighborhood is gone, and sklearn cannot recover it.
+This is fine for *exchangeable* operators (PCA, scaling, isotonic calibration) and a footgun for anything that depends on adjacency.
+
+**Geophysical reading.**
+"Sample" here means an independent realization of the geophysical process — a different scene over a different region, or a different ensemble member of a Monte Carlo simulation.
+Two adjacent Sentinel-2 tiles are *not* iid samples (they share atmosphere, illumination, and surface), and sklearn cannot tell.
+Treating them as iid is the silent assumption behind almost every "machine-learning baseline" failure on EO benchmarks: the reported test score is overoptimistic because the operator's iid assumption was violated by the very spatial autocorrelation the operator threw away in the reshape.
+
+Alternate sklearn flavor — "each pixel is a sample, each timestep is a feature" — for per-pixel temporal classifiers:
+
+```python
+def per_pixel_timeseries(arr: Float[Array, "S T V X"]) -> Float[Array, "N F"]:
+    return einx.rearrange("s t v x -> (s x) (t v)", arr)
+```
+
+This one preserves *time* as a feature axis but discards both `S`-vs-`X` distinction and spatial geometry.
+It is the standard pre-processing for **per-pixel land-cover classification from time-series stacks** (the TIMESAT / BFAST style of analysis), where each pixel's 30-year Landsat record becomes a 30-dimensional feature vector and the operator never knows two adjacent pixels exist.
+
+### 2.2 skimage — `(H, W)` or `(H, W, C)`
+
+skimage's iron rule: a single 2-D (or 2-D + channel) image.
+No time, no batch — those are *your* job to vectorise over.
+
+```python
+def to_skimage(arr: Float[Array, "S T V H W"]) -> Float[Array, "B V H W"]:
+    return einx.rearrange("s t v h w -> (s t) v h w", arr)
+```
+
+```
+[S, T, V, H, W]                      [B=S·T, V, H, W]
+                                     ┌──────┐
+   per-sample, per-time              │  H W │  per V (channel)
+   image stack                       │      │
+                                     └──────┘
+                                     repeated B times
+```
+
+The cost: time is hidden inside the batch axis and the operator cannot use it.
+This is appropriate when *each frame is processed independently* — denoising, morphology, edge detection.
+It is *wrong* for ops that need temporal context (optical flow, change detection); for those, see §2.4.
+
+**Geophysical reading.**
+The skimage shape is the natural one for **scene-level radiometric and geometric corrections** — cloud masking from a single Sentinel-2 scene, gradient-based edge detection on a single SAR backscatter image, water-body extraction from a single Landsat tile.
+These operations exploit local pixel adjacency (the `(H, W)` axes) and treat the scene as a self-contained image; bringing time in would only add noise unless you have a specific multi-temporal algorithm in mind.
+
+### 2.3 Channel-first / ConvLSTM — `(B, V, T, H, W)`
+
+PyTorch convention; time and channel both kept, geometry preserved.
+
+```python
+def to_convlstm(arr: Float[Array, "S T V H W"]) -> Float[Array, "S V T H W"]:
+    return einx.rearrange("s t v h w -> s v t h w", arr)
+```
+
+No reduction at all — just a transpose.
+This is the "lose nothing, decide later" reshape, and the default for any operator that genuinely uses all four named axes.
+
+**Geophysical reading.**
+This is the right shape for *anything that couples space and time at comparable scales* — convective-precipitation nowcasting, sea-ice-drift prediction, mesoscale-eddy tracking in altimetry, plume-evolution forecasting from hyperspectral cubes.
+The operator's parameter tensor will typically span `V` (channels), have *learnable* spatial-temporal kernels of fixed extent (the receptive field is the operator's `L_c`), and be applied as a sliding window over `(T, H, W)`.
+If your operator's receptive field is smaller than the phenomenon's `L_c`, you are under-resolving; larger, and you are bleeding across phenomena of different physical origin.
+
+### 2.4 Spatial EOF / PCA — `(N, F)` with geometry packed into features
+
+A classic in climate: each *timestep* is a sample; the spatial field is the feature vector.
+
+```python
+def to_eof(arr: Float[Array, "S T V H W"]) -> Float[Array, "N F"]:
+    return einx.rearrange("s t v h w -> (s t) (v h w)", arr)
+```
+
+Here `S·T` becomes the "iid samples" axis (which it isn't, strictly — but EOF tolerates it) and `V·H·W` becomes a feature vector whose covariance structure is precisely what we want PCA to find.
+
+**Geophysical reading.**
+This is the reshape behind every standard climate-mode analysis: EOFs of monthly SST anomalies (ENSO, PDO, AMO), EOFs of geopotential-height anomalies (NAO, AO, PNA), EOFs of soil-moisture anomalies for drought monitoring.
+The reshape *encodes* the physical hypothesis that the variability lives in a low-rank spatial pattern that recurs across many timesteps.
+If the variability is instead localised in space and stationary in time (e.g., a persistent plume), EOF will waste its leading modes representing the constant background and discover nothing.
+
+### 2.5 Cheat sheet
+
+| Target ecosystem            | Pattern                                       | What's lost                  |
+|-----------------------------|-----------------------------------------------|------------------------------|
+| sklearn (whole-sample)      | `"s t v x -> s (t v x)"`                      | all geometry, all time order |
+| sklearn (per-pixel time-series) | `"s t v x -> (s x) (t v)"`                | space ↔ sample distinction   |
+| skimage (per-frame)         | `"s t v h w -> (s t) v h w"`                  | time as a context axis       |
+| ConvLSTM                    | `"s t v h w -> s v t h w"`                    | nothing                      |
+| EOF / spatial PCA           | `"s t v h w -> (s t) (v h w)"`                | sample/time iid-ness         |
+| Per-pixel regression        | `"s t v h w -> (s h w) t v"` then per-row fit | spatial structure of fit     |
+
+The pattern is the operator's *contract* with its ecosystem.
+If two of your operators have different contracts, they cannot compose without a re-reshape between them.
+This is what motivates `geotoolz.Operator` having a single shape protocol.
+
+---
+
+## 3. The dependency game — global vs local
+
+We now answer the central question: *which axes does my operator's parameter tensor span?*
+
+Frame every operator as a pair `(fit_scope, predict_scope)`.
+Each can be *global* (reduce that axis during fit / predict) or *local* (keep that axis varying).
+That gives a 2×2.
+
+|                       | **predict global** (one summary)            | **predict local** (one output per cell)  |
+|-----------------------|---------------------------------------------|------------------------------------------|
+| **fit global**        | §3.1 EOF / climatology                      | §3.2 KMeans land cover, quantile mapping |
+| **fit local**         | §3.4 Variogram pooling, global Moran's I    | §3.3 Per-pixel detrending, harmonic fit  |
+
+The diagonal is common.
+The off-diagonals are where most of the design judgment lives.
+
+---
+
+### 3.1 Fit global, predict global — *climatology and EOF*
+
+**Real-world example: EOF analysis of SST anomalies.**
+The leading empirical orthogonal function of monthly sea-surface-temperature anomalies *is* the El Niño Southern Oscillation pattern.
+Fit reduces over all samples and time to find spatial modes; predict projects a new field onto those modes and returns a low-dimensional mode-amplitude vector.
+
+Parameter tensor: `(K, V, H, W)` — `K` spatial modes shared by every sample.
+Output of `predict`: `(S, T, K)` — one amplitude per mode per sample-time.
+Nothing varies per pixel after the fit; the operator is *global in space and time*.
+
+```python
+def fit(arr: Float[Array, "S T V H W"], k: int) -> Float[Array, "K V H W"]:
+    flat = einx.rearrange("s t v h w -> (s t) (v h w)", arr - arr.mean(("s", "t")))
+    _, _, vt = jnp.linalg.svd(flat, full_matrices=False)
+    return einx.rearrange(
+        "k (v h w) -> k v h w", vt[:k], v=arr.shape[2], h=arr.shape[3], w=arr.shape[4]
+    )
+
+def predict(
+    arr: Float[Array, "S T V H W"], modes: Float[Array, "K V H W"],
+) -> Float[Array, "S T K"]:
+    return einx.dot("s t v h w, k v h w -> s t k", arr, modes)
+```
+
+**Other instances:**
+
+- **Long-term climatology mean** over a region — the 30-year monthly mean of MERRA-2 temperature at each grid point that every anomaly product subtracts.
+- **Whole-field z-score normalisation** (`mean`, `std` are global scalars per variable) — the standard pre-processing for any climate-mode index.
+- **Regression of a global index on another global index** — NAO on Iberian winter rainfall, ENSO3.4 on East-African short rains, AMO on Sahelian decadal drought.
+- **Spherical-harmonic decomposition** of geopotential or gravity (GRACE), where the parameter tensor is the harmonic coefficients shared across all timesteps.
+- **Global tide-model fits** (TPXO, FES) — a single set of harmonic constants fit globally, applied to predict tidal height at any `(lat, lon, t)`.
+
+**Physical reasoning.**
+This cell is the natural home for any phenomenon whose `L_c` and `T_c` are *comparable to the data extent*.
+ENSO has spatial extent of roughly half the Pacific basin and a recurrence time of 2–7 years; there is no smaller subdomain that contains it, and there is no shorter temporal window that resolves it.
+A regional fit would never see the mode — it would estimate its leading EOF as a local SST gradient and miss the planetary teleconnection entirely.
+The same logic applies to NAO, the seasonal cycle of total-column water vapour, the global mean energy budget, or anything whose spatial scale is the domain itself.
+
+The *parameter tensor* (`K` shared spatial modes) is in some sense the *physics* of these phenomena: the leading modes of climate variability are the slow manifold of the coupled atmosphere-ocean system, and the fact that they are recoverable as a low-rank decomposition reflects an underlying separation of timescales.
+When you reach for this cell, you are asserting that the phenomenon is *spatially stationary in pattern, temporally stationary in statistics*, and that a single parameter tensor is enough to encode it.
+
+```
+fit:          [S, T, V, H, W] ──reduce S,T──► params[K, V, H, W]
+predict:      [S, T, V, H, W] ──project────► out[S, T, K]
+                                  ↑
+                          params are shared
+                          across every (s, t) and every pixel
+```
+
+---
+
+### 3.2 Fit global, predict local — *KMeans land cover, quantile mapping*
+
+**Real-world example: KMeans land-cover clustering from a multi-temporal Sentinel-2 cube.**
+Fit pools every pixel from every scene into one giant bag of `V`-dimensional points and learns `K` cluster centers.
+Predict assigns each pixel of a new scene to its nearest center, producing a label *per pixel*.
+
+Parameter tensor: `(K, V)` — `K` centers in variable-space.
+Output of `predict`: `(S, T, H, W)` — one label per pixel.
+The fit is global; the predict is local-in-space because each pixel is scored independently against the *same* centers.
+
+```python
+def fit(arr: Float[Array, "S T V H W"], k: int) -> Float[Array, "K V"]:
+    pixels = einx.rearrange("s t v h w -> (s t h w) v", arr)
+    return kmeans(pixels, k=k).centers  # (K, V)
+
+def predict(
+    arr: Float[Array, "S T V H W"], centers: Float[Array, "K V"],
+) -> Int[Array, "S T H W"]:
+    d2 = einx.reduce(
+        "s t v h w, k v -> s t k h w", arr, centers,
+        op=lambda a, c: (a - c) ** 2, reduce="sum", axis="v",
+    )
+    return einx.argmin("s t [k] h w", d2)
+```
+
+**Other instances:**
+
+- **Quantile-mapping bias correction** for climate model output: empirical CDFs fit on all historical (model, obs) pairs, applied per pixel × per day to correct CMIP projections before regional impact analysis.
+- **Random-forest pixel classifier** trained once on the full archive, then scored per-pixel on new scenes — the workhorse of the ESA WorldCover and Dynamic World land-cover products.
+- **Pretrained foundation-model embeddings** (Prithvi, SatMAE, Clay, AnySat) — weights frozen and global, output is a per-patch latent that downstream pipelines consume.
+- **Global radiance-to-reflectance regression** trained on the full collocation set, applied at each pixel — the structure of every atmospheric-correction algorithm (6S, Py6S, LUT-based ACOLITE).
+- **Look-up-table retrievals**: trace-gas retrievals (CH₄, NO₂, CO₂) where the LUT is built once from radiative-transfer simulations across the global parameter space, then queried per-pixel against the observed radiance.
+- **SMAP / SMOS soil-moisture retrieval**: a single forward model (τ-ω, single-channel algorithm) fit to validation data globally, applied to each L-band brightness-temperature pixel.
+
+**Physical reasoning.**
+This cell is the right home for any phenomenon where the *physical law connecting the variables is universal*, but its *spatial expression is per-pixel*.
+A forest is a forest in the Amazon, in Borneo, and in the Congo, and its reflectance in `V`-space (R, G, NIR, SWIR) is approximately the same — the cluster centers are a property of *land cover as a category*, not of any particular scene.
+But the *spatial arrangement* of categories is per-scene, set by historical land use, soil, topography, and management.
+Pairing a global parameter tensor with a local predict is exactly the right algebra: the parameter tensor encodes the universal physics, the per-pixel application encodes the local realisation.
+
+The same structure underwrites *every retrieval* in remote sensing.
+Atmospheric correction, methane plume detection, snow-cover mapping, sea-surface salinity from SMOS — they all rest on a forward model that is approximately stationary in `(X, T)` and a per-pixel inversion.
+When the assumption breaks (an aerosol regime not seen in training, a novel cloud type for the cloud mask, a previously unobserved cover type), the global parameter tensor cannot adapt and the retrieval silently fails at those pixels — the typical failure mode is bias, not noise, because the operator's prior is wrong rather than uncertain.
+
+```
+fit:          [S, T, V, H, W] ──reduce S,T,H,W──► params[K, V]
+predict:      [S, T, V, H, W] ──per-pixel score─► out[S, T, H, W]
+                                  ↑
+                          one set of params,
+                          scored independently at every pixel
+```
+
+---
+
+### 3.3 Fit local, predict local — *per-pixel detrending*
+
+The most common cell in EO time-series analysis.
+Each pixel gets its own parameter set, derived from its own history.
+
+**Real-world example: per-pixel temporal detrending of NDVI.**
+For every pixel, fit a slope-and-intercept across time; subtract the linear trend.
+You end up with a slope map (often the deliverable on its own — "where is greening happening?") and a residual cube (the deliverable as an operator).
+
+Parameter tensor: `(2, V, H, W)` — slope + intercept per pixel per variable.
+Output of `predict`: `(S, T, V, H, W)` — detrended cube.
+Both fit and predict are local in space; the operator is *embarrassingly parallel over `(H, W)`*.
+
+```python
+def fit(arr: Float[Array, "S T V H W"]) -> Float[Array, "2 V H W"]:
+    t = jnp.arange(arr.shape[1], dtype=arr.dtype)
+    X = jnp.stack([jnp.ones_like(t), t], axis=1)            # (T, 2)
+    pinv = jnp.linalg.pinv(X)                               # (2, T)
+
+    y = einx.rearrange("s t v h w -> t (s v h w)", arr)
+    coef = pinv @ y                                          # (2, S·V·H·W)
+    coef = einx.rearrange(
+        "two (s v h w) -> two s v h w", coef,
+        s=arr.shape[0], v=arr.shape[2], h=arr.shape[3], w=arr.shape[4],
+    )
+    return coef.mean(axis=1)                                 # average over S → (2, V, H, W)
+
+def predict(
+    arr: Float[Array, "S T V H W"], coef: Float[Array, "2 V H W"],
+) -> Float[Array, "S T V H W"]:
+    t = jnp.arange(arr.shape[1], dtype=arr.dtype)
+    trend = einx.dot("t, v h w -> t v h w", t, coef[1]) + coef[0][None]  # (T, V, H, W)
+    return arr - trend[None]
+```
+
+**Other instances:**
+
+- **Per-pixel STL decomposition** of sea-ice extent, NDVI, or surface temperature, exposing trend, seasonality, and remainder per cell.
+- **Per-pixel harmonic / Fourier fit** — annual + semi-annual cycle, leaves a residual that highlights anomalies (the basis of CCDC continuous change detection).
+- **Local linear regression / LOESS** for surface fitting — DEM smoothing, sea-surface-height detrending against geoid.
+- **KNN regression** where every query point has its own neighbor set — gap-filling missing pixels in MODIS LST stacks.
+- **Per-station rainfall-IDF fitting** in hydrology — every gauge gets its own extreme-value distribution because rainfall extremes depend on local orography and proximity to moisture sources.
+- **Per-pixel diurnal cycle fitting** in geostationary LST (MSG, ABI) — every pixel's daytime peak amplitude depends on its surface thermal inertia, which varies on the field scale.
+- **Per-pixel snow phenology** (start-of-season, melt-out date) from MODIS or VIIRS — strongly modulated by aspect and elevation, varies on hectometre scales.
+- **Per-station / per-buoy bias calibration** for in-situ networks (Argo, GTS) — each instrument has its own systematic offsets.
+
+**Physical reasoning.**
+This cell is forced on you whenever the *parameters themselves vary on a scale comparable to the pixel grid*.
+NDVI's seasonal cycle phase and amplitude depend on biome, latitude, hydroclimate, and management; the cycle of a tropical-evergreen pixel is near-flat, while a boreal-deciduous pixel has a sharp summer peak with an envelope set by snow-cover dates.
+A *global* trend fit would mix these regimes and produce a "mean" that mostly tracks biome composition rather than greening — the right scope for the question "is this pixel getting greener" is per-pixel because the *baseline* is per-pixel.
+
+A second physical motivation is *measurement-instrument heterogeneity*.
+Two adjacent gauges in an IDF network may sit in radically different precipitation regimes (windward vs leeward of a ridge), and pooling them would bias the extreme-value parameters toward the milder regime.
+Per-station fitting is not a methodological convenience — it is the only way to respect the actual spatial nonstationarity of the rainfall process.
+
+The risk on the other side is *sample starvation*: per-pixel fits with too few timesteps are noisy.
+Real systems often add a regularisation term that couples nearby pixels (a spatial prior, a Markov-random-field smoother, a hierarchical pooling of slopes toward a regional mean) — at which point the operator slides from "purely local" toward "windowed-local" or even "hierarchical local + global pooling" (§3.4).
+The boundary between §3.3 and §3.4 is gradual, not sharp, and the right choice depends on the ratio of `T` (samples per pixel) to the parameter count.
+
+```
+fit:          [S, T, V, H, W] ──reduce S,T,─────► params[2, V, H, W]
+                                  (per pixel)
+predict:      [S, T, V, H, W] ─per-pixel subtract► out[S, T, V, H, W]
+                                  ↑
+                          parameter tensor varies per pixel —
+                          same shape grain as the input
+```
+
+---
+
+### 3.4 Fit local, predict global — *variogram pooling, global Moran's I*
+
+The rare cell, and the one that most operator wrappers get wrong (they often refuse to express it).
+The fits are local — each one uses a small window or neighborhood — but the *deliverable* is a single global object.
+
+**Real-world example: empirical variogram pooling for kriging.**
+For each spatial window, compute the empirical variogram (variance as a function of lag).
+Average the per-window variograms into one pooled variogram and fit a single covariance model (`nugget`, `sill`, `range`).
+That single model is then used everywhere for kriging interpolation.
+
+Parameter tensor: `(3,)` — `(nugget, sill, range)`.
+The *intermediate* parameter tensor (per-window variograms) has shape `(N_windows, L)`, but it is *pooled* before becoming the operator's parameters.
+
+```python
+def fit(
+    arr: Float[Array, "S T V H W"], patch: int, n_lags: int,
+) -> Float[Array, "3"]:
+    patches = einx.rearrange(
+        "s t v (nh ph) (nw pw) -> (s t v nh nw) ph pw",
+        arr, ph=patch, pw=patch,
+    )
+    local = jax.vmap(empirical_variogram, in_axes=(0, None))(patches, n_lags)   # (N, L)
+    pooled = local.mean(axis=0)                                                  # (L,)
+    return fit_spherical(pooled)                                                 # (3,)
+```
+
+`predict` here is *kriging* using that single covariance — the operator's "global" output is the covariance object itself; downstream interpolation is a separate operator (and lives in §3.2 — fit global, predict local).
+
+**Other instances of fit-local / predict-global:**
+
+- **Global Moran's I** from local-Moran statistics — measure per-pixel spatial autocorrelation, aggregate to a single global index + significance test for whether spatial clustering is present at all.
+- **"Fraction of land showing significant greening"** — per-pixel Mann-Kendall trend tests, aggregated to one scalar deliverable for an IPCC-style report or national greenhouse-gas inventory.
+- **Hierarchical / multilevel temperature-trend models** — fit per-station slopes, pool to a single population-level slope estimate via partial pooling (the Berkeley Earth, HadCRUT, GISTEMP families all do a version of this).
+- **Stacked regional emulators** — train per-region surrogates of a numerical model, fit a single meta-weighting via out-of-sample errors to make a global ensemble emulator.
+- **Spatial-scan hotspot detection** for epidemiology / pollution — per-window likelihood-ratio statistics, aggregated to a global "is there clustering" p-value (Kulldorff scan).
+- **National / basin-scale methane budgets** — per-plume emission estimates from TROPOMI or EMIT scenes, aggregated to one annual flux per country or per oil-and-gas basin (Permian, Sahara, North Sea).
+- **Ice-sheet mass balance** — per-tile altimetry trends (ICESat-2, CryoSat-2) aggregated to a single dM/dt for Greenland or Antarctica, which then drives a single sea-level-rise contribution.
+- **GRACE basin water-storage anomalies** — per-mascon trends pooled into a basin-aggregated groundwater-depletion estimate.
+- **Permafrost active-layer-thickness sensitivity** — per-borehole thaw-depth trends, pooled to one circumpolar carbon-release rate.
+
+```
+fit:          [S, T, V, H, W] ──windowed reduce──► local_params[N_windows, L]
+                                                   │
+                                          pool / aggregate
+                                                   ▼
+                                              params[L_global]
+predict:      anything ──single global object───► out[…]
+                                  ↑
+                          parameter tensor is small;
+                          the fit work was local but the deliverable is one thing
+```
+
+**Physical reasoning.**
+This cell exists because *the world is spatially nonstationary but the deliverable is one number*.
+Soil and topography differ across a continent — the variogram of a rugged catchment is not the variogram of a flat agricultural region — but a kriging interpolator needs a *single* covariance function, and a national emissions inventory needs *one* annual flux.
+A purely global fit would be biased toward the dominant subregion (the biggest basin, the largest land class), under-representing everything else.
+A purely local fit gives you a *map* of locally-fitted parameters, but it does not collapse that map to the scalar your stakeholder asked for.
+
+Pooling local fits into a global one is a *robust-statistics trick* with a clean physical interpretation: each window contributes information about short-range variability, the pooling averages out region-specific quirks, and the deliverable inherits the robustness of the mean.
+This is how the climate-science community produces IPCC headline numbers ("warming since 1850 of 1.1 K"), how the methane community converts per-plume detections into national flux estimates, and how mass-balance studies turn per-pixel altimetry into a contribution to sea-level rise.
+
+The conceptual difference from §3.1 ("fit global, predict global") is *what stationarity you assume*.
+§3.1 assumes the parameter tensor itself is the right shape for the phenomenon and that pooling can happen at the data level.
+§3.4 assumes the data is too heterogeneous to pool directly, but the *summary statistic* of locally-fit parameters is still meaningful at the global scale.
+The first is the right call when the physics has a low-rank global pattern (ENSO); the second is the right call when the physics is heterogeneous but the bookkeeping target is global (the national methane budget).
+
+---
+
+### 3.5 The axis-triage decision
+
+You can derive the right cell mechanically:
+
+1. **List the axes** of your input tensor (here `S, T, V, X`).
+2. **Mark each axis** with one of:
+   - **F** — reduced during fit (operator is global in this axis),
+   - **K** — kept during fit (operator's parameters span this axis),
+   - **P** — reduced during predict (operator collapses this axis at inference),
+   - **B** — broadcast / passed through during predict.
+3. The marking of `(F vs K)` tells you the fit cell; `(P vs B)` tells you the predict cell.
+
+Worked examples from above:
+
+| Operator                          | S    | T    | V    | X    | Cell                          |
+|-----------------------------------|------|------|------|------|-------------------------------|
+| Spatial EOF                       | F, P | F, P | K, B | K, P | global / global (modes)       |
+| KMeans land cover                 | F, B | F, B | K, P | F, B | global / local                |
+| Per-pixel detrend                 | F, B | F, B | K, B | K, B | local-in-X / local-in-X       |
+| Variogram pooling                 | F, — | F, — | F, — | K-windowed → F | local / global      |
+
+If two operators in a pipeline don't agree on what's `K` and what's `F`, they don't compose without a `Reduce` or `Broadcast` operator between them.
+This is how `geotoolz.Sequential` and the upcoming `Reduce` / `Broadcast` markers fall out of the design naturally.
+
+---
+
+## 4. Appendix — beyond rasters: locality is geometric, not logistical (KNN vs radius)
+
+> **Status: preview of future non-raster tutorial.**
+> The rest of this tutorial assumes raster input, where neighborhoods are fixed stencils and the question of "what is a neighbor?" is decided by the grid.
+> This appendix previews how the same dependency-game framework extends to non-raster geometries (point sets, meshes, graphs), where the operator must *define* its neighborhood explicitly.
+> The full treatment of graph and mesh operators belongs to a later tutorial; this section is here because the design implication for `geotoolz`'s `Operator` signature is already worth flagging.
+
+The hardest part of the dependency game on non-raster data is that *"local"* is not a single concept.
+Two operators can both claim to be local in `X` and yet have entirely different physical receptive fields, because they disagree on *how to define a neighborhood*.
+The two canonical definitions are **K-nearest-neighbors** (count-bounded) and **radius neighbors** (distance-bounded), and choosing between them is a *physical* statement about the phenomenon you are modelling — not a logistical convenience.
+
+On a raster, both strategies collapse to the same fixed-stencil convolution — the regular tessellation makes the neighborhood unambiguous.
+The choice only becomes interesting once you leave the raster, which is what this appendix is about.
+
+This section walks through the distinction, shows why it matters under resampling, and lays out the pseudocode of an operator parametrised by a `Neighborhood` strategy.
+
+---
+
+### 4.1 The two strategies
+
+**K-nearest-neighbors (`KNN`).**
+For each query point, find the `k` reference points whose distances are smallest.
+Receptive field has *variable spatial extent* — small in dense regions, large in sparse ones.
+Number of neighbors is fixed.
+
+**Radius neighbors (`Radius`).**
+For each query point, find all reference points within distance `r`.
+Receptive field has *fixed spatial extent* — exactly `r` everywhere.
+Number of neighbors is variable (zero in sparse regions, many in dense ones).
+
+```
+   point cloud (uniform)               point cloud (clustered)
+
+                                                  •••
+   •   •   •   •   •                            ••• •••
+                                                  •••
+   •   •  ★   •   •                              •★•   •     •
+                                                  •••
+   •   •   •   •   •                            ••• •••
+                                                  •••
+
+   KNN(k=4):                            KNN(k=4):
+   ┌───┐                                  ┌─┐
+   │ ★ │  receptive field                 │★│  receptive field
+   └───┘  matches grid                    └─┘  collapses in cluster
+
+   Radius(r=R):                         Radius(r=R):
+   ┌───┐                                ┌───┐
+   │ ★ │  same R                        │ ★ │  same R
+   └───┘                                └───┘
+```
+
+Both strategies satisfy "the operator uses local information."
+But they answer different questions:
+
+- **KNN** asks *"who are my `k` most similar (closest) neighbors?"* — density-adaptive.
+- **Radius** asks *"who is physically within distance `r` of me?"* — geometry-faithful.
+
+---
+
+### 4.2 The mesh-invariance test
+
+The cleanest way to see which strategy preserves physical locality is to *resample the same field at two densities* and ask whether the operator's effective receptive field stays the same.
+
+Consider a methane plume sampled from a hyperspectral cube.
+The plume has a physical extent `L_c ≈ 1 km`.
+You build a smoothing operator that averages over each pixel's neighborhood.
+
+- At native 30 m resolution, `KNN(k=8)` covers ≈ 240 m — smaller than the plume — and smooths within the plume.
+- At resampled 5 m resolution (e.g., after super-resolution), `KNN(k=8)` covers ≈ 40 m — now the operator smooths over a region inside the plume that is structurally meaningful, *but the receptive field has shrunk*.
+
+The plume hasn't changed.
+The physics hasn't changed.
+Your operator's effective receptive field changed *because the data density changed*.
+This is the silent failure mode of KNN-based operators in EO pipelines: they appear to work on one resolution, then fail validation on another, with no warning that the issue is geometric.
+
+Radius-based operators do not suffer this failure mode.
+A `Radius(r=200 m)` operator covers 200 m of physical space at every resolution; the *number* of pixels it averages changes, but the spatial scale of the smoothing does not.
+
+```
+   data density × 1                     data density × 4
+
+   • • • • •                            •••••••••••••••
+   • • ★ • •     KNN(k=8) ≈ 2Δ          •••••••••••••••
+   • • • • •                            •••••••★•••••••
+                                        •••••••••••••••
+                                        •••••••••••••••
+
+                                        KNN(k=8) ≈ Δ/2  ←── shrunk!
+
+
+   Radius(r=R)                          Radius(r=R)
+       ┌─┐                                  ┌─┐
+       │★│   R fixed                        │★│   R fixed
+       └─┘                                  └─┘
+```
+
+This is the same lesson the operator-learning community learnt the hard way moving from grid-based CNNs to mesh-free graph neural operators.
+A vanilla GNN with `KNN` edges is *not* mesh-invariant; remesh the same physics with different node density, and the network's effective stencil changes.
+The fix — adopted by Graph Neural Operators (GNO), Mesh GraphNets, and the Equivariant-style PDE solvers — is to use radius graphs, so that the operator's receptive field is determined by the *physics* (the correlation length of the PDE solution) rather than by the *grid* (where you happened to sample).
+
+---
+
+### 4.3 Pseudocode — a `Neighborhood` strategy and an operator built on it
+
+We make the neighborhood definition an explicit, swappable object — not a flag, not a string, not an `if/else`.
+The operator consumes the neighborhood; the *choice* of `KNN` vs `Radius` is a physical statement made at construction time.
+
+```python
+import equinox as eqx
+from jaxtyping import Float, Int, Array
+
+# ----- strategies -----
+
+class Neighborhood(eqx.Module):
+    """Strategy interface: maps a query set to a neighbor index."""
+
+    def find(
+        self,
+        query: Float[Array, "Q D"],
+        ref:   Float[Array, "N D"],
+    ) -> Int[Array, "Q K"]:
+        raise NotImplementedError
+
+
+class KNN(Neighborhood):
+    k: int
+
+    def find(self, query, ref):
+        # pairwise distance — illustrative; production code uses a KDTree
+        d = einx.dot("q d, n d -> q n",
+                     query - query.mean(0),   # placeholder centring
+                     ref   - ref.mean(0))
+        d = einx.reduce("q [d], n [d] -> q n",
+                        query[:, None] - ref[None], op="sqsum")
+        return einx.argmin("q [n] -> q k", d, k=self.k)
+
+
+class Radius(Neighborhood):
+    r: float
+    k_max: int   # we still return a fixed-shape index for jit; pad with -1
+
+    def find(self, query, ref):
+        d2 = einx.reduce("q [d], n [d] -> q n",
+                         query[:, None] - ref[None], op="sqsum")
+        within = d2 < self.r ** 2                                  # (Q, N) bool
+        # top-k_max within-radius hits, ties broken by distance:
+        masked = jnp.where(within, d2, jnp.inf)
+        return einx.argmin("q [n] -> q k", masked, k=self.k_max)
+        # entries with d2 == inf are sentinels — downstream code masks them
+```
+
+Now an operator that *consumes* a neighborhood — say, a local-mean smoother — written in the coord-aware `(data, coords) → (data, coords)` signature from [Spatiotemporal data §3.6](spatiotemporal_data.md):
+
+```python
+class LocalMean(eqx.Module):
+    neighborhood: Neighborhood
+
+    def __call__(
+        self,
+        data:   Float[Array, "N V"],
+        coords: dict[str, Array],          # must contain "lat", "lon" (or generic "pos")
+    ) -> tuple[Float[Array, "N V"], dict[str, Array]]:
+        positions = einx.rearrange(
+            "n, n -> n two", coords["lat"], coords["lon"],
+        )                                                            # (N, 2)
+        idx = self.neighborhood.find(positions, positions)           # (N, K)
+        neighbors = einx.get_at("[n] v, q k -> q k v", data, idx)    # (N, K, V)
+        smoothed  = einx.mean("n [k] v", neighbors)
+        return smoothed, coords          # coords pass through unchanged
+```
+
+The operator *demands* coords in its signature — there is no version of `LocalMean` that doesn't.
+The two strategies are then a one-line configuration choice:
+
+```python
+density_adaptive = LocalMean(neighborhood=KNN(k=16))
+mesh_invariant   = LocalMean(neighborhood=Radius(r=200.0, k_max=64))
+```
+
+Two operators, same algorithm, different *physical* contracts.
+The first is appropriate for problems where similarity-in-feature-space is the locality (anomaly detection in `V`-space, manifold-based gap-filling).
+The second is appropriate for problems where the geometry sets the scale (PDE solvers, plume smoothing, kriging, spatially-stationary GP priors).
+
+**Static vs dynamic coords** (the [Spatiotemporal data §3.3](spatiotemporal_data.md) distinction) maps cleanly onto neighborhood reuse:
+
+```python
+# Static coords — KDTree / radius index built ONCE, reused across all timesteps
+static_op = LocalMean(neighborhood=Radius(r=200.0, k_max=64))
+neighborhood_idx = static_op.neighborhood.find(positions_static, positions_static)
+# … apply per timestep with the precomputed idx
+
+# Dynamic coords — KDTree / radius index rebuilt per timestep
+def step(data_t, coords_t):
+    return LocalMean(neighborhood=Radius(r=200.0, k_max=64))(data_t, coords_t)
+
+result = jax.vmap(step)(data, coords_per_t)
+```
+
+The structural cost difference (one build vs `T` builds) is exactly the asymmetry [Spatiotemporal data §3.3](spatiotemporal_data.md) flagged: static coords amortise neighborhood construction, dynamic coords cannot.
+Operators that consume `Neighborhood` strategies should be written so the index is *cacheable* on static-coord tensors — otherwise dynamic-coord workloads silently inflate cost by a factor of `T`.
+
+---
+
+### 4.4 Which to pick — a physical decision rule
+
+The choice is dictated by *what your operator is approximating*.
+
+**Use radius when the operator is a discretisation of a continuous physical kernel.**
+Convolution against a Gaussian, Green's function for a PDE, kriging covariance, atmospheric-transport response, point-spread-function deconvolution.
+These kernels have a *fixed length scale* — they live in the metric of the underlying space, not in the metric of your sampling.
+Examples: GraphCast and similar weather-model emulators use radius graphs because the dynamics are local in physical space; mesh-free PDE solvers like Smoothed Particle Hydrodynamics use kernel functions with fixed support radius for the same reason.
+
+**Use KNN when the operator is a smoother in feature space, or when sampling density is intentionally uniform.**
+The classic case is anomaly detection in `V`-space (k-NN density estimation), or gap-filling on a regular grid where `KNN(k=4)` and `Radius(r=Δx)` are interchangeable.
+Examples: cosine-similarity retrieval over satellite embeddings; collaborative-filtering-style spatial gap-fill on a regular Landsat grid; nearest-neighbour resampling in image warping.
+
+**A useful tie-breaker.**
+If you can write down the operator's correlation length scale in *physical units* (km, days), use `Radius`.
+If you can only write it down in *count units* (k = 16), you are implicitly assuming the sampling density is meaningful — fine on a regular grid, dangerous everywhere else.
+
+---
+
+### 4.5 Geophysical examples where the choice matters
+
+- **Methane plume detection in TROPOMI / EMIT scenes.**
+  Plume extent is ~ 1–10 km, set by wind speed and source strength.
+  A KNN-based smoother trained on a 7 km TROPOMI grid will silently change behaviour when applied to a 30 m EMIT scene; a radius-based smoother does not.
+- **Ocean drifter / Argo float interpolation.**
+  Sampling density varies by factor of 10× across the ocean.
+  Radius-based interpolation respects the eddy length scale; KNN-based interpolation produces tight stencils in the data-rich tropics and balloons in the Southern Ocean, biasing the resulting maps.
+- **Mesh-free PDE surrogates (DeepONet, FNO-Graph, GNO).**
+  Radius graphs make the operator mesh-invariant; KNN graphs make it mesh-dependent and break under refinement.
+- **Soil-moisture downscaling.**
+  Sensor footprints are 1–40 km but topographic / vegetation drivers vary at 10–100 m.
+  The correct local kernel for downscaling has a physical scale (soil-correlation length); use `Radius`.
+- **Aftershock-rate estimation in seismology.**
+  Each main shock has an Omori-law decay in time and a fault-extent in space; aggregating aftershocks by KNN biases toward dense seismic networks (urban) and away from sparse ones (offshore); aggregating by radius is geophysically correct.
+- **EnKF / EnSRF localisation.**
+  Ensemble Kalman filters localise covariance with a *physical* localisation radius (Gaspari-Cohn, typically a few hundred km in the atmosphere).
+  Using KNN here would silently amplify ensemble-size sensitivity.
+
+---
+
+### 4.6 How this plugs back into the dependency game
+
+`KNN` and `Radius` do not change the §3 cell — they parametrise *what "local" means inside it*.
+
+- A per-pixel local regression (§3.3) can use either strategy to define the neighborhood whose data fits the per-pixel model.
+- A windowed variogram (§3.4) uses `Radius` implicitly — the window is a fixed spatial extent.
+- A KMeans clustering (§3.2) uses *neither* — its locality is in `V`-space, with no spatial structure at all.
+- An EOF (§3.1) is *not local in `X`* by construction; the neighborhood is the whole field.
+
+So the picture is two-dimensional: §3 chooses *which axes* are local; §4 chooses *what locality means* on those axes.
+A robust operator wrapper carries both: a scope marker per axis, and (where applicable) a `Neighborhood` strategy for the local axes.
+
+---
+
+## 5. A worked operator — four scopes, one algorithm
+
+> **Stub.**
+> Carry one algorithm — *anomaly detection on temperature* — through all four cells:
+>
+> 1. **Global / global**: climatology subtraction; the "anomaly" is the residual.
+> 2. **Global / local**: quantile-mapped exceedance against a global CDF.
+> 3. **Local / local**: per-pixel z-score against the pixel's own historical mean and std.
+> 4. **Local / global**: per-window heatwave statistics aggregated to a regional indicator.
+>
+> Each gets pseudocode + a side-by-side parameter-tensor shape diagram, so the reader sees the same algorithm assuming four different scope contracts.
+
+---
+
+## 6. Cheat sheet
+
+> **Stub.**
+> One-page reference: axis-triage table, the `einx.rearrange` patterns from §2, the four cells of §3, and a "footguns" callout (sklearn flatten kills geometry, KNN-as-locality, mixing fit/predict scopes in `Sequential`).

--- a/projects/geotoolz/tutorials/spatiotemporal_operators.md
+++ b/projects/geotoolz/tutorials/spatiotemporal_operators.md
@@ -67,7 +67,9 @@ For most of the tutorial we write `X` as a single axis and note where structure 
 We type our arrays with [jaxtyping](https://github.com/google/jaxtyping) and name dimensions explicitly with [xarray](https://docs.xarray.dev/) so that every reshape is auditable.
 
 ```python
-from jaxtyping import Float, Array
+import jax
+import jax.numpy as jnp
+from jaxtyping import Float, Int, Bool, Array
 import xarray as xr
 import einx
 
@@ -276,6 +278,7 @@ This is what motivates `geotoolz.Operator` having a single shape protocol.
 
 ---
 
+(operators-dependency-game)=
 ## 3. The dependency game — global vs local
 
 We now answer the central question: *which axes does my operator's parameter tensor span?*
@@ -306,7 +309,8 @@ Nothing varies per pixel after the fit; the operator is *global in space and tim
 
 ```python
 def fit(arr: Float[Array, "S T V H W"], k: int) -> Float[Array, "K V H W"]:
-    flat = einx.rearrange("s t v h w -> (s t) (v h w)", arr - arr.mean(("s", "t")))
+    anomaly = arr - arr.mean(axis=(0, 1), keepdims=True)         # remove mean over S, T
+    flat = einx.rearrange("s t v h w -> (s t) (v h w)", anomaly)
     _, _, vt = jnp.linalg.svd(flat, full_matrices=False)
     return einx.rearrange(
         "k (v h w) -> k v h w", vt[:k], v=arr.shape[2], h=arr.shape[3], w=arr.shape[4]
@@ -469,6 +473,7 @@ predict:      [S, T, V, H, W] ─per-pixel subtract► out[S, T, V, H, W]
 
 ---
 
+(operators-local-global)=
 ### 3.4 Fit local, predict global — *variogram pooling, global Moran's I*
 
 The rare cell, and the one that most operator wrappers get wrong (they often refuse to express it).
@@ -692,30 +697,32 @@ class KNN(Neighborhood):
     k: int
 
     def find(self, query, ref):
-        # pairwise distance — illustrative; production code uses a KDTree
-        d = einx.dot("q d, n d -> q n",
-                     query - query.mean(0),   # placeholder centring
-                     ref   - ref.mean(0))
-        d = einx.reduce("q [d], n [d] -> q n",
-                        query[:, None] - ref[None], op="sqsum")
-        return einx.argmin("q [n] -> q k", d, k=self.k)
+        # squared pairwise distance — illustrative; production code uses a KDTree
+        d2 = einx.reduce("q [d], n [d] -> q n",
+                         query[:, None] - ref[None], op="sqsum")
+        return einx.argmin("q [n] -> q k", d2, k=self.k)
 
 
 class Radius(Neighborhood):
     r: float
-    k_max: int   # we still return a fixed-shape index for jit; pad with -1
+    k_max: int   # we still return a fixed-shape index for jit
 
-    def find(self, query, ref):
+    def find(self, query, ref) -> Int[Array, "Q K"]:
         d2 = einx.reduce("q [d], n [d] -> q n",
                          query[:, None] - ref[None], op="sqsum")
-        within = d2 < self.r ** 2                                  # (Q, N) bool
-        # top-k_max within-radius hits, ties broken by distance:
+        within = d2 < self.r ** 2                          # (Q, N) bool
+
+        # top-k_max within-radius hits, ties broken by distance.
+        # Out-of-radius slots are filled with -1 sentinels that downstream
+        # code must mask before indexing.
         masked = jnp.where(within, d2, jnp.inf)
-        return einx.argmin("q [n] -> q k", masked, k=self.k_max)
-        # entries with d2 == inf are sentinels — downstream code masks them
+        idx    = einx.argmin("q [n] -> q k", masked, k=self.k_max)
+        # mark any slot whose chosen neighbor is out of radius as -1:
+        chosen_d2 = einx.get_at("q [n], q k -> q k", masked, idx)
+        return jnp.where(chosen_d2 < jnp.inf, idx, -1)
 ```
 
-Now an operator that *consumes* a neighborhood — say, a local-mean smoother — written in the coord-aware `(data, coords) → (data, coords)` signature from [Spatiotemporal data §3.6](spatiotemporal_data.md):
+Now an operator that *consumes* a neighborhood — say, a local-mean smoother — written in the coord-aware `(data, coords) → (data, coords)` signature from [Spatiotemporal data §3.6](spatiotemporal_data.md#coords-dependency-game):
 
 ```python
 class LocalMean(eqx.Module):
@@ -747,7 +754,7 @@ Two operators, same algorithm, different *physical* contracts.
 The first is appropriate for problems where similarity-in-feature-space is the locality (anomaly detection in `V`-space, manifold-based gap-filling).
 The second is appropriate for problems where the geometry sets the scale (PDE solvers, plume smoothing, kriging, spatially-stationary GP priors).
 
-**Static vs dynamic coords** (the [Spatiotemporal data §3.3](spatiotemporal_data.md) distinction) maps cleanly onto neighborhood reuse:
+**Static vs dynamic coords** (the [Spatiotemporal data §3.3](spatiotemporal_data.md#coords-static-dynamic) distinction) maps cleanly onto neighborhood reuse:
 
 ```python
 # Static coords — KDTree / radius index built ONCE, reused across all timesteps
@@ -762,7 +769,7 @@ def step(data_t, coords_t):
 result = jax.vmap(step)(data, coords_per_t)
 ```
 
-The structural cost difference (one build vs `T` builds) is exactly the asymmetry [Spatiotemporal data §3.3](spatiotemporal_data.md) flagged: static coords amortise neighborhood construction, dynamic coords cannot.
+The structural cost difference (one build vs `T` builds) is exactly the asymmetry [Spatiotemporal data §3.3](spatiotemporal_data.md#coords-static-dynamic) flagged: static coords amortise neighborhood construction, dynamic coords cannot.
 Operators that consume `Neighborhood` strategies should be written so the index is *cacheable* on static-coord tensors — otherwise dynamic-coord workloads silently inflate cost by a factor of `T`.
 
 ---


### PR DESCRIPTION
## Summary

Two new MyST tutorials under [projects/geotoolz/tutorials/](projects/geotoolz/tutorials/), wired into the geotoolz navigation in [myst.yml](myst.yml). The pair splits *what arrives at the operator* from *what the operator does with it*.

- **[spatiotemporal_data.md](projects/geotoolz/tutorials/spatiotemporal_data.md)** (992 lines) — the data side.
  - Build-up of the canonical tensor \`[S, T, V, X]\` from univariate time series through six stages, plus the three \`S\`-axis constructions (ensembling / windowing / patching) with their coord-transform footers.
  - Coord taxonomy: raw vs feature × static vs dynamic, with cost-asymmetry pseudocode and a real-world product matrix (ERA5, Sentinel-2, TROPOMI, Argo, drifters, GHCN, FLUXNET, GraphCast, …).
  - Geometry: five-primitive hierarchy (point / line / polygon / multi-polygon / raster), per-primitive deep dive with EO examples, four bridging operations (rasterise / vectorise / sample / aggregate), \"why raster is fast,\" \"rasterise too early vs too late\" failure modes, and the explicit \`(data, coords, topology) → (data, coords, topology)\` operator signature.

- **[spatiotemporal_operators.md](projects/geotoolz/tutorials/spatiotemporal_operators.md)** (841 lines) — raster-focused operator side.
  - The dependency game: 4 cells (global/global, global/local, local/local, local/global) with real EO examples for each, physical reasoning callouts, and the axis-triage decision rule.
  - Physics of locality: characteristic length and time scales table (ENSO, mesoscale eddies, plumes, soil moisture, …) and the three rules-of-thumb that fall out of it.
  - The reshape game across sklearn / skimage / ConvLSTM / EOF with \"geophysical reading\" callouts.
  - KNN vs radius kept as an explicit *appendix / preview of a future non-raster tutorial*.

Style follows the project conventions: MyST frontmatter, one-sentence-per-line ventilated prose, \`einx\` + \`xarray\` + \`jaxtyping\` in pseudocode, ASCII diagrams, no executable cells.

## Test plan

- [ ] \`npx mystmd build --html\` succeeds locally with no broken cross-links.
- [ ] Both tutorials render in the geotoolz navigation under a new \"Tutorials\" node.
- [ ] Internal cross-refs between the two files resolve (\`[Spatiotemporal data §3.3](spatiotemporal_data.md)\` etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)