### PR TITLE
docs(assimilation): surface filterax master list in MyST TOC

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -95,6 +95,7 @@ project:
         - title: Data assimilation
           children:
             - file: projects/assimilation/README.md
+            - file: projects/assimilation/docs/TUTORIAL_MASTER_LIST_FILTER.md
             - title: Lorenz-63
               children:
                 - file: projects/assimilation/notebooks/00_lorenz63_setup.md


### PR DESCRIPTION
## Summary
PR #75 added `projects/assimilation/docs/TUTORIAL_MASTER_LIST_FILTER.md` but didn't wire it into `myst.yml`, so the page doesn't render in the JupyterBook.

This is a one-line addition that places the master list as the second child of the existing `Data assimilation` TOC block — after the README, before the Lorenz benchmark notebooks.

```diff
         - title: Data assimilation
           children:
             - file: projects/assimilation/README.md
+            - file: projects/assimilation/docs/TUTORIAL_MASTER_LIST_FILTER.md
             - title: Lorenz-63
```

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('myst.yml'))"` → yaml parses cleanly.
- [x] Diff is one inserted line in `myst.yml`; no other file touched.

(Sorry about the earlier confusion — I had pushed an obsolete branch that pre-dated the #73 merge. Branch is now reset to current main with just this single fix on top.)

https://claude.ai/code/session_01PPKxuHPad9k8wf3XsnKxvt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPKxuHPad9k8wf3XsnKxvt)_