### PR TITLE
docs(assimilation): register filterax tutorial master list in myst.yml

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -95,6 +95,7 @@ project:
         - title: Data assimilation
           children:
             - file: projects/assimilation/README.md
+            - file: projects/assimilation/docs/TUTORIAL_MASTER_LIST_FILTER.md
             - title: Lorenz-63
               children:
                 - file: projects/assimilation/notebooks/00_lorenz63_setup.md


### PR DESCRIPTION
## Summary

Adds `projects/assimilation/docs/TUTORIAL_MASTER_LIST_FILTER.md` to the MyST toc so the filterax tutorial master list (shipped in #75) is reachable from the JupyterBook nav. Placed right after `projects/assimilation/README.md`, matching the convention used by `projects/gaussian_processes/TUTORIAL_MASTER_LIST.md` and `projects/gaussianization/TUTORIAL_MASTER_LIST.md`.

## MyST compliance check

- Plain markdown (no YAML frontmatter), same shape as the GP / gaussianization master lists which render fine.
- 127 inline `$math$` expressions render under MyST's default math support; no block math.
- Standard markdown tables, callouts, and emoji legends.
- `uv run --group docs myst build` resolves the page successfully — `_build/site/content/tutorial-master-list-filter.json` exists; 201 pages built in 11 s.

## Test plan

- [x] `myst build` exits cleanly (only unrelated upstream warnings about external image content-types).
- [x] Site content includes `tutorial-master-list-filter.json`.
- [x] Sidebar nav structure unchanged for every other project.


---
_Generated by [Claude Code](https://claude.ai/code/session_013jMD55Uea3GA332USkaR7w)_