### PR TITLE
feat(satellite_viewer): add AOI preview tool with Panel / Streamlit / Jupyter subapps

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -92,6 +92,17 @@ project:
                 - file: projects/geostack/notebooks/catalog/03_set_algebra.ipynb
                 - file: projects/geostack/notebooks/catalog/04_duckdb.ipynb
                 - file: projects/geostack/notebooks/catalog/05_patching_bridge.ipynb
+        - title: Satellite viewer & climatology
+          children:
+            - file: projects/satellite_viewer/README.md
+            - title: Climatology design docs
+              children:
+                - file: projects/satellite_viewer/plans/satellite_climatology/README.md
+                - file: projects/satellite_viewer/plans/satellite_climatology/v0_aoi_preview.md
+                - file: projects/satellite_viewer/plans/satellite_climatology/v1_analytical.md
+                - file: projects/satellite_viewer/plans/satellite_climatology/v2_data_driven_scene_level.md
+                - file: projects/satellite_viewer/plans/satellite_climatology/v2_5_pixel_level.md
+                - file: projects/satellite_viewer/plans/satellite_climatology/v3_pixel_level_global.md
         - title: Data assimilation
           children:
             - file: projects/assimilation/README.md

--- a/pixi.toml
+++ b/pixi.toml
@@ -301,11 +301,13 @@ jupyter = "*"
 jupytext = ">=1.16"
 
 [feature.satellite-viewer.pypi-dependencies]
-satellite_viewer = { path = "projects/satellite_viewer", editable = true, extras = ["panel", "notebook"] }
+satellite_viewer = { path = "projects/satellite_viewer", editable = true, extras = ["panel", "notebook", "streamlit"] }
 
 [feature.satellite-viewer.tasks]
 # Launch the Panel subapp (forward port 5006 in your editor).
 panel-app = "panel serve projects/satellite_viewer/apps/panel_app.py --port 5006 --allow-websocket-origin=* --show"
+# Launch the Streamlit subapp (forward port 8501 in your editor).
+streamlit-app = "streamlit run projects/satellite_viewer/apps/streamlit_app.py --server.port 8501 --server.headless true"
 # Launch JupyterLab so you can open notebooks/viewer.py via jupytext.
 lab = "jupyter lab --no-browser --port 8888"
 # Offline registry sanity checks.

--- a/pixi.toml
+++ b/pixi.toml
@@ -290,9 +290,9 @@ test-geostack = "pytest projects/geostack/tests/ -v -m slow"
 
 # ---------------------------------------------------------------------------
 # Showcase env: satellite-viewer
-# Two presentation layers (Panel + Jupyter notebook) over one shared
-# STAC discovery core. Used to preview which scenes intersect an AOI
-# before deciding what to download.
+# Three presentation layers (Panel + Streamlit + Jupyter notebook) over
+# one shared STAC discovery core. Used to preview which scenes intersect
+# an AOI before deciding what to download.
 # ---------------------------------------------------------------------------
 [feature.satellite-viewer.dependencies]
 python = "3.12.*"
@@ -304,8 +304,12 @@ jupytext = ">=1.16"
 satellite_viewer = { path = "projects/satellite_viewer", editable = true, extras = ["panel", "notebook", "streamlit"] }
 
 [feature.satellite-viewer.tasks]
-# Launch the Panel subapp (forward port 5006 in your editor).
-panel-app = "panel serve projects/satellite_viewer/apps/panel_app.py --port 5006 --allow-websocket-origin=* --show"
+# Launch the Panel subapp (forward port 5006 in your editor). The
+# websocket-origin allowlist is restricted to localhost — when port-
+# forwarding from a remote container the browser still hits
+# localhost:5006, so this keeps cross-site WebSocket hijacking off
+# without breaking the typical local workflow.
+panel-app = "panel serve projects/satellite_viewer/apps/panel_app.py --port 5006 --allow-websocket-origin=localhost:5006 --show"
 # Launch the Streamlit subapp (forward port 8501 in your editor).
 streamlit-app = "streamlit run projects/satellite_viewer/apps/streamlit_app.py --server.port 8501 --server.headless true"
 # Launch JupyterLab so you can open notebooks/viewer.py via jupytext.

--- a/pixi.toml
+++ b/pixi.toml
@@ -288,6 +288,29 @@ execute-geostack-all = { depends-on = ["execute-geostack", "execute-geostack-pat
 # Smoke-test the data loaders against the live external APIs.
 test-geostack = "pytest projects/geostack/tests/ -v -m slow"
 
+# ---------------------------------------------------------------------------
+# Showcase env: satellite-viewer
+# Two presentation layers (Panel + Jupyter notebook) over one shared
+# STAC discovery core. Used to preview which scenes intersect an AOI
+# before deciding what to download.
+# ---------------------------------------------------------------------------
+[feature.satellite-viewer.dependencies]
+python = "3.12.*"
+ipykernel = ">=6.29"
+jupyter = "*"
+jupytext = ">=1.16"
+
+[feature.satellite-viewer.pypi-dependencies]
+satellite_viewer = { path = "projects/satellite_viewer", editable = true, extras = ["panel", "notebook"] }
+
+[feature.satellite-viewer.tasks]
+# Launch the Panel subapp (forward port 5006 in your editor).
+panel-app = "panel serve projects/satellite_viewer/apps/panel_app.py --port 5006 --allow-websocket-origin=* --show"
+# Launch JupyterLab so you can open notebooks/viewer.py via jupytext.
+lab = "jupyter lab --no-browser --port 8888"
+# Offline registry sanity checks.
+test-satellite-viewer = "pytest projects/satellite_viewer/tests/ -v"
+
 [environments]
 default = { features = ["dev"], solve-group = "default" }
 docs = { features = ["docs"], solve-group = "default" }
@@ -298,6 +321,7 @@ coordax = { features = ["coordax"], solve-group = "coordax" }
 methane-pod = { features = ["methane-pod", "dev"], solve-group = "methane-pod" }
 plume-simulation = { features = ["plume-simulation", "dev"], solve-group = "plume-simulation" }
 geostack = { features = ["geostack", "dev"], solve-group = "geostack" }
+satellite-viewer = { features = ["satellite-viewer", "dev"], solve-group = "satellite-viewer" }
 
 [tasks]
 test = "pytest -v"

--- a/projects/satellite_viewer/README.md
+++ b/projects/satellite_viewer/README.md
@@ -79,12 +79,20 @@ A lighter-weight in-notebook variant using ipywidgets + leafmap + matplotlib.
 
 ```bash
 pixi run -e satellite-viewer lab
-# then open projects/satellite_viewer/notebooks/viewer.ipynb
+# then open projects/satellite_viewer/notebooks/viewer.py — JupyterLab
+# with the jupytext extension renders the .py as a notebook.
 ```
 
 Source: [`notebooks/viewer.py`](notebooks/viewer.py) — paired as a
-jupytext py:percent script. Open it in JupyterLab with the jupytext
-extension and it appears as a normal notebook.
+jupytext py:percent script. The repo does not ship a checked-in
+`.ipynb`; opening the `.py` with the jupytext extension installed (it
+is, in this pixi env) gives the notebook experience directly. If you
+prefer a one-off `.ipynb` artifact:
+
+```bash
+pixi run -e satellite-viewer jupytext --to ipynb \
+    projects/satellite_viewer/notebooks/viewer.py
+```
 
 ## Layout
 

--- a/projects/satellite_viewer/README.md
+++ b/projects/satellite_viewer/README.md
@@ -1,0 +1,135 @@
+---
+title: "Satellite Time-Series Viewer"
+---
+
+# Satellite time-series viewer
+
+> Preview intersecting satellite imagery for an AOI **before** downloading.
+
+Pick a sensor, draw an AOI, set a date range, and get back the
+**footprints**, **timeline**, and **preview thumbnails** of every
+intersecting scene — without a single full-resolution download. The
+goal is fast inspection: "is there usable imagery here at this time?"
+before paying the bandwidth bill.
+
+```mermaid
+flowchart LR
+    A["AOI bbox or<br/>drawn polygon"] --> S["search()"]
+    P["sensor + date range +<br/>cloud %"] --> S
+    S --> H["GeoDataFrame<br/>(id, datetime,<br/>footprint, preview)"]
+    H --> M["Map<br/>(footprints + AOI)"]
+    H --> T["Timeline<br/>(time x sensor)"]
+    H --> X["Thumbnail strip"]
+```
+
+## Scope
+
+**Polar-orbiting and tasked sensors only**, via the Microsoft Planetary
+Computer STAC API (anonymous read, no auth required):
+
+| Key                | Description                                                       |
+|--------------------|-------------------------------------------------------------------|
+| `sentinel-2-l2a`   | Sentinel-2 L2A surface reflectance (10-60 m, ~5 day revisit)      |
+| `sentinel-1-grd`   | Sentinel-1 C-band SAR GRD (10 m, all-weather)                     |
+| `landsat-c2-l2`    | Landsat Collection-2 L2 surface reflectance (30 m, ~16 day)       |
+| `modis-09a1`       | MODIS Terra/Aqua 8-day surface reflectance (500 m)                |
+| `emit-l2a-rfl`     | EMIT L2A imaging spectrometer reflectance (60 m, tasked)          |
+
+Geostationary platforms (GOES, Himawari, Meteosat) are **out of scope** —
+their ~5-15 minute cadence makes "is there imagery over my AOI?" a
+trivially-yes question for any point inside the scan sector, so the
+preview-before-download workflow doesn't add value there.
+
+## Subapps
+
+Two presentation layers over the same `satellite_viewer.search`
+backend, so the discovery logic stays in one place.
+
+### Panel
+
+A standalone web app with linked map / timeline / thumbnail panes.
+
+```bash
+pixi run -e satellite-viewer panel-app
+# or
+pixi run -e satellite-viewer panel serve \
+    projects/satellite_viewer/apps/panel_app.py --show
+```
+
+Source: [`apps/panel_app.py`](apps/panel_app.py).
+
+### Jupyter notebook
+
+A lighter-weight in-notebook variant using ipywidgets + leafmap + matplotlib.
+
+```bash
+pixi run -e satellite-viewer lab
+# then open projects/satellite_viewer/notebooks/viewer.ipynb
+```
+
+Source: [`notebooks/viewer.py`](notebooks/viewer.py) — paired as a
+jupytext py:percent script. Open it in JupyterLab with the jupytext
+extension and it appears as a normal notebook.
+
+## Layout
+
+```
+projects/satellite_viewer/
+├── pyproject.toml
+├── README.md
+├── src/satellite_viewer/
+│   ├── __init__.py
+│   ├── sensors.py       # registry of supported sensors
+│   └── search.py        # one entry point: search(sensor, aoi, start, end)
+├── tests/
+│   └── test_sensors.py  # offline registry sanity checks
+├── apps/
+│   └── panel_app.py     # Panel subapp
+└── notebooks/
+    └── viewer.py        # jupytext py:percent notebook
+```
+
+## Public API
+
+```python
+from datetime import datetime
+from shapely.geometry import box
+from satellite_viewer import SENSORS, search
+
+aoi = box(-120.20, 38.95, -119.90, 39.25)  # Lake Tahoe
+hits = search(
+    "sentinel-2-l2a",
+    aoi,
+    datetime(2024, 6, 1),
+    datetime(2024, 9, 1),
+    cloud_lt=20,
+    max_items=50,
+)
+# -> GeoDataFrame[id, datetime, geometry, sensor, cloud_cover, preview_url]
+```
+
+Output schema is identical across sensors so the UI code is one
+render path. `preview_url` is a signed Planetary Computer
+`rendered_preview` href — fetch it directly to get a small RGB PNG.
+
+## Reproducing
+
+```bash
+pixi install -e satellite-viewer
+pixi run -e satellite-viewer test-satellite-viewer
+```
+
+For non-pixi users, the standalone `pyproject.toml` here pins the
+same deps; `uv pip install -e projects/satellite_viewer[panel,notebook]`
+into an activated venv works equivalently.
+
+## Why not just plug `geocatalog` in directly?
+
+[`geocatalog`](https://github.com/jejjohnson/geocatalog) is the right
+primitive once you've decided what to keep — it builds a queryable
+index over a chosen collection of files. The viewer's job is
+**upstream of that**: figure out *which* scenes you'd want to put in a
+catalog in the first place. After the user clicks "Search" and likes
+what they see, the natural next step is to hand the returned
+GeoDataFrame to `geocatalog.from_stac_items(...)` and proceed from
+there.

--- a/projects/satellite_viewer/README.md
+++ b/projects/satellite_viewer/README.md
@@ -42,12 +42,13 @@ preview-before-download workflow doesn't add value there.
 
 ## Subapps
 
-Two presentation layers over the same `satellite_viewer.search`
+Three presentation layers over the same `satellite_viewer.search`
 backend, so the discovery logic stays in one place.
 
 ### Panel
 
-A standalone web app with linked map / timeline / thumbnail panes.
+A standalone web app with linked map / timeline / thumbnail panes
+(leafmap + holoviews + tabulator).
 
 ```bash
 pixi run -e satellite-viewer panel-app
@@ -57,6 +58,20 @@ pixi run -e satellite-viewer panel serve \
 ```
 
 Source: [`apps/panel_app.py`](apps/panel_app.py).
+
+### Streamlit
+
+A single-file rerun-on-change script — folium map with a Draw plugin,
+altair timeline, thumbnail grid.
+
+```bash
+pixi run -e satellite-viewer streamlit-app
+# or
+pixi run -e satellite-viewer streamlit run \
+    projects/satellite_viewer/apps/streamlit_app.py
+```
+
+Source: [`apps/streamlit_app.py`](apps/streamlit_app.py).
 
 ### Jupyter notebook
 
@@ -84,7 +99,8 @@ projects/satellite_viewer/
 ├── tests/
 │   └── test_sensors.py  # offline registry sanity checks
 ├── apps/
-│   └── panel_app.py     # Panel subapp
+│   ├── panel_app.py     # Panel subapp
+│   └── streamlit_app.py # Streamlit subapp
 └── notebooks/
     └── viewer.py        # jupytext py:percent notebook
 ```
@@ -120,7 +136,7 @@ pixi run -e satellite-viewer test-satellite-viewer
 ```
 
 For non-pixi users, the standalone `pyproject.toml` here pins the
-same deps; `uv pip install -e projects/satellite_viewer[panel,notebook]`
+same deps; `uv pip install -e projects/satellite_viewer[panel,streamlit,notebook]`
 into an activated venv works equivalently.
 
 ## Why not just plug `geocatalog` in directly?

--- a/projects/satellite_viewer/apps/panel_app.py
+++ b/projects/satellite_viewer/apps/panel_app.py
@@ -22,7 +22,6 @@ Nothing is downloaded — every preview is a STAC `rendered_preview` URL.
 from __future__ import annotations
 
 import datetime as dt
-from io import StringIO
 
 import geopandas as gpd
 import pandas as pd
@@ -146,13 +145,13 @@ def _redraw_map(aoi, hits: gpd.GeoDataFrame) -> None:
     for layer in list(m.layers)[1:]:
         m.remove_layer(layer)
     m.add_geojson(
-        _geojson_str(gpd.GeoDataFrame(geometry=[aoi], crs="EPSG:4326")),
+        gpd.GeoDataFrame(geometry=[aoi], crs="EPSG:4326").__geo_interface__,
         layer_name="AOI",
         style={"color": "#1565c0", "weight": 3, "fillOpacity": 0.05},
     )
     if not hits.empty:
         m.add_geojson(
-            _geojson_str(hits[["geometry", "id", "sensor"]]),
+            hits[["geometry", "id", "sensor"]].__geo_interface__,
             layer_name="scenes",
             style={
                 "color": "#43a047",
@@ -160,12 +159,6 @@ def _redraw_map(aoi, hits: gpd.GeoDataFrame) -> None:
                 "fillOpacity": 0.08,
             },
         )
-
-
-def _geojson_str(gdf: gpd.GeoDataFrame) -> str:
-    buf = StringIO()
-    gdf.to_file(buf, driver="GeoJSON")
-    return buf.getvalue()
 
 
 def _do_search(_event=None) -> None:

--- a/projects/satellite_viewer/apps/panel_app.py
+++ b/projects/satellite_viewer/apps/panel_app.py
@@ -1,0 +1,244 @@
+"""Panel subapp: linked map / timeline / thumbnail strip for a satellite preview.
+
+Run:
+
+    pixi run -e satellite-viewer panel-app
+
+Or directly:
+
+    panel serve projects/satellite_viewer/apps/panel_app.py --show
+
+Workflow:
+
+1. Pick sensor(s), date range, optional cloud-cover cap.
+2. The default AOI is a small Lake Tahoe bbox. Edit the four corner
+   inputs to point somewhere else.
+3. Click "Search" — footprints land on the map, a timeline appears
+   below, and thumbnail tiles render in the bottom strip.
+
+Nothing is downloaded — every preview is a STAC `rendered_preview` URL.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from io import StringIO
+
+import geopandas as gpd
+import pandas as pd
+import panel as pn
+from satellite_viewer import SENSORS, search
+from shapely.geometry import box
+
+
+pn.extension("ipywidgets", "tabulator", sizing_mode="stretch_width")
+
+
+# ---------------------------------------------------------------------------
+# Widgets
+# ---------------------------------------------------------------------------
+
+sensor_widget = pn.widgets.MultiChoice(
+    name="Sensors",
+    options=list(SENSORS),
+    value=["sentinel-2-l2a"],
+    height=110,
+)
+date_range = pn.widgets.DateRangeSlider(
+    name="Date range",
+    start=dt.date(2023, 1, 1),
+    end=dt.date.today(),
+    value=(dt.date.today() - dt.timedelta(days=60), dt.date.today()),
+)
+cloud_slider = pn.widgets.IntSlider(
+    name="Max cloud cover %", start=0, end=100, value=40
+)
+max_items = pn.widgets.IntInput(name="Max items / sensor", value=50, start=1, end=500)
+# Lake Tahoe default.
+minx = pn.widgets.FloatInput(name="W lon", value=-120.20, step=0.05)
+miny = pn.widgets.FloatInput(name="S lat", value=38.95, step=0.05)
+maxx = pn.widgets.FloatInput(name="E lon", value=-119.90, step=0.05)
+maxy = pn.widgets.FloatInput(name="N lat", value=39.25, step=0.05)
+go_btn = pn.widgets.Button(name="Search", button_type="primary")
+status = pn.pane.Markdown("")
+
+
+# ---------------------------------------------------------------------------
+# Map (leafmap, ipyleaflet-backed). The Panel `ipywidgets` extension renders
+# any ipywidget — including leafmap maps — natively.
+# ---------------------------------------------------------------------------
+
+import leafmap
+
+
+m = leafmap.Map(
+    center=(39.10, -120.05),
+    zoom=9,
+    height="500px",
+    draw_control=True,
+    measure_control=False,
+    fullscreen_control=False,
+)
+map_pane = pn.pane.IPyWidget(m, sizing_mode="stretch_both")
+
+
+def _current_aoi():
+    return box(minx.value, miny.value, maxx.value, maxy.value)
+
+
+# ---------------------------------------------------------------------------
+# Output panes
+# ---------------------------------------------------------------------------
+
+results_table = pn.widgets.Tabulator(
+    pd.DataFrame(), pagination="local", page_size=10, height=320
+)
+timeline_pane = pn.pane.HoloViews(sizing_mode="stretch_width", height=260)
+thumbs_pane = pn.FlexBox(sizing_mode="stretch_width")
+
+
+def _render_timeline(hits: gpd.GeoDataFrame):
+    import holoviews as hv
+
+    hv.extension("bokeh", logo=False)
+    if hits.empty:
+        return hv.Text(0.5, 0.5, "no hits").opts(width=600, height=200)
+    df = hits.copy()
+    df["sensor"] = df["sensor"].astype(str)
+    df["y"] = df["sensor"]
+    return hv.Scatter(df, kdims=["datetime"], vdims=["y", "cloud_cover", "id"]).opts(
+        height=260,
+        responsive=True,
+        size=8,
+        color="sensor",
+        cmap="Category10",
+        tools=["hover"],
+        ylabel="sensor",
+        xlabel="acquisition time",
+        title="Timeline of intersecting scenes",
+    )
+
+
+def _render_thumbnails(hits: gpd.GeoDataFrame, n_max: int = 12) -> pn.FlexBox:
+    rows = hits[hits["preview_url"].notna()].head(n_max)
+    tiles = []
+    for _, row in rows.iterrows():
+        caption = (
+            f"**{row['sensor']}**\n\n"
+            f"{pd.Timestamp(row['datetime']).strftime('%Y-%m-%d %H:%M')}"
+        )
+        if pd.notna(row.get("cloud_cover")):
+            caption += f" — cloud {row['cloud_cover']:.0f}%"
+        tiles.append(
+            pn.Column(
+                pn.pane.PNG(row["preview_url"], width=180),
+                pn.pane.Markdown(caption, height=44),
+                width=200,
+            )
+        )
+    if not tiles:
+        tiles = [pn.pane.Markdown("_No previewable items._")]
+    return pn.FlexBox(*tiles, sizing_mode="stretch_width")
+
+
+def _redraw_map(aoi, hits: gpd.GeoDataFrame) -> None:
+    # Drop every previous overlay layer (keep the basemap).
+    for layer in list(m.layers)[1:]:
+        m.remove_layer(layer)
+    m.add_geojson(
+        _geojson_str(gpd.GeoDataFrame(geometry=[aoi], crs="EPSG:4326")),
+        layer_name="AOI",
+        style={"color": "#1565c0", "weight": 3, "fillOpacity": 0.05},
+    )
+    if not hits.empty:
+        m.add_geojson(
+            _geojson_str(hits[["geometry", "id", "sensor"]]),
+            layer_name="scenes",
+            style={
+                "color": "#43a047",
+                "weight": 1,
+                "fillOpacity": 0.08,
+            },
+        )
+
+
+def _geojson_str(gdf: gpd.GeoDataFrame) -> str:
+    buf = StringIO()
+    gdf.to_file(buf, driver="GeoJSON")
+    return buf.getvalue()
+
+
+def _do_search(_event=None) -> None:
+    aoi = _current_aoi()
+    start = dt.datetime.combine(date_range.value[0], dt.time())
+    end = dt.datetime.combine(date_range.value[1], dt.time(23, 59))
+    status.object = f"Searching {len(sensor_widget.value)} sensor(s)…"
+
+    frames: list[gpd.GeoDataFrame] = []
+    for key in sensor_widget.value:
+        cfg = SENSORS[key]
+        try:
+            cl = cloud_slider.value if cfg.cloud_field is not None else None
+            hits = search(
+                key,
+                aoi,
+                start,
+                end,
+                max_items=max_items.value,
+                cloud_lt=cl,
+            )
+        except Exception as exc:
+            status.object = f"**{key}** failed: `{type(exc).__name__}: {exc}`"
+            continue
+        frames.append(hits)
+
+    if not frames:
+        return
+    combined = pd.concat(frames, ignore_index=True)
+    combined = gpd.GeoDataFrame(combined, geometry="geometry", crs="EPSG:4326")
+
+    results_table.value = pd.DataFrame(combined.drop(columns="geometry"))
+    timeline_pane.object = _render_timeline(combined)
+    thumbs_pane.objects = _render_thumbnails(combined).objects
+    _redraw_map(aoi, combined)
+    status.object = f"Done — **{len(combined)}** scene(s) found."
+
+
+go_btn.on_click(_do_search)
+
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+
+sidebar = pn.Column(
+    pn.pane.Markdown("### Search"),
+    sensor_widget,
+    date_range,
+    cloud_slider,
+    max_items,
+    pn.pane.Markdown("**AOI bbox** (WGS84):"),
+    pn.Row(minx, miny),
+    pn.Row(maxx, maxy),
+    go_btn,
+    status,
+    width=320,
+)
+
+main = pn.Column(
+    map_pane,
+    pn.pane.Markdown("### Timeline"),
+    timeline_pane,
+    pn.pane.Markdown("### Thumbnails"),
+    thumbs_pane,
+    pn.pane.Markdown("### Results table"),
+    results_table,
+)
+
+template = pn.template.MaterialTemplate(
+    title="Satellite Time-Series Viewer",
+    sidebar=[sidebar],
+    main=[main],
+)
+
+template.servable()

--- a/projects/satellite_viewer/apps/streamlit_app.py
+++ b/projects/satellite_viewer/apps/streamlit_app.py
@@ -1,0 +1,240 @@
+"""Streamlit subapp: AOI -> sensor preview, single-file rerun-on-change script.
+
+Run:
+
+    pixi run -e satellite-viewer streamlit-app
+
+Or directly:
+
+    streamlit run projects/satellite_viewer/apps/streamlit_app.py
+
+Workflow:
+
+1. Pick sensor(s), date range, optional cloud-cover cap in the sidebar.
+2. Draw a rectangle on the map (or keep the Lake Tahoe default bbox).
+3. Click "Search" — the rest of the page re-renders with footprints,
+   a timeline, thumbnails, and the raw results table.
+
+Nothing is downloaded — every preview is a STAC `rendered_preview` URL.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import altair as alt
+import folium
+import geopandas as gpd
+import pandas as pd
+import streamlit as st
+from folium.plugins import Draw
+from satellite_viewer import SENSORS, search
+from shapely.geometry import box, shape
+from streamlit_folium import st_folium
+
+
+st.set_page_config(
+    page_title="Satellite Time-Series Viewer",
+    layout="wide",
+)
+
+
+# ---------------------------------------------------------------------------
+# Sidebar — inputs
+# ---------------------------------------------------------------------------
+
+st.sidebar.title("Search")
+sensors = st.sidebar.multiselect(
+    "Sensors",
+    options=list(SENSORS),
+    default=["sentinel-2-l2a"],
+    help="Polar-orbiting / tasked sensors on Microsoft Planetary Computer.",
+)
+today = dt.date.today()
+start_date, end_date = st.sidebar.date_input(
+    "Date range",
+    value=(today - dt.timedelta(days=60), today),
+    min_value=dt.date(2015, 1, 1),
+    max_value=today,
+)
+cloud_lt = st.sidebar.slider("Max cloud cover %", 0, 100, 40)
+max_items = st.sidebar.number_input(
+    "Max items / sensor", min_value=1, max_value=500, value=50
+)
+
+st.sidebar.markdown("---")
+st.sidebar.markdown("**AOI bbox** (WGS84)")
+col_w, col_e = st.sidebar.columns(2)
+minx = col_w.number_input("W lon", value=-120.20, step=0.05, format="%.4f")
+maxx = col_e.number_input("E lon", value=-119.90, step=0.05, format="%.4f")
+col_s, col_n = st.sidebar.columns(2)
+miny = col_s.number_input("S lat", value=38.95, step=0.05, format="%.4f")
+maxy = col_n.number_input("N lat", value=39.25, step=0.05, format="%.4f")
+go = st.sidebar.button("Search", type="primary", width="stretch")
+
+
+# ---------------------------------------------------------------------------
+# Map (folium + Draw plugin). The map is interactive on every rerun; if
+# the user drew a polygon it overrides the bbox text inputs.
+# ---------------------------------------------------------------------------
+
+st.title("Satellite Time-Series Viewer")
+
+bbox_aoi = box(minx, miny, maxx, maxy)
+m = folium.Map(location=[(miny + maxy) / 2, (minx + maxx) / 2], zoom_start=9)
+Draw(
+    export=False,
+    draw_options={
+        "polyline": False,
+        "circle": False,
+        "circlemarker": False,
+        "marker": False,
+        "polygon": True,
+        "rectangle": True,
+    },
+).add_to(m)
+folium.GeoJson(
+    gpd.GeoSeries([bbox_aoi], crs="EPSG:4326").__geo_interface__,
+    name="bbox AOI",
+    style_function=lambda _f: {
+        "color": "#1565c0",
+        "weight": 2,
+        "fillOpacity": 0.04,
+    },
+).add_to(m)
+
+map_state = st_folium(m, height=500, width=None, key="aoi_map")
+
+
+def _resolve_aoi():
+    """Last-drawn polygon wins over the bbox text inputs."""
+    drawings = (map_state or {}).get("all_drawings") or []
+    if drawings:
+        return shape(drawings[-1]["geometry"])
+    return bbox_aoi
+
+
+# ---------------------------------------------------------------------------
+# Search + results
+# ---------------------------------------------------------------------------
+
+
+@st.cache_data(show_spinner=False)
+def _cached_search(
+    sensor: str,
+    aoi_wkt: str,
+    start: dt.datetime,
+    end: dt.datetime,
+    cloud_lt: float | None,
+    max_items: int,
+) -> pd.DataFrame:
+    """Cache key is by-value; we serialise the AOI to WKT to make it hashable."""
+    from shapely import wkt
+
+    aoi = wkt.loads(aoi_wkt)
+    gdf = search(sensor, aoi, start, end, cloud_lt=cloud_lt, max_items=max_items)
+    # Return a plain DataFrame for Streamlit's hashing; reconstitute
+    # geometry from WKT on the consumer side.
+    out = pd.DataFrame(gdf.drop(columns="geometry"))
+    out["geometry_wkt"] = gdf.geometry.to_wkt()
+    return out
+
+
+if go and sensors:
+    aoi = _resolve_aoi()
+    start_dt = dt.datetime.combine(start_date, dt.time())
+    end_dt = dt.datetime.combine(end_date, dt.time(23, 59))
+
+    frames: list[pd.DataFrame] = []
+    progress = st.progress(0.0, text="searching…")
+    for i, key in enumerate(sensors, 1):
+        cfg = SENSORS[key]
+        cl = cloud_lt if cfg.cloud_field is not None else None
+        try:
+            frames.append(
+                _cached_search(key, aoi.wkt, start_dt, end_dt, cl, int(max_items))
+            )
+        except Exception as exc:  # surfaced to the UI, not swallowed
+            st.error(f"{key} failed: {type(exc).__name__}: {exc}")
+        progress.progress(i / len(sensors), text=f"searched {key}")
+    progress.empty()
+
+    if not frames:
+        st.warning("No results.")
+        st.stop()
+
+    combined = pd.concat(frames, ignore_index=True)
+    n = len(combined)
+    st.success(f"Found **{n}** scene(s) across {len(sensors)} sensor(s).")
+
+    # --- Footprints on the map (render below the input map) -----------------
+    st.subheader("Footprints")
+    from shapely import wkt
+
+    footprints = gpd.GeoSeries(
+        [wkt.loads(w) for w in combined["geometry_wkt"]], crs="EPSG:4326"
+    )
+    m2 = folium.Map(location=[(miny + maxy) / 2, (minx + maxx) / 2], zoom_start=8)
+    folium.GeoJson(
+        gpd.GeoSeries([aoi], crs="EPSG:4326").__geo_interface__,
+        name="AOI",
+        style_function=lambda _f: {
+            "color": "#1565c0",
+            "weight": 3,
+            "fillOpacity": 0.05,
+        },
+    ).add_to(m2)
+    folium.GeoJson(
+        gpd.GeoDataFrame(
+            {"sensor": combined["sensor"]}, geometry=footprints
+        ).__geo_interface__,
+        name="scenes",
+        style_function=lambda _f: {
+            "color": "#43a047",
+            "weight": 1,
+            "fillOpacity": 0.08,
+        },
+    ).add_to(m2)
+    st_folium(m2, height=420, width=None, returned_objects=[], key="result_map")
+
+    # --- Timeline -----------------------------------------------------------
+    st.subheader("Timeline")
+    timeline = (
+        alt.Chart(combined)
+        .mark_circle(size=80)
+        .encode(
+            x=alt.X("datetime:T", title="acquisition time"),
+            y=alt.Y("sensor:N", title="sensor"),
+            color=alt.Color("sensor:N", legend=None),
+            tooltip=["id", "datetime", "cloud_cover", "sensor"],
+        )
+        .properties(height=240)
+    )
+    st.altair_chart(timeline, use_container_width=True)
+
+    # --- Thumbnails ---------------------------------------------------------
+    st.subheader("Thumbnails")
+    rows = combined[combined["preview_url"].notna()].head(12)
+    if rows.empty:
+        st.caption("No previewable thumbnails for this result set.")
+    else:
+        cols = st.columns(4)
+        for i, (_, row) in enumerate(rows.iterrows()):
+            with cols[i % 4]:
+                st.image(row["preview_url"], width="stretch")
+                caption = (
+                    f"**{row['sensor']}** — "
+                    f"{pd.Timestamp(row['datetime']).strftime('%Y-%m-%d %H:%M')}"
+                )
+                if pd.notna(row.get("cloud_cover")):
+                    caption += f" — cloud {row['cloud_cover']:.0f}%"
+                st.caption(caption)
+
+    # --- Raw table ----------------------------------------------------------
+    st.subheader("Results table")
+    st.dataframe(combined.drop(columns="geometry_wkt"), width="stretch", height=320)
+else:
+    st.info(
+        "Pick sensors and a date range in the sidebar, optionally draw a "
+        "polygon on the map, then click **Search**."
+    )

--- a/projects/satellite_viewer/notebooks/viewer.py
+++ b/projects/satellite_viewer/notebooks/viewer.py
@@ -27,7 +27,6 @@
 from __future__ import annotations
 
 import datetime as dt
-from io import StringIO
 
 import geopandas as gpd
 import ipywidgets as W
@@ -107,23 +106,17 @@ def _aoi_from_draw():
     return shape(last["geometry"])
 
 
-def _geojson_str(gdf: gpd.GeoDataFrame) -> str:
-    buf = StringIO()
-    gdf.to_file(buf, driver="GeoJSON")
-    return buf.getvalue()
-
-
 def _redraw_map(aoi, hits: gpd.GeoDataFrame) -> None:
     for layer in list(m.layers)[1:]:
         m.remove_layer(layer)
     m.add_geojson(
-        _geojson_str(gpd.GeoDataFrame(geometry=[aoi], crs="EPSG:4326")),
+        gpd.GeoDataFrame(geometry=[aoi], crs="EPSG:4326").__geo_interface__,
         layer_name="AOI",
         style={"color": "#1565c0", "weight": 3, "fillOpacity": 0.05},
     )
     if not hits.empty:
         m.add_geojson(
-            _geojson_str(hits[["geometry", "id", "sensor"]]),
+            hits[["geometry", "id", "sensor"]].__geo_interface__,
             layer_name="scenes",
             style={"color": "#43a047", "weight": 1, "fillOpacity": 0.08},
         )

--- a/projects/satellite_viewer/notebooks/viewer.py
+++ b/projects/satellite_viewer/notebooks/viewer.py
@@ -1,0 +1,240 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Satellite time-series viewer — notebook subapp
+#
+# Pair of widgets + a leafmap map that lets you draw an AOI, pick a
+# sensor, hit "Search", and inspect the intersecting STAC items
+# (footprints, timeline, thumbnails) **before downloading anything**.
+#
+# Same backend as the Panel subapp (`satellite_viewer.search`) — this
+# notebook is just a lighter-weight presentation layer that lives next
+# to your other experiments.
+
+# %%
+from __future__ import annotations
+
+import datetime as dt
+from io import StringIO
+
+import geopandas as gpd
+import ipywidgets as W
+import leafmap
+import matplotlib.pyplot as plt
+import pandas as pd
+from IPython.display import display
+from shapely.geometry import box, shape
+
+from satellite_viewer import SENSORS, search
+
+
+# %% [markdown]
+# ## Controls
+#
+# Edit the bbox inputs or draw a rectangle on the map (the most recent
+# draw wins on the next Search click). Sentinel-2 is selected by
+# default since it has the cleanest preview thumbnails.
+
+# %%
+sensor_picker = W.SelectMultiple(
+    options=list(SENSORS),
+    value=("sentinel-2-l2a",),
+    description="Sensors",
+    rows=6,
+)
+date_start = W.DatePicker(
+    description="Start", value=dt.date.today() - dt.timedelta(days=60)
+)
+date_end = W.DatePicker(description="End", value=dt.date.today())
+cloud_max = W.IntSlider(
+    description="Cloud %", min=0, max=100, value=40, continuous_update=False
+)
+max_items = W.BoundedIntText(
+    description="Max items", min=1, max=500, value=50
+)
+# Lake Tahoe default.
+minx = W.FloatText(description="W lon", value=-120.20)
+miny = W.FloatText(description="S lat", value=38.95)
+maxx = W.FloatText(description="E lon", value=-119.90)
+maxy = W.FloatText(description="N lat", value=39.25)
+go_btn = W.Button(description="Search", button_style="primary")
+status = W.HTML()
+
+controls = W.VBox(
+    [
+        sensor_picker,
+        W.HBox([date_start, date_end]),
+        cloud_max,
+        max_items,
+        W.HBox([minx, miny]),
+        W.HBox([maxx, maxy]),
+        go_btn,
+        status,
+    ]
+)
+
+# %%
+m = leafmap.Map(center=(39.10, -120.05), zoom=9, draw_control=True)
+display(W.HBox([controls, m]))
+
+
+# %% [markdown]
+# ## Helpers
+
+
+# %%
+def _aoi_from_controls():
+    return box(minx.value, miny.value, maxx.value, maxy.value)
+
+
+def _aoi_from_draw():
+    """If the user drew a rectangle on the map, prefer that AOI."""
+    last = m.draw_last_feature
+    if last is None:
+        return None
+    return shape(last["geometry"])
+
+
+def _geojson_str(gdf: gpd.GeoDataFrame) -> str:
+    buf = StringIO()
+    gdf.to_file(buf, driver="GeoJSON")
+    return buf.getvalue()
+
+
+def _redraw_map(aoi, hits: gpd.GeoDataFrame) -> None:
+    for layer in list(m.layers)[1:]:
+        m.remove_layer(layer)
+    m.add_geojson(
+        _geojson_str(gpd.GeoDataFrame(geometry=[aoi], crs="EPSG:4326")),
+        layer_name="AOI",
+        style={"color": "#1565c0", "weight": 3, "fillOpacity": 0.05},
+    )
+    if not hits.empty:
+        m.add_geojson(
+            _geojson_str(hits[["geometry", "id", "sensor"]]),
+            layer_name="scenes",
+            style={"color": "#43a047", "weight": 1, "fillOpacity": 0.08},
+        )
+
+
+def _plot_timeline(hits: gpd.GeoDataFrame) -> None:
+    if hits.empty:
+        print("no hits")
+        return
+    fig, ax = plt.subplots(figsize=(10, 2.5))
+    df = hits.copy()
+    df["y"] = df["sensor"].astype("category").cat.codes
+    sc = ax.scatter(
+        df["datetime"],
+        df["y"],
+        c=df["cloud_cover"].fillna(-1),
+        cmap="viridis",
+        s=40,
+    )
+    ax.set_yticks(range(df["sensor"].nunique()))
+    ax.set_yticklabels(
+        df["sensor"].astype("category").cat.categories.tolist()
+    )
+    ax.set_xlabel("acquisition time")
+    ax.set_title("Timeline of intersecting scenes")
+    fig.colorbar(sc, ax=ax, label="cloud cover %")
+    fig.autofmt_xdate()
+    plt.show()
+
+
+def _show_thumbnails(hits: gpd.GeoDataFrame, n: int = 8) -> None:
+    rows = hits[hits["preview_url"].notna()].head(n)
+    if rows.empty:
+        print("no previewable thumbnails")
+        return
+    images = []
+    for _, row in rows.iterrows():
+        img = W.Image(
+            value=_fetch(row["preview_url"]),
+            format="png",
+            width=180,
+            height=180,
+        )
+        cap = W.HTML(
+            f"<small><b>{row['sensor']}</b><br>"
+            f"{pd.Timestamp(row['datetime']).strftime('%Y-%m-%d %H:%M')}"
+            f"</small>"
+        )
+        images.append(W.VBox([img, cap]))
+    display(W.HBox(images, layout=W.Layout(flex_flow="row wrap")))
+
+
+def _fetch(url: str) -> bytes:
+    import requests
+
+    return requests.get(url, timeout=30).content
+
+
+# %% [markdown]
+# ## Wire up the button
+
+
+# %%
+output = W.Output()
+display(output)
+
+
+def _on_click(_btn):
+    output.clear_output()
+    aoi = _aoi_from_draw() or _aoi_from_controls()
+    start = dt.datetime.combine(date_start.value, dt.time())
+    end = dt.datetime.combine(date_end.value, dt.time(23, 59))
+    status.value = "<i>searching...</i>"
+
+    frames = []
+    for key in sensor_picker.value:
+        cfg = SENSORS[key]
+        cl = cloud_max.value if cfg.cloud_field is not None else None
+        try:
+            hits = search(
+                key,
+                aoi,
+                start,
+                end,
+                max_items=max_items.value,
+                cloud_lt=cl,
+            )
+        except Exception as exc:  # noqa: BLE001
+            with output:
+                print(f"{key} failed: {type(exc).__name__}: {exc}")
+            continue
+        frames.append(hits)
+
+    if not frames:
+        status.value = "<b>no results</b>"
+        return
+    combined = pd.concat(frames, ignore_index=True)
+    combined = gpd.GeoDataFrame(
+        combined, geometry="geometry", crs="EPSG:4326"
+    )
+
+    _redraw_map(aoi, combined)
+    with output:
+        _plot_timeline(combined)
+        _show_thumbnails(combined)
+        display(
+            combined.drop(columns="geometry").head(20).style.set_caption(
+                f"{len(combined)} hits (showing first 20)"
+            )
+        )
+    status.value = f"<b>{len(combined)}</b> scene(s) found."
+
+
+go_btn.on_click(_on_click)

--- a/projects/satellite_viewer/plans/satellite_climatology/README.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/README.md
@@ -1,0 +1,139 @@
+# Satellite climatology — design docs
+
+A global product showing **temporal cadence and cloud-free observability**
+of satellite imagery per pixel of the Earth, sliced by sensor and time
+window. Built sequentially in four stages of increasing fidelity:
+
+| Stage    | Scale            | What it answers                                              | Data source              | New repo introduced |
+|----------|------------------|--------------------------------------------------------------|--------------------------|---------------------|
+| **v1**   | global           | *Theoretical* overpass cadence per pixel per sensor          | TLEs / orbit propagation | (none — skyfield)   |
+| **v2**   | global           | *Observed* scene count + scene-level cloud cover per pixel   | STAC `eo:cloud_cover`    | `geocatalog`, `geopatcher`, `geotoolz` |
+| **v2.5** | one AOI on demand | *True per-pixel* clear-observation fraction inside an AOI    | STAC + windowed reads    | `georeader`         |
+| **v3**   | global           | v2.5 scaled to the whole globe — *true per-pixel*, batched  | STAC + windowed reads    | (same as v2.5; cluster) |
+
+Each stage writes into the **same global Zarr product** below (except
+v2.5, which writes a per-AOI time series rather than a global grid).
+The dashboard reads whichever bands exist.
+
+## Why staged
+
+- **v1** is a ~100-line orbit-mechanics script with **no catalog scan**.
+  It gives the *theoretical ceiling* (how often *could* you image here?)
+  and is the baseline the data-driven stages get compared against.
+- **v2** adds the catalog scan but stays at scene-level metadata. ~100×
+  cheaper than v3. Answers "how many actual scenes per pixel, and what
+  was the *scene-wide* cloud cover?" Good enough for many users.
+- **v2.5** is the **single-AOI, on-demand** variant of the pixel-level
+  problem. Same flow as the `satellite_viewer` apps: pick an AOI (up to
+  some size cap, ~50 km), the system reads QA bands for the
+  intersecting scenes and returns the **truthful** clear-fraction time
+  series for that AOI. Validates QA decoders + `georeader` integration
+  at user-facing scale before committing to global compute.
+- **v3** is v2.5 scaled to the whole globe — same algorithm, batched
+  per tile, written into the global Zarr. Cluster-grade compute.
+
+## Shared substrate
+
+### Global grid
+
+```
+crs        : EPSG:4326
+resolution : 0.1°   (3600 × 1800 = 6.48M cells)  -- tunable knob
+extent     : [-180, -90, 180, 90]
+indexing   : (lat ascending, lon ascending)
+```
+
+The 0.1° default puts each cell at ~11 km at the equator, ~6 km at 50°.
+That matches the scene-footprint scale of Landsat/S2 (~110×110 km) ÷ ~10
+so a typical scene covers ~100 cells — fine for revisit stats, coarse
+enough that 6.48M cells × ~5 sensors × ~24 months × ~6 bands fits in a
+few GB Zarr.
+
+Switch to **H3 hex bins** (res 5: ~250 km² cells) if equal-area is
+important — discussed in v2.
+
+### Sensor list
+
+| key                  | platforms                                  | nominal revisit      |
+|----------------------|--------------------------------------------|----------------------|
+| `sentinel-2`         | Sentinel-2A + 2B + 2C                      | 5 days @ equator     |
+| `landsat-8-9`        | Landsat 8 + 9 (combined)                   | 8 days               |
+| `modis-terra`        | Terra MODIS                                | ~daily               |
+| `modis-aqua`         | Aqua MODIS                                 | ~daily               |
+| `viirs-jpss`         | NPP + JPSS-1 + JPSS-2 VIIRS                | ~daily               |
+
+Sensor key is a dimension coordinate in the Zarr.
+
+### Output product (Zarr schema)
+
+```
+Dims     : (sensor, time, lat, lon)
+Coords   :
+  sensor : ["sentinel-2", "landsat-8-9", "modis-terra", "modis-aqua", "viirs-jpss"]
+  time   : pandas.PeriodIndex(freq="M", start=...)   # monthly bins
+  lat    : np.arange(-90, 90, 0.1)
+  lon    : np.arange(-180, 180, 0.1)
+Data vars:
+  # v1 — analytical
+  overpasses             : int16     # count of overpasses in this month
+  mean_gap_days          : float32   # mean gap between consecutive overpasses
+  p95_gap_days           : float32   # 95th percentile gap (long-gap stat)
+
+  # v2 — data-driven, scene-level
+  scenes_count           : int16     # number of catalog items intersecting this cell
+  mean_scene_cloud_pct   : float32   # mean of eo:cloud_cover across items
+  cloud_free_scene_count : int16     # items where eo:cloud_cover < 10%
+
+  # v3 — pixel-level QA (global)
+  clear_obs_count        : int16     # pixel actually clear in QA mask
+  clear_fraction         : float32   # clear_obs_count / scenes_count
+  pixel_max_gap_days     : float32   # longest gap between clear observations
+```
+
+A given Zarr can be partially populated — v1 only writes the first three
+bands, v2 adds the next three, v3 adds the last three. The UI reads
+what's there.
+
+**v2.5 does *not* write into this Zarr.** It produces a per-AOI time-series
+DataFrame and is rendered live in the dashboard. The same `ReadQA → DecodeQA
+→ CellClearFrac` pipeline is reused unchanged in v3 — that's the contract
+the staging guarantees.
+
+### Time binning
+
+Monthly is the default — captures seasonality (cloud climatology has
+strong monsoon / wet-season signal) without exploding the time axis.
+Yearly is a one-line `.resample("Y").sum()` collapse for users who just
+want long-term averages.
+
+## Repos & how they slot in
+
+| Stage  | geocatalog  | geopatcher                  | geotoolz                | georeader        |
+|--------|-------------|-----------------------------|-------------------------|------------------|
+| v1     | —           | global grid iteration (opt) | —                       | —                |
+| v2     | catalog scan + bbox queries | grid iteration over cells | `Fanout` of per-cell reducers | — |
+| v2.5   | (reuses satellite_viewer.search) | — (single AOI) | per-scene `Operator` graph for QA mask | windowed SCL/QA reads |
+| v3     | (as v2)     | (as v2)                     | (as v2.5)               | (as v2.5)        |
+
+## Milestones (suggested)
+
+1. **M0 — design**: this folder. Four docs reviewed before any code.
+2. **M1 — v1 prototype**: skyfield + numpy, single notebook, 0.5° grid,
+   one sensor. Validates the Zarr schema and the UI hook.
+3. **M2 — v1 full**: full sensor list, 0.1° grid, monthly bins.
+4. **M3 — v2 scene-level**: catalog scan over 1 year, S2 only, 0.1°.
+5. **M4 — v2 full**: extend to all sensors and 3 years.
+6. **M5 — v2.5 AOI pixel-level**: per-AOI dashboard reusing
+   `satellite_viewer.search` for discovery, `georeader` for QA reads.
+   Single sensor first (S2).
+7. **M6 — v3 global pixel-level**: same operators batched over the
+   global grid; sized for a cluster job.
+8. **M7 — UI**: notebook + Panel/Streamlit dashboard reading the Zarr,
+   with the v2.5 AOI panel as a separate tab.
+
+## Files in this folder
+
+- [`v1_analytical.md`](v1_analytical.md) — orbit-mechanics version.
+- [`v2_data_driven_scene_level.md`](v2_data_driven_scene_level.md) — catalog + scene-level cloud.
+- [`v2_5_pixel_level.md`](v2_5_pixel_level.md) — per-AOI pixel-level via georeader.
+- [`v3_pixel_level_global.md`](v3_pixel_level_global.md) — v2.5 scaled to the whole globe.

--- a/projects/satellite_viewer/plans/satellite_climatology/README.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/README.md
@@ -1,22 +1,31 @@
+---
+title: "Satellite climatology — design docs"
+---
+
 # Satellite climatology — design docs
 
 A global product showing **temporal cadence and cloud-free observability**
 of satellite imagery per pixel of the Earth, sliced by sensor and time
-window. Built sequentially in four stages of increasing fidelity:
+window. Built sequentially in five stages of increasing fidelity:
 
-| Stage    | Scale            | What it answers                                              | Data source              | New repo introduced |
-|----------|------------------|--------------------------------------------------------------|--------------------------|---------------------|
-| **v1**   | global           | *Theoretical* overpass cadence per pixel per sensor          | TLEs / orbit propagation | (none — skyfield)   |
-| **v2**   | global           | *Observed* scene count + scene-level cloud cover per pixel   | STAC `eo:cloud_cover`    | `geocatalog`, `geopatcher`, `geotoolz` |
+| Stage    | Scale             | What it answers                                              | Data source              | New repo introduced |
+|----------|-------------------|--------------------------------------------------------------|--------------------------|---------------------|
+| **v0**   | one AOI on demand | *Which scenes touched my AOI?* (footprints + thumbnails)    | STAC item metadata       | `pystac-client` + `planetary-computer` |
+| **v1**   | global            | *Theoretical* overpass cadence per pixel per sensor          | TLEs / orbit propagation | (skyfield)          |
+| **v2**   | global            | *Observed* scene count + scene-level cloud cover per pixel   | STAC `eo:cloud_cover`    | `geocatalog`, `geopatcher`, `geotoolz` |
 | **v2.5** | one AOI on demand | *True per-pixel* clear-observation fraction inside an AOI    | STAC + windowed reads    | `georeader`         |
-| **v3**   | global           | v2.5 scaled to the whole globe — *true per-pixel*, batched  | STAC + windowed reads    | (same as v2.5; cluster) |
+| **v3**   | global            | v2.5 scaled to the whole globe — *true per-pixel*, batched  | STAC + windowed reads    | (same as v2.5; cluster) |
 
-Each stage writes into the **same global Zarr product** below (except
-v2.5, which writes a per-AOI time series rather than a global grid).
-The dashboard reads whichever bands exist.
+Each global stage writes into the **same Zarr product** below (except
+v0 and v2.5, which are per-AOI tools returning a DataFrame, not a
+global grid). The dashboard reads whichever bands exist.
 
 ## Why staged
 
+- **v0** is the satellite_viewer AOI preview tool — already shipped in
+  this PR. *"What scenes are available here?"* with footprints,
+  timestamps, scene-wide cloud cover, and preview thumbnails. The
+  upstream-of-download inspection step.
 - **v1** is a ~100-line orbit-mechanics script with **no catalog scan**.
   It gives the *theoretical ceiling* (how often *could* you image here?)
   and is the baseline the data-driven stages get compared against.
@@ -24,13 +33,14 @@ The dashboard reads whichever bands exist.
   cheaper than v3. Answers "how many actual scenes per pixel, and what
   was the *scene-wide* cloud cover?" Good enough for many users.
 - **v2.5** is the **single-AOI, on-demand** variant of the pixel-level
-  problem. Same flow as the `satellite_viewer` apps: pick an AOI (up to
-  some size cap, ~50 km), the system reads QA bands for the
-  intersecting scenes and returns the **truthful** clear-fraction time
-  series for that AOI. Validates QA decoders + `georeader` integration
-  at user-facing scale before committing to global compute.
-- **v3** is v2.5 scaled to the whole globe — same algorithm, batched
-  per tile, written into the global Zarr. Cluster-grade compute.
+  problem. Inherits v0's AOI flow: pick an AOI (up to a size cap,
+  ~50 km), the system reads QA bands for the intersecting scenes and
+  returns the **truthful** clear-fraction time series for that AOI.
+  Validates QA decoders + `georeader` integration at user-facing scale
+  before committing to global compute.
+- **v3** is v2.5 scaled to the whole globe — same per-scene operator
+  graph, batched per tile, written into the global Zarr. Cluster-grade
+  compute.
 
 ## Shared substrate
 
@@ -110,6 +120,7 @@ want long-term averages.
 
 | Stage  | geocatalog  | geopatcher                  | geotoolz                | georeader        |
 |--------|-------------|-----------------------------|-------------------------|------------------|
+| v0     | —           | —                           | —                       | —                |
 | v1     | —           | global grid iteration (opt) | —                       | —                |
 | v2     | catalog scan + bbox queries | grid iteration over cells | `Fanout` of per-cell reducers | — |
 | v2.5   | (reuses satellite_viewer.search) | — (single AOI) | per-scene `Operator` graph for QA mask | windowed SCL/QA reads |
@@ -117,22 +128,25 @@ want long-term averages.
 
 ## Milestones (suggested)
 
-1. **M0 — design**: this folder. Four docs reviewed before any code.
-2. **M1 — v1 prototype**: skyfield + numpy, single notebook, 0.5° grid,
+0. **M0 — v0 (shipped)**: the satellite_viewer AOI preview tool in this PR.
+   `satellite_viewer.search` + Panel / Streamlit / Jupyter subapps.
+1. **M1 — design**: this folder. Five docs reviewed before more code.
+2. **M2 — v1 prototype**: skyfield + numpy, single notebook, 0.5° grid,
    one sensor. Validates the Zarr schema and the UI hook.
-3. **M2 — v1 full**: full sensor list, 0.1° grid, monthly bins.
-4. **M3 — v2 scene-level**: catalog scan over 1 year, S2 only, 0.1°.
-5. **M4 — v2 full**: extend to all sensors and 3 years.
-6. **M5 — v2.5 AOI pixel-level**: per-AOI dashboard reusing
+3. **M3 — v1 full**: full sensor list, 0.1° grid, monthly bins.
+4. **M4 — v2 scene-level**: catalog scan over 1 year, S2 only, 0.1°.
+5. **M5 — v2 full**: extend to all sensors and 3 years.
+6. **M6 — v2.5 AOI pixel-level**: per-AOI dashboard reusing
    `satellite_viewer.search` for discovery, `georeader` for QA reads.
    Single sensor first (S2).
-7. **M6 — v3 global pixel-level**: same operators batched over the
+7. **M7 — v3 global pixel-level**: same operators batched over the
    global grid; sized for a cluster job.
-8. **M7 — UI**: notebook + Panel/Streamlit dashboard reading the Zarr,
-   with the v2.5 AOI panel as a separate tab.
+8. **M8 — UI**: notebook + Panel/Streamlit dashboard reading the Zarr,
+   with the v0 / v2.5 AOI panels as separate tabs.
 
 ## Files in this folder
 
+- [`v0_aoi_preview.md`](v0_aoi_preview.md) — AOI preview tool (shipped).
 - [`v1_analytical.md`](v1_analytical.md) — orbit-mechanics version.
 - [`v2_data_driven_scene_level.md`](v2_data_driven_scene_level.md) — catalog + scene-level cloud.
 - [`v2_5_pixel_level.md`](v2_5_pixel_level.md) — per-AOI pixel-level via georeader.

--- a/projects/satellite_viewer/plans/satellite_climatology/v0_aoi_preview.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v0_aoi_preview.md
@@ -1,0 +1,196 @@
+---
+title: "v0 — AOI preview tool (shipped)"
+short_title: "v0 AOI preview"
+---
+
+# v0 — AOI preview tool
+
+> *Given an AOI, a date range, and a list of sensors, return the
+> intersecting STAC items with their footprints, timestamps, scene-wide
+> cloud cover, and preview thumbnail URLs — before downloading anything.*
+
+**Status:** shipped. The code referenced by this doc is the contents of
+this PR (`projects/satellite_viewer/`). This page exists so the
+staging arc starts from the thing already built, not from a blank
+slate.
+
+## Goal
+
+A user-facing tool that answers *"what scenes are available here?"*
+without paying the bandwidth bill of opening any of them. It's the
+upstream-of-download step: inspect first, choose, then commit to a
+download (or a `geocatalog.from_stac_items(...)` ingest, or a v2.5
+clear-fraction request).
+
+## Question answered
+
+> "Across these sensors, between these dates, which scenes touched my
+> AOI, when, and how cloudy were they at the scene level?"
+
+This is **scene-level metadata only**. v2.5 is the same input shape
+but the output is the *pixel-level truthful clear-fraction* for that
+AOI — see `v2_5_pixel_level.md`.
+
+## Scope
+
+Polar-orbiting / tasked sensors only, all via Microsoft Planetary
+Computer STAC (anonymous read, no auth):
+
+| key              | description                                               |
+|------------------|-----------------------------------------------------------|
+| `sentinel-2-l2a` | Sentinel-2 L2A surface reflectance (10-60 m, ~5 d revisit)|
+| `sentinel-1-grd` | Sentinel-1 C-band SAR GRD (10 m, all-weather)             |
+| `landsat-c2-l2`  | Landsat C2 L2 surface reflectance (30 m, ~16 d revisit)   |
+| `modis-09a1`     | MODIS Terra/Aqua 8-day surface reflectance (500 m)        |
+| `emit-l2a-rfl`   | EMIT L2A imaging spectrometer reflectance (60 m, tasked)  |
+
+Geostationary platforms (GOES, Himawari, Meteosat) are deliberately
+out of scope — their ~5-15 minute cadence makes "is there imagery
+over my AOI?" trivially yes inside any scan sector.
+
+## Algorithm
+
+```
+def search(sensor, aoi, t0, t1, *, cloud_lt=None, max_items=100):
+    cfg = SENSORS[sensor]
+    client = pystac_client.Client.open(
+        cfg.stac_endpoint,
+        modifier=planetary_computer.sign_inplace if cfg.requires_pc_signing else None,
+    )
+    items = client.search(
+        collections=[cfg.collection_id],
+        intersects=aoi.__geo_interface__,
+        datetime=f"{t0.isoformat()}/{t1.isoformat()}",
+        query={cfg.cloud_field: {"lt": cloud_lt}} if cloud_lt is not None else None,
+        max_items=max_items,
+    ).items()
+    return gpd.GeoDataFrame.from_records(
+        {
+            "id": it.id,
+            "datetime": ...,
+            "geometry": shape(it.geometry),
+            "sensor": cfg.name,
+            "cloud_cover": it.properties.get(cfg.cloud_field),
+            "preview_url": it.assets[cfg.preview_asset].href,
+        }
+        for it in items
+    )
+```
+
+One STAC call per sensor; signed `rendered_preview` hrefs let the UI
+display thumbnails without fetching pixel data.
+
+## Architecture
+
+```
+projects/satellite_viewer/
+├── src/satellite_viewer/
+│   ├── __init__.py          # exports search, SENSORS
+│   ├── sensors.py           # the SENSORS registry (5 entries)
+│   └── search.py            # the search() function above
+├── apps/
+│   ├── panel_app.py         # Panel subapp (leafmap + holoviews + tabulator)
+│   └── streamlit_app.py     # Streamlit subapp (folium + altair)
+├── notebooks/
+│   └── viewer.py            # jupytext py:percent notebook (ipywidgets + leafmap + matplotlib)
+└── tests/
+    └── test_sensors.py      # offline registry sanity checks (4 tests)
+```
+
+Repos & how they slot in:
+
+- **`pystac-client`** — STAC search and item iteration.
+- **`planetary-computer`** — signs the asset hrefs.
+- **None of jejjohnson/* yet.** v0 is deliberately library-light; the
+  later stages bring `geocatalog`, `geopatcher`, `geotoolz`, and
+  (spaceml-org's) `georeader` in turn.
+
+## Output
+
+A single `GeoDataFrame`, schema stable across sensors:
+
+```
+columns:
+  id                   : string         # STAC item id
+  datetime             : datetime[UTC]  # acquisition timestamp
+  geometry             : Polygon        # scene footprint (WGS84)
+  sensor               : string         # registry key
+  cloud_cover          : float | NaN    # eo:cloud_cover (scene-wide)
+  preview_url          : string | None  # signed rendered_preview href
+crs:  EPSG:4326
+```
+
+## UI integration
+
+Three subapps share this DataFrame as the data layer:
+
+1. **Panel** (`apps/panel_app.py`) — sidebar widgets, leafmap map,
+   holoviews timeline, FlexBox thumbnail strip, tabulator results.
+2. **Streamlit** (`apps/streamlit_app.py`) — sidebar widgets, folium
+   map with Draw plugin, altair timeline, st.columns thumbnail grid,
+   st.dataframe results.
+3. **Jupyter** (`notebooks/viewer.py`) — ipywidgets controls, leafmap
+   map with DrawControl, matplotlib timeline, ipywidgets.Image grid.
+
+All three call `satellite_viewer.search(...)` for discovery; they only
+differ in the presentation layer.
+
+## Compute budget
+
+Per request:
+
+- One STAC search per selected sensor, paginated by `max_items`
+  (default 50). ~500 ms - 3 s per sensor depending on AOI size and
+  result density.
+- No pixel reads, no downloads. Preview thumbnails are fetched
+  lazily by the UI when they render.
+- Memory: trivial (≤ a few MB of GeoDataFrame + ≤ 50 thumbnail PNGs
+  of ~30 KB each).
+
+## Risks & open questions
+
+- **STAC endpoint quirks** — `query={"eo:cloud_cover": {"lt": ...}}`
+  only filters where the field exists. SAR (S1) has no cloud_cover;
+  the search code skips the query for sensors with `cloud_field=None`.
+- **Preview asset key isn't standard.** MPC uses `rendered_preview`;
+  Earth Search uses `thumbnail`. The registry keeps this per-sensor
+  to stay portable.
+- **Date range > sensor lifetime** — the apps don't clip to per-sensor
+  availability windows (S2 starts 2015, Landsat 8 starts 2013, etc.).
+  Result is just "0 items" instead of an explicit error.
+- **Live UI smoke-test still pending** — the test suite covers the
+  registry only. Panel / Streamlit / notebook subapps haven't been
+  clicked through against live MPC yet (test plan checklist in the
+  draft PR).
+
+## Acceptance
+
+- `pixi run -e satellite-viewer test-satellite-viewer` passes (4/4
+  registry checks).
+- `ruff check` and `ruff format --check` pass on
+  `projects/satellite_viewer/`.
+- Each of the three subapps starts and renders the default Lake Tahoe
+  AOI without errors. Clicking *Search* with default Sentinel-2
+  yields scenes on the map + timeline + thumbnails.
+
+## Where v0 ends, the climatology starts
+
+v0 returns *which scenes intersect my AOI*. Three follow-on questions
+are answered by the climatology stages:
+
+- *How often **could** I have imaged here?* → v1
+- *How often **was** here imaged, and how cloudy were those scenes?*
+  → v2 (globally), already-shipped v0 (per-AOI scene-level)
+- *How often was **this exact pixel** clear?* → v2.5 (per-AOI),
+  v3 (globally)
+
+The v2.5 AOI subapp will reuse `satellite_viewer.search` verbatim for
+its discovery step — that's the v0 → v2.5 contract.
+
+## Out of scope
+
+- Pixel reads of any kind (v2.5 / v3).
+- Catalog persistence (v2 / v3 brings `geocatalog.DuckDBGeoCatalog`).
+- Cloud-free time series for a single AOI (v2.5).
+- Global cadence / coverage maps (v1 / v2 / v3).
+- Geostationary sensors (out of scope project-wide).

--- a/projects/satellite_viewer/plans/satellite_climatology/v1_analytical.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v1_analytical.md
@@ -1,3 +1,8 @@
+---
+title: "v1 — Analytical revisit climatology"
+short_title: "v1 analytical"
+---
+
 # v1 — Analytical revisit climatology
 
 > *Where on Earth, and how often, could each sensor have imaged the

--- a/projects/satellite_viewer/plans/satellite_climatology/v1_analytical.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v1_analytical.md
@@ -1,0 +1,146 @@
+# v1 — Analytical revisit climatology
+
+> *Where on Earth, and how often, could each sensor have imaged the
+> surface — independent of what's actually in the catalog?*
+
+## Goal
+
+For every pixel of a 0.1° global grid and each sensor in scope, compute
+the **theoretical overpass cadence** purely from orbit propagation +
+swath geometry. No catalog scan, no STAC, no pixel reads.
+
+## Question answered
+
+> "How many times in $[t_0, t_1]$ does a satellite with this orbit and
+> swath cross over this pixel?"
+
+Useful as:
+
+1. The **ceiling** the data-driven stages get compared against —
+   missing scenes in v2 = catalog gaps, processing failures, off-nadir
+   tasking limits, etc.
+2. A **standalone product** for users who need "max possible cadence"
+   regardless of cloud / catalog status (mission planning,
+   feasibility studies).
+
+## Scope
+
+- **Sensors**: full list from the shared README — `sentinel-2`,
+  `landsat-8-9`, `modis-terra`, `modis-aqua`, `viirs-jpss`.
+- **Time window**: configurable. Default: rolling 24 months ending now.
+- **Resolution**: 0.1° (shared default).
+- **Grid**: WGS84 regular lat/lon (shared default).
+
+## Algorithm
+
+For each sensor:
+
+1. **Acquire TLEs** for every platform in the constellation, sampled at
+   weekly cadence over the window (orbits drift; one TLE per year is
+   too coarse). Source: CelesTrak or Space-Track.
+2. **Propagate** with `skyfield` (or `sgp4`) at a fixed time step Δt
+   (60 s is fine — at 7 km/s the satellite moves ~420 km/step, finer
+   than the swath width for any of these sensors).
+3. **Project ground track + swath** onto the WGS84 grid:
+   - Compute nadir lat/lon at each step.
+   - Inflate to a cross-track swath polygon using the sensor's swath
+     width (S2: 290 km, L8/9: 185 km, MODIS: 2330 km, VIIRS: 3060 km).
+   - Rasterise the swath polygon to the grid → boolean mask of cells
+     touched at this timestep.
+4. **Tally per cell**: increment `overpasses[lat, lon, sensor, month]`
+   for every cell touched.
+5. **Gap statistics**: for each cell, derive `mean_gap_days` and
+   `p95_gap_days` from the timestamps of overpasses in that cell.
+
+## Architecture
+
+This stage is intentionally **library-light**. No `geocatalog`, no
+`geotoolz`. Single notebook + small helper module:
+
+```
+projects/satellite_climatology/
+└── src/satellite_climatology/
+    ├── grid.py        # global Zarr schema + grid helpers (shared)
+    ├── sensors.py     # platform → swath / inclination / TLE source
+    └── analytical.py  # propagate_and_rasterise(sensor, t0, t1) -> xr.Dataset
+```
+
+The one place a repo *could* be used:
+
+- **`geopatcher`** could chunk the global grid into N tiles for
+  parallel rasterisation. Useful only when you push to 0.01° or want
+  multi-node compute. **For 0.1°, skip it** — a single-process loop
+  finishes in minutes.
+
+## Output
+
+Writes these three bands of the shared Zarr:
+
+```
+overpasses             (sensor, time, lat, lon) int16
+mean_gap_days          (sensor, time, lat, lon) float32
+p95_gap_days           (sensor, time, lat, lon) float32
+```
+
+## Compute budget
+
+Per sensor:
+
+- 24 months × 30 d × 1440 min/d ≈ 1M timesteps.
+- Per timestep: rasterise one swath polygon into the global grid.
+  Vectorised numpy / shapely-prepared polygon → ~ms per step.
+- → ~15–30 min per sensor, single-process.
+- × 5 sensors = ~2 hours wall-clock on a laptop.
+
+Memory: peak ~1 GB (grid + accumulator).
+
+## UI integration
+
+The Zarr is loaded by the dashboard / notebook directly. UI controls:
+
+- Sensor dropdown (single-select)
+- Stat dropdown: `overpasses` | `mean_gap_days` | `p95_gap_days`
+- Time-window slider (start / end month)
+- Aggregation: monthly (raw) | yearly mean | window total
+
+The whole-globe raster is rendered as a tile layer (leafmap `add_raster`
+or deck.gl `BitmapLayer` after a quick TiTiler tile).
+
+## Risks & open questions
+
+- **TLE quality drift** — TLE accuracy degrades over weeks. Mitigate
+  by pulling one TLE per platform per week and using each TLE only
+  for ±3 days around its epoch.
+- **Tasked vs. nominal acquisition** — EMIT and (partly) S2 only
+  acquire over tasked targets. The "theoretical max" overstates
+  reality for these. **Document this caveat in the UI**; don't try
+  to model tasking here.
+- **Sensor decommissioning** — Landsat 7 / Aqua / Terra are end-of-life
+  and may stop acquiring during the window. Pull each platform's status
+  from CelesTrak and respect end-dates.
+- **Swath roll** — some sensors point off-nadir (SPOT, Pleiades). For
+  our list this isn't an issue (all nadir-only), so the simple
+  inflate-by-swath-width approximation is fine.
+- **Day/night** — should we count only daytime passes? Most optical
+  users want this; SAR users want both. Add a `daylight_only` band
+  (computed from sub-satellite solar zenith) so the UI can flip
+  between the two.
+
+## Acceptance
+
+- Zarr written to `data/satellite_climatology.zarr` matches the
+  schema in the shared README.
+- Sanity checks pass:
+  - Equatorial cell has S2 `overpasses` ≈ `(t1 - t0) / 5 days` (within ±20%).
+  - Polar cell has > equatorial cell for all polar-orbiting sensors.
+  - MODIS `overpasses` > S2 `overpasses` everywhere.
+- Notebook reproduces a published figure (e.g., the equator → pole
+  revisit curve for S2 from the ESA Sentinel-2 user guide).
+- UI tile layer renders without serverside compute.
+
+## Out of scope
+
+- Cloud cover (that's v2).
+- Tasked acquisition modelling (that's a research problem).
+- Sub-pixel ground sample distance — we're per-grid-cell only.
+- Pointing / agility (off-nadir constellations).

--- a/projects/satellite_viewer/plans/satellite_climatology/v2_5_pixel_level.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v2_5_pixel_level.md
@@ -1,3 +1,8 @@
+---
+title: "v2.5 — Per-AOI pixel-level cloud climatology"
+short_title: "v2.5 AOI pixel-level"
+---
+
 # v2.5 — Per-AOI pixel-level cloud climatology
 
 > *Given an AOI (point with radius, polygon, or bbox up to ~50 km), use

--- a/projects/satellite_viewer/plans/satellite_climatology/v2_5_pixel_level.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v2_5_pixel_level.md
@@ -1,0 +1,200 @@
+# v2.5 — Per-AOI pixel-level cloud climatology
+
+> *Given an AOI (point with radius, polygon, or bbox up to ~50 km), use
+> the actual QA bands of every intersecting scene to compute the
+> truthful clear-fraction time series — on demand, in seconds.*
+
+This is the **single-AOI, on-demand** version of the pixel-level problem.
+It shares the AOI flow with `satellite_viewer` (the same input shape —
+draw a polygon, pick a sensor, pick a date range) but the output is the
+**clear-fraction climatology** for that AOI, not a thumbnail preview.
+
+## Goal
+
+For one user-supplied AOI and time window:
+
+1. Discover intersecting scenes (reuse `satellite_viewer.search`).
+2. For each scene, lazily read the QA band windowed to the AOI via
+   `georeader`.
+3. Decode the QA band to a per-pixel clear mask using a per-sensor
+   decoder.
+4. Reduce the mask to a single number: **clear-pixel fraction** inside
+   the AOI for this acquisition.
+5. Return the (datetime, clear_fraction, scene_id) time series plus
+   aggregates (`clear_obs_count`, `mean_clear_fraction`,
+   `longest_clear_gap_days`).
+
+## Question answered
+
+> "Across all scenes that touched this AOI in $[t_0, t_1]$, what
+> fraction of the AOI's pixels were *actually* clear in each scene, and
+> what does the resulting clear-fraction time series look like?"
+
+Validates v3's algorithm at user-facing scale before committing to the
+global compute. Also a **standalone product**: ecologists, agronomists,
+plume hunters all care about "how often can I see this specific field /
+hotspot / region clearly?" — exactly the v2.5 deliverable.
+
+## Scope
+
+- **AOI**: single shapely geometry, **size-capped** (default 50 km bbox
+  side; user knob). Above the cap the dashboard refuses the request
+  with a "use v3 / batch mode" hint.
+- **Sensors**: starts with `sentinel-2-l2a` (SCL band). Add
+  `landsat-c2-l2` (QA_PIXEL) next. MODIS / VIIRS deferred.
+- **Time window**: user-supplied. Multi-year is fine — the work is
+  proportional to scenes, not to area.
+- **Compute target**: 1–30 s per request on a laptop / single
+  notebook server.
+
+## Algorithm
+
+```
+1. items = satellite_viewer.search(sensor, aoi, t0, t1, cloud_lt=None, max_items=1000)
+2. for item in items:                                 # → parallelisable
+       qa = georeader.read_window(item.assets[qa_band_key], aoi)
+       clear_mask = decoder(qa, clear_classes=cfg.clear_classes)
+       clear_frac = clear_mask.mean()                 # float in [0, 1]
+       record (item.datetime, item.id, clear_frac)
+3. emit:
+   - per-scene time series: [(datetime, scene_id, clear_frac, eo:cloud_cover)]
+   - aggregates: clear_obs_count = sum(frac > clear_threshold),
+                 mean_clear_fraction = mean(frac),
+                 longest_clear_gap_days = max(gap between frac > threshold)
+```
+
+The per-item work is the same code that v3 will run in its inner loop —
+the abstraction split is "v2.5 = one AOI, run interactively" vs.
+"v3 = every cell of the global grid, run as a batch."
+
+## Architecture
+
+```
+projects/satellite_climatology/
+└── src/satellite_climatology/
+    ├── grid.py             # (shared with v1/v2/v3) — not used by v2.5
+    ├── sensors.py          # (shared) — adds qa_band_key, clear_classes per sensor
+    ├── qa_decoders/        # (shared with v3)
+    │   ├── s2_scl.py
+    │   ├── landsat_qapixel.py
+    │   └── modis_state1km.py
+    ├── operators.py        # (shared with v3) — ReadQA, DecodeQA, CellClearFrac
+    └── aoi_pipeline.py     # the v2.5 entry point — runs the per-scene op over an AOI
+```
+
+Repo wiring:
+
+- **`satellite_viewer.search`** — reused unchanged for discovery. The
+  same `(sensor, aoi, t0, t1) -> GeoDataFrame[id, datetime, geometry, …]`
+  surface is what v2.5 consumes.
+- **`geotoolz`** holds the per-scene pipeline as a serialisable
+  `Operator` graph:
+  ```
+  per_scene = (
+      ResolveAsset(asset_key=cfg.qa_band)        # item -> signed COG URL
+      | ReadQA(reader="georeader", window=aoi)    # URL -> ndarray
+      | DecodeQA(decoder=cfg.qa_decoder, clear_classes=cfg.clear_classes)
+      | CellClearFrac()                           # ndarray -> float in [0, 1]
+  )
+  ```
+  The same graph is reused in v3. `get_config()` serialises the whole
+  thing so the v3 batch job and the v2.5 interactive call produce
+  bit-identical numbers.
+- **`georeader`** is the heavy lifting: lazy windowed reads of the
+  COG / HDF / Zarr asset, clipped to the AOI bbox at the asset's CRS,
+  no full-scene download.
+- **`geocatalog`** is **not** used at v2.5 scale — we don't need a
+  persistent index for a single AOI's worth of items. v3 brings it
+  back when the catalog scan goes global.
+- **`geopatcher`** is **not** used at v2.5 (single AOI, no tiling).
+  v3 brings it back.
+
+## Output
+
+A pandas DataFrame, not a Zarr band:
+
+```
+columns: ["datetime", "scene_id", "sensor", "scene_cloud_pct", "clear_fraction"]
+shape:   (n_scenes, 5)
+index:   reset
+crs:     no geometry (the AOI is shared across rows)
+```
+
+Plus the three scalar aggregates returned alongside.
+
+## UI integration
+
+A new tab in the `satellite_viewer` dashboard, or a sibling subapp.
+Same AOI input shape as the preview tool. Output panes:
+
+1. **Clear-fraction time series** — scatter or line of `clear_fraction`
+   vs. `datetime`, colour-coded by sensor.
+2. **Climatology stats card** — `clear_obs_count`, `mean_clear_fraction`,
+   `longest_clear_gap_days`, `n_scenes`.
+3. **Side-by-side scenes** — for each acquisition, RGB thumbnail (from
+   STAC `rendered_preview`, reused from `satellite_viewer`) next to the
+   QA-derived clear mask preview at AOI scale.
+4. **Comparison with scene-level** — overlay `eo:cloud_cover` (the v2
+   answer) vs. `1 − clear_fraction` (the v2.5 answer). Where they
+   diverge is the entire point of v2.5.
+
+## Compute budget
+
+Per AOI, default 50 km bbox cap:
+
+- 1 year of S2 over a 50 km AOI ≈ 50–150 items.
+- Per item: one windowed COG read of the SCL band, AOI-clipped → ~50
+  KB to ~5 MB raw bytes, dominated by TCP / TLS / signing.
+- → ~100 items × 100–300 ms (parallelised with `asyncio` / thread
+  pool) = **3–10 s wall-clock**.
+- Memory: peak ~50 MB for the largest single SCL window.
+
+This is the dashboard-tractable target. Above the size cap or beyond
+~5-year windows the user gets routed to v3.
+
+## Risks & open questions
+
+- **Per-sensor QA decoder is real work** — S2 SCL is the easiest (single
+  class enum, well-documented). Landsat QA_PIXEL is bit-packed.
+  MODIS state_1km is bit-packed and version-dependent. **Ship S2 only
+  for M5.**
+- **"Clear" definition is a user knob.** Default for S2 SCL: classes
+  {4, 5, 6, 11} (veg, bare, water, snow) treated as clear; {3, 8, 9, 10}
+  (shadow, cloud_med, cloud_high, thin_cirrus) treated as not clear;
+  {7} (unclassified) treated as not clear by default. Expose
+  `clear_classes` in the dashboard so users can flip e.g. snow on/off.
+- **CRS handling** — S2 SCL is per-MGRS-tile UTM; AOI is EPSG:4326.
+  Reprojection on read (or AOI reprojection to the item's CRS) is
+  `georeader`'s job. Verify it does the right thing for a multi-tile
+  AOI in M5's first day.
+- **AOI larger than one MGRS tile** — request is split into per-tile
+  reads, merged at AOI scale. `georeader` already handles this for
+  S2; verify and bench.
+- **Out-of-MGRS AOIs** (e.g., polar > 80°) need explicit handling
+  since S2 doesn't tile there. Just exclude with a clear error.
+- **Async vs. thread pool** — `georeader`'s API is sync (last I
+  checked). Wrap with `concurrent.futures.ThreadPoolExecutor` for
+  per-scene parallelism. Re-evaluate if `georeader` adds an async API.
+
+## Acceptance
+
+- Single notebook + Panel/Streamlit subapp answering "draw an AOI,
+  pick a date range, get a clear-fraction time series" in < 15 s for
+  the default 50 km × 1 year case.
+- Sanity:
+  - `clear_fraction` ≤ 1 in every row.
+  - For cells fully inside a single scene of low `eo:cloud_cover`:
+    `clear_fraction ≈ 1 − eo:cloud_cover / 100` (within ~10%).
+  - For cells inside the cloudy half of a heterogeneous scene:
+    `clear_fraction` ≪ `1 − eo:cloud_cover / 100` (the *point* of v2.5).
+- The per-scene operator graph runs unchanged in a v3 prototype over
+  a 1° × 1° patch (same numbers as the dashboard).
+
+## Out of scope
+
+- Global compute (that's v3).
+- Multi-sensor fusion (different sensors have different "clear"
+  semantics; defer until each sensor's decoder ships).
+- Atmospheric correction quality flags (only "clear or not").
+- Sub-pixel cloud masking — we accept the QA band's spatial resolution.
+- Real-time / incremental updates — every request re-fetches.

--- a/projects/satellite_viewer/plans/satellite_climatology/v2_data_driven_scene_level.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v2_data_driven_scene_level.md
@@ -1,0 +1,226 @@
+# v2 — Data-driven, scene-level cloud climatology
+
+> *Of the scenes that were actually acquired and ingested into the
+> Planetary Computer / Earth Search catalogs, how many cover each
+> pixel and what was their scene-wide cloud cover?*
+
+## Goal
+
+For every pixel of the shared 0.1° global grid and each sensor, scan
+the real STAC catalog and aggregate per-cell statistics from the
+**item metadata** (footprint + `eo:cloud_cover` + datetime). No pixel
+reads — this stage stays in metadata-land.
+
+## Question answered
+
+> "Given the catalog as it actually exists, how many scenes covered
+> this pixel in $[t_0, t_1]$, and what fraction were nominally
+> cloud-free at the scene level?"
+
+The user-facing pitch is the **"reality gap" map**: subtract v2's
+`scenes_count` from v1's `overpasses` and you visualise where the
+catalog is incomplete vs. theoretical max — useful for spotting
+processing-pipeline outages, off-nadir tasking effects, or regions
+where a sensor is simply not acquired (e.g., open ocean for L8/9
+WRS-2 land grid).
+
+## Scope
+
+- **Sensors**: same five as v1, but each maps to one or more STAC
+  collections (e.g., `sentinel-2-l2a` for sentinel-2).
+- **Time window**: configurable. Default: rolling 12 months. Longer
+  is feasible (24 → 36 months) but linearly more compute.
+- **Resolution**: 0.1° (shared). H3 res-5 alternative discussed below.
+- **STAC source**: Microsoft Planetary Computer (anonymous, no auth)
+  for all five sensors. Element84 Earth Search as a fallback.
+
+## Algorithm
+
+Two-pass design — neither pass queries per cell:
+
+### Pass 1 — catalog ingestion
+
+For each sensor's collection:
+
+1. Issue a **paginated STAC search** over the global bbox + time
+   window with no spatial filter (or a coarse one to chunk).
+2. Stream items into a **DuckDB-backed GeoCatalog** (`geocatalog`'s
+   `DuckDBGeoCatalog` — GeoParquet 1.1 with bbox-column predicate
+   pushdown). Persists as `data/catalogs/<sensor>.parquet`.
+3. Item attributes kept: `id`, `datetime`, `geometry` (footprint),
+   `eo:cloud_cover`, `platform`.
+
+Why DuckDB and not InMemory: 1 year of S2 over the globe is ~1M items.
+DuckDB handles this on a laptop; an InMemory GeoDataFrame doesn't.
+
+### Pass 2 — per-cell aggregation
+
+The key insight is **inverting the loop**. Don't iterate cells and
+query the catalog. Iterate **items** and stamp them into cells:
+
+1. For each item, compute the set of grid cells its footprint
+   intersects (rasterise the footprint polygon onto the 0.1° grid).
+2. For each cell, push the item's `(datetime, eo:cloud_cover)` into
+   that cell's accumulator.
+3. After all items: each cell's accumulator yields:
+   - `scenes_count` = `len(items)`
+   - `mean_scene_cloud_pct` = `mean(item.cloud_cover for item in items)`
+   - `cloud_free_scene_count` = `sum(c < 10 for c in cloud_covers)`
+   - `max_gap_days` = `max(diff(sorted(datetimes)))`
+
+Either pass can be windowed by `geopatcher` to keep memory bounded:
+process the global grid in N-cell tiles, aggregate per-tile, concat.
+
+## Architecture
+
+This is where your repo stack lights up:
+
+```
+projects/satellite_climatology/
+└── src/satellite_climatology/
+    ├── grid.py             # (shared with v1)
+    ├── sensors.py          # (shared with v1) + STAC collection mapping
+    ├── catalog.py          # build_global_catalog(sensor, t0, t1) -> DuckDBGeoCatalog
+    ├── aggregate.py        # bin items into cells -> per-cell stats
+    └── operators.py        # geotoolz Operators wrapping the reducers
+```
+
+Repo wiring:
+
+- **`geocatalog`** is the substrate.
+  - `from_stac_search(STACSource(...))` ingests the items into a
+    `DuckDBGeoCatalog` per sensor.
+  - The catalog persists between runs (it's GeoParquet on disk), so
+    re-aggregating with different thresholds is free.
+
+- **`geopatcher`** drives the grid iteration.
+  - `SpatialPatcher(SpatialRectangular(size=(0.1°, 0.1°)),
+    SpatialRegularStride(...))` over a `RasterField` covering the
+    global bbox.
+  - Per-tile (not per-cell) work is run via `runners.parallel_map`
+    across processes.
+
+- **`geotoolz`** holds the reducer as a composable graph:
+  ```
+  per_cell = (
+      Fanout({
+          "scenes_count":           Count(),
+          "mean_scene_cloud_pct":   Mean(field="cloud_cover"),
+          "cloud_free_scene_count": CountWhere(field="cloud_cover", op="<", value=10),
+          "max_gap_days":           MaxGap(field="datetime"),
+      })
+  )
+  ```
+  The `Fanout` shape means one item-iteration computes all four stats;
+  `get_config()` serialises the reducer for the run manifest.
+
+- **`georeader`** is **not** used in v2. (That's v2.5.)
+
+## Output
+
+Adds these four bands to the shared Zarr:
+
+```
+scenes_count           (sensor, time, lat, lon) int16
+mean_scene_cloud_pct   (sensor, time, lat, lon) float32
+cloud_free_scene_count (sensor, time, lat, lon) int16
+max_gap_days           (sensor, time, lat, lon) float32
+```
+
+Same grid as v1, so:
+
+```python
+ds = xr.open_zarr("data/satellite_climatology.zarr")
+gap_v1 = ds["overpasses"]                    # theoretical
+got_v2 = ds["scenes_count"]                  # observed
+catalog_gap = (gap_v1 - got_v2).clip(min=0)  # the "reality gap" map
+```
+
+## Compute budget
+
+Pass 1 (catalog scan):
+
+- S2 1 yr globally: ~1M items, MPC paginated search at ~500 items/page
+  → ~2000 paginated requests, ~30 min wall-clock (mostly network).
+- × 5 sensors with very different volumes: MODIS daily × 8 platforms
+  is the heaviest at ~10M items/yr.
+- → ~2–6 hours total. Run once, persist.
+
+Pass 2 (aggregation):
+
+- 1M items × ~100 cells/item = ~100M (cell, item) stamps.
+- Vectorised by tile, this is ~5–15 min per sensor on a laptop.
+- Parallelised over patches: linearly faster.
+
+Storage:
+
+- Per-sensor GeoParquet catalogs: a few GB total.
+- Output Zarr (with v1+v2 bands, 5 sensors, 12 months): ~2–3 GB.
+
+## UI integration
+
+Adds new stats to the dashboard dropdown:
+
+- `scenes_count` — observed catalog density
+- `cloud_free_scene_count` — observed cloud-free density
+- `mean_scene_cloud_pct` — observed mean cloud
+- `max_gap_days` — longest dry spell
+- `reality_gap` = v1.overpasses − v2.scenes_count — derived band
+
+Same tile-server approach as v1.
+
+## H3 alternative (equal-area)
+
+For latitudes > 60° the 0.1° lat/lon cell shrinks to ~5 km width while
+staying 11 km tall — heavy distortion. If equal-area matters
+(area-weighted statistics, comparing high vs low latitudes):
+
+- Replace the grid with **H3 hex bins at resolution 5** (~250 km² each,
+  ~2.0M cells globally).
+- All `geopatcher`-iteration logic is the same; replace
+  `SpatialRectangular` with a `PolygonIntersection` geometry over the
+  H3 polygon set.
+- Zarr → Parquet (`pandas` with H3 index column), or sparse Zarr.
+
+Decide this at M3 once we see the latitude-distortion in the v1 maps.
+
+## Risks & open questions
+
+- **Catalog completeness varies by sensor.** MPC's Landsat goes back
+  to 2013, MODIS to 2000+, S2 to 2015. The product window must be
+  clipped per-sensor or padded with nulls.
+- **`eo:cloud_cover` is scene-wide.** A 60%-cloud scene can be 100%
+  clear over your pixel (or vice versa). v2 is documented as a
+  *scene-level* statistic; v2.5 is the per-pixel answer.
+- **Footprints aren't pixel-exact** — STAC item geometry is the scene
+  outline, which can be slightly larger than actual valid-data extent
+  (especially S2 swath edges). Acceptable for cell-scale stats.
+- **Re-ingestion drift** — collections get reprocessed (new baseline,
+  republished items). Pin the run date and store it in the Zarr
+  metadata so users know what catalog snapshot they're looking at.
+- **Rate limits** — MPC is generous but not infinite. Throttle the
+  scan with `pystac-client`'s `max_items` per call + a backoff
+  decorator.
+
+## Acceptance
+
+- All four data vars are written for at least one sensor over a
+  12-month window at 0.1°.
+- Sanity checks:
+  - `scenes_count` ≤ v1 `overpasses` cell-wise (catalog ≤ theoretical).
+  - `mean_scene_cloud_pct` map qualitatively matches a published cloud
+    climatology (e.g., MODIS MOD08 monthly mean) — wet-season Amazonas
+    > Atacama Desert.
+  - `cloud_free_scene_count` is zero for cells with `scenes_count = 0`.
+- Catalog Parquet files are reproducible (re-running the pipeline
+  yields the same row count given the same date pin).
+- Reality-gap map renders in the dashboard.
+
+## Out of scope
+
+- Per-pixel cloud masks (v2.5).
+- L1C / L2A choice — we use L2A everywhere it exists; document the
+  collection per sensor in `sensors.py`.
+- Off-nadir tasking modelling.
+- Sub-monthly time bins. (Easy to add later — the schema supports it,
+  just blow up the time axis.)

--- a/projects/satellite_viewer/plans/satellite_climatology/v2_data_driven_scene_level.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v2_data_driven_scene_level.md
@@ -1,3 +1,8 @@
+---
+title: "v2 — Data-driven, scene-level cloud climatology"
+short_title: "v2 scene-level"
+---
+
 # v2 — Data-driven, scene-level cloud climatology
 
 > *Of the scenes that were actually acquired and ingested into the

--- a/projects/satellite_viewer/plans/satellite_climatology/v3_pixel_level_global.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v3_pixel_level_global.md
@@ -1,3 +1,8 @@
+---
+title: "v3 — Global pixel-level cloud climatology"
+short_title: "v3 global pixel-level"
+---
+
 # v3 — Global pixel-level cloud climatology
 
 > *v2.5's per-AOI clear-fraction algorithm, batched over the whole

--- a/projects/satellite_viewer/plans/satellite_climatology/v3_pixel_level_global.md
+++ b/projects/satellite_viewer/plans/satellite_climatology/v3_pixel_level_global.md
@@ -1,0 +1,228 @@
+# v3 — Global pixel-level cloud climatology
+
+> *v2.5's per-AOI clear-fraction algorithm, batched over the whole
+> globe and written into the shared Zarr.*
+
+This is the capstone: the same per-scene operator graph from v2.5
+applied to every cell of the global 0.1° grid for every scene in v2's
+catalog, producing the truthful per-pixel clear-observation statistics
+at planetary scale.
+
+## Goal
+
+For every cell of the shared 0.1° global grid, each sensor, and each
+monthly time bin, compute the **true pixel-level clear-observation
+statistics** by reading each intersecting scene's QA band, masking to
+clear pixels, and aggregating into the cell.
+
+## Question answered
+
+> "How often was the surface inside this exact cell *actually* visible
+> to the sensor over $[t_0, t_1]$?"
+
+The truthful version of v2's question, answered globally. The
+v2-vs-v3 difference map is the headline product: it shows where
+scene-level cloud is a *biased* estimate of pixel-level
+observability — coastal, mountain, partly-cloudy regions.
+
+## Scope
+
+- **Sensors**: subset of v2. Start with `sentinel-2` (validated by
+  v2.5 first). Add `landsat-8-9` once its v2.5 decoder ships.
+  MODIS / VIIRS deferred to v3.1.
+- **Time window**: same as v2 by default (12 months rolling). Longer
+  is feasible but linearly more compute.
+- **Resolution**: 0.1° (shared default). Coarser is an easy first run.
+- **Compute target**: batch job. Single laptop is feasible only for
+  continental subsets at coarser grid; full global × all-sensors
+  needs a cluster.
+
+## Algorithm
+
+The same `per_scene` operator graph from v2.5, run with the loop
+inverted to keep compute tractable:
+
+```
+1. For each (sensor, time_bin):
+     items = v2_catalog.query(global_bbox, time_bin)
+2. For each item (in parallel across workers):
+     qa_band = georeader.read_full(item.assets[qa_band_key])   # one full SCL/QA read
+     clear_pixel_mask = decoder(qa_band, clear_classes=cfg.clear_classes)
+     # Reduce to grid cells immediately — don't accumulate full-res masks.
+     cells_touched = footprint_to_cells(item.geometry, grid_resolution=0.1°)
+     for cell in cells_touched:
+         window = clear_pixel_mask.window(cell)                # ~10×10 pixels at 0.1°
+         emit (cell, item.datetime, window.mean())             # one float per (cell, item)
+3. For each cell, aggregate the per-item floats:
+     clear_obs_count    = sum(frac > clear_threshold)
+     clear_fraction     = mean(frac)
+     pixel_max_gap_days = max(gap between frac > threshold)
+4. Write into shared Zarr at (sensor, time, lat, lon).
+```
+
+**Why loop-inversion is essential**: the alternative ("for each cell,
+loop over items") opens each scene N times (N = cells per scene ~ 100).
+Inversion opens each scene **once**. Same total work, 100× less I/O.
+
+## Architecture
+
+```
+projects/satellite_climatology/
+└── src/satellite_climatology/
+    ├── grid.py             # (shared)
+    ├── sensors.py          # (shared)
+    ├── qa_decoders/        # (shared with v2.5)
+    ├── operators.py        # (shared with v2.5) — the same per_scene graph
+    ├── catalog.py          # (shared with v2) — DuckDBGeoCatalog scan
+    ├── aggregate.py        # (extends v2) — bin per-item clear floats into cells
+    └── global_pipeline.py  # the v3 entry point — runs the inverted loop
+```
+
+The four-repo capstone in one diagram:
+
+```
+            +---- DuckDBGeoCatalog (geocatalog) ----+
+            | one row per STAC item                  |
+            | bbox + datetime + asset hrefs          |
+            +---------------------------------------+
+                          |
+                          v
+            +---- geopatcher.SpatialPatcher ---------+
+            | iterates monthly batches of items      |
+            | (parallelisation unit = N items)       |
+            +---------------------------------------+
+                          |
+                          v
+            +---- geotoolz Operator graph -----------+   <- IDENTICAL to v2.5
+            | ResolveAsset                           |
+            | | ReadQA(reader="georeader")  <-+      |
+            | | DecodeQA(decoder=...)        |      |  georeader does the
+            | | CellClearFrac (per-cell mean)|      |  windowed read
+            +--------------------------------|------+
+                          |                  |
+                          v                  v
+            +---- accumulator (xarray Zarr) --------+
+            | bands: clear_obs_count, clear_frac,   |
+            |        pixel_max_gap_days             |
+            +---------------------------------------+
+```
+
+## Output
+
+Writes the last three bands of the shared Zarr:
+
+```
+clear_obs_count        (sensor, time, lat, lon) int16
+clear_fraction         (sensor, time, lat, lon) float32
+pixel_max_gap_days     (sensor, time, lat, lon) float32
+```
+
+After v3 the Zarr is complete and the dashboard shows the full ten-band
+set, including the v2-vs-v3 difference map.
+
+## Compute budget
+
+Per S2 item (the worst case):
+
+- SCL band is 20 m, single 109×109 km scene = ~5500×5500 pixels =
+  60 MB uncompressed (12 MB after COG-deflate).
+- Read full SCL via `georeader`: ~5–15 s per scene (network-bound).
+- Decode + per-cell reduce: ~1–2 s.
+- → ~10 s/scene wall-clock.
+- 1 year of S2 globally ≈ 1M scenes.
+- **3000 CPU-hours / year of S2.**
+
+Sized down:
+
+- 0.5° grid × 1 year × S2 only × CONUS: ~50k scenes × 10 s ÷ 32
+  workers = ~4 hours. **Laptop-tractable.**
+- 0.1° grid × 1 year × S2 only × CONUS: same scenes, same per-scene
+  cost (resolution doesn't change the read). ~4 hours.
+- 0.1° grid × 1 year × S2 only × global: ~3000 worker-hours →
+  ~4 days on 32-worker cluster, ~half-day on 256-worker.
+
+Memory: per-worker peak is one SCL band read (~150 MB live). Trivial.
+
+Storage:
+
+- Output Zarr (all ten bands, 5 sensors, 12 months, 0.1°): ~3 GB.
+- Intermediate (per-scene clear-frac records): ~1 KB/scene × 1M
+  scenes = ~1 GB per sensor-year.
+
+## Sizing path
+
+1. **M6.1** — single sensor (S2), continental AOI (CONUS), 0.5° grid,
+   1 year. Validates the pipeline end-to-end. Laptop-tractable.
+2. **M6.2** — S2 only, CONUS, 0.1° grid, 1 year. Same scenes, finer
+   binning.
+3. **M6.3** — S2 only, **global**, 0.1° grid, 1 year. First cluster
+   job. Decide on infra (Azure Batch, Dask cluster, etc.).
+4. **M6.4** — Add Landsat 8/9.
+5. **M6.5** — Add MODIS / VIIRS once their decoders ship.
+
+Ship the dashboard with v2 + v2.5 at M5; v3 progressively fills in the
+global pixel-level bands as each milestone completes.
+
+## UI integration
+
+The v3 Zarr is rendered as additional tile layers in the same
+dashboard from v1/v2. New dropdowns:
+
+- `clear_obs_count` — observed pixel-clear scene count
+- `clear_fraction` — the headline pixel-level cloud-free fraction
+- `pixel_max_gap_days` — longest "no clear look" interval
+- `scene_vs_pixel_diff` = `v2.cloud_free_scene_count` −
+  `v3.clear_obs_count` — derived band; the v2/v3 disagreement map
+
+The v2.5 AOI tab is unchanged — it remains the user-facing "drill
+into a single AOI" tool, with v3 being its global archive.
+
+## Risks & open questions
+
+- **Compute is the headline risk.** Loop inversion is non-negotiable.
+  Even with it, going global × all-sensors needs a cluster. Decide
+  infra at M6.3 start.
+- **`georeader` performance at scale** — micro-bench at M6.1 against
+  `rioxarray` / `odc-stac` / direct rasterio with explicit windowed
+  reads. If the API doesn't expose batched async reads, swap in
+  whichever does — the `Operator` abstraction makes this transparent.
+- **Re-runs are expensive.** Pin the catalog snapshot date in the
+  Zarr metadata. Re-runs are full re-runs; incremental update is
+  v3.1.
+- **MGRS edge effects** — S2 scenes overlap their tile neighbours by
+  ~10 km. A given cell near an MGRS edge can appear in 2–4 scenes
+  per overpass. Double-counting? Not really: each is an independent
+  observation and clear-fraction averages over them. Document the
+  semantics so users know.
+- **HDF reads for MODIS** — MODIS QA lives inside MOD09GA HDFs, not
+  COGs. Separate `georeader` adapter or fallback to `pyhdf` /
+  `h5py` + grid lookup. Defer to v3.1.
+- **Cost** — if the cluster is on Azure (same region as MPC),
+  egress is free and S2 reads are cheap (< $100 for 1 year × global).
+  Cross-region or cross-cloud will dominate the bill.
+
+## Acceptance
+
+- All three pixel-level bands populated for at least Sentinel-2 over
+  a 12-month window at 0.1° globally, written into the shared Zarr.
+- Sanity (continues from v2.5):
+  - `clear_obs_count` ≤ `v2.scenes_count` cell-wise (clear ≤ total).
+  - `clear_fraction` map qualitatively matches MODIS MOD09CMG annual
+    cloud-fraction climatology.
+  - For a random sample of cells, the v3 Zarr value at the cell
+    centre matches the v2.5 dashboard answer for an AOI = the
+    cell polygon (within 2% — the only source of difference is
+    binning).
+- The v2-vs-v3 difference map renders in the dashboard and matches
+  intuition (coastal / mountain / monsoon regions are the largest
+  disagreement).
+- Pipeline is reproducible from the run manifest
+  (`get_config()` of every operator + the catalog-snapshot date).
+
+## Out of scope
+
+- Real-time / incremental updates — batch only.
+- Adaptive resolution (denser grid where it matters) — uniform 0.1°.
+- ML-based gap-filling — we report the raw observations.
+- Atmospheric / BRDF correction quality flags.
+- Above-MGRS-extent polar coverage for S2 (data simply doesn't exist).

--- a/projects/satellite_viewer/pyproject.toml
+++ b/projects/satellite_viewer/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "satellite_viewer"
 version = "0.1.0"
-description = "Preview intersecting satellite imagery (Sentinel, Landsat, MODIS, EMIT) for an AOI before downloading. Shared core + two subapps (Panel + Jupyter)."
+description = "Preview intersecting satellite imagery (Sentinel, Landsat, MODIS, EMIT) for an AOI before downloading. Shared core + three subapps (Panel + Streamlit + Jupyter)."
 requires-python = ">=3.12"
 
 dependencies = [
@@ -25,6 +25,7 @@ panel = [
     "panel>=1.5",
     "leafmap>=0.40",
     "ipyleaflet>=0.19",
+    "ipywidgets>=8",
     "hvplot>=0.10",
     "bokeh>=3.5",
 ]

--- a/projects/satellite_viewer/pyproject.toml
+++ b/projects/satellite_viewer/pyproject.toml
@@ -1,0 +1,58 @@
+[project]
+name = "satellite_viewer"
+version = "0.1.0"
+description = "Preview intersecting satellite imagery (Sentinel, Landsat, MODIS, EMIT) for an AOI before downloading. Shared core + two subapps (Panel + Jupyter)."
+requires-python = ">=3.12"
+
+dependencies = [
+    # STAC discovery + signed asset hrefs.
+    "pystac-client>=0.8",
+    "planetary-computer>=1.0",
+    # Vector + spatial.
+    "geopandas>=0.14",
+    "shapely>=2",
+    "pyproj>=3.6",
+    # Plotting / dataframes.
+    "pandas>=2.2",
+    "matplotlib>=3.10",
+    # Network.
+    "requests>=2.31",
+]
+
+[project.optional-dependencies]
+# Panel subapp.
+panel = [
+    "panel>=1.5",
+    "leafmap>=0.40",
+    "ipyleaflet>=0.19",
+    "hvplot>=0.10",
+    "bokeh>=3.5",
+]
+# Notebook subapp.
+notebook = [
+    "leafmap>=0.40",
+    "ipyleaflet>=0.19",
+    "ipywidgets>=8",
+    "ipykernel>=6.29",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/satellite_viewer"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v"
+markers = [
+    "slow: marks tests that hit live external APIs (STAC, S3); skip with -m 'not slow'",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::UserWarning",
+]

--- a/projects/satellite_viewer/pyproject.toml
+++ b/projects/satellite_viewer/pyproject.toml
@@ -35,6 +35,13 @@ notebook = [
     "ipywidgets>=8",
     "ipykernel>=6.29",
 ]
+# Streamlit subapp.
+streamlit = [
+    "streamlit>=1.40",
+    "streamlit-folium>=0.22",
+    "folium>=0.17",
+    "altair>=5",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/projects/satellite_viewer/src/satellite_viewer/__init__.py
+++ b/projects/satellite_viewer/src/satellite_viewer/__init__.py
@@ -1,0 +1,16 @@
+"""Preview intersecting satellite imagery before download.
+
+Public surface:
+
+- `SENSORS` — registry of every supported sensor.
+- `search(...)` — sensor-agnostic AOI x time-range query returning a
+  GeoDataFrame of hits (one row per scene/granule).
+"""
+
+from __future__ import annotations
+
+from satellite_viewer.search import search
+from satellite_viewer.sensors import SENSORS, SensorConfig
+
+
+__all__ = ["SENSORS", "SensorConfig", "search"]

--- a/projects/satellite_viewer/src/satellite_viewer/search.py
+++ b/projects/satellite_viewer/src/satellite_viewer/search.py
@@ -1,0 +1,116 @@
+"""Sensor-agnostic discovery: AOI x date-range -> GeoDataFrame of hits.
+
+One row per scene/granule. Columns:
+
+| col            | dtype     | notes                                   |
+|----------------|-----------|-----------------------------------------|
+| `id`           | string    | STAC item id                            |
+| `datetime`     | tz-aware  | acquisition timestamp                   |
+| `geometry`     | geometry  | scene footprint                         |
+| `sensor`       | string    | sensor name from the registry           |
+| `cloud_cover`  | float     | percent 0-100, or NaN                   |
+| `preview_url`  | string    | signed thumbnail URL, or None           |
+
+Delegates to `pystac-client` and signs preview hrefs with
+`planetary-computer` when the registry says so.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import shape
+from shapely.geometry.base import BaseGeometry
+
+from satellite_viewer.sensors import SENSORS, SensorConfig
+
+
+def search(
+    sensor: str,
+    aoi: BaseGeometry,
+    start: datetime,
+    end: datetime,
+    *,
+    max_items: int = 100,
+    cloud_lt: float | None = None,
+) -> gpd.GeoDataFrame:
+    """Return scenes / granules of `sensor` intersecting `aoi` between dates."""
+
+    if sensor not in SENSORS:
+        raise KeyError(f"unknown sensor {sensor!r}; known: {sorted(SENSORS)}")
+    cfg = SENSORS[sensor]
+    return _stac_search(cfg, aoi, start, end, max_items, cloud_lt)
+
+
+def _stac_search(
+    cfg: SensorConfig,
+    aoi: BaseGeometry,
+    start: datetime,
+    end: datetime,
+    max_items: int,
+    cloud_lt: float | None,
+) -> gpd.GeoDataFrame:
+    # Heavy imports kept lazy so `import satellite_viewer` stays cheap.
+    import planetary_computer
+    import pystac_client
+
+    modifier = planetary_computer.sign_inplace if cfg.requires_pc_signing else None
+    client = pystac_client.Client.open(cfg.stac_endpoint, modifier=modifier)
+
+    query: dict[str, Any] | None = None
+    if cloud_lt is not None and cfg.cloud_field is not None:
+        query = {cfg.cloud_field: {"lt": cloud_lt}}
+
+    stac_search = client.search(
+        collections=[cfg.collection_id],
+        intersects=aoi.__geo_interface__,
+        datetime=f"{start.isoformat()}/{end.isoformat()}",
+        max_items=max_items,
+        query=query,
+    )
+
+    rows: list[dict] = []
+    for item in stac_search.items():
+        preview_url: str | None = None
+        if cfg.preview_asset and cfg.preview_asset in item.assets:
+            preview_url = item.assets[cfg.preview_asset].href
+
+        cloud: float | None = None
+        if cfg.cloud_field is not None:
+            cloud = item.properties.get(cfg.cloud_field)
+
+        ts = pd.Timestamp(item.datetime)
+        ts = ts.tz_localize("UTC") if ts.tzinfo is None else ts.tz_convert("UTC")
+
+        rows.append(
+            {
+                "id": item.id,
+                "datetime": ts,
+                "geometry": shape(item.geometry),
+                "sensor": cfg.name,
+                "cloud_cover": cloud,
+                "preview_url": preview_url,
+            }
+        )
+
+    if not rows:
+        return _empty_gdf()
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:4326")
+
+
+def _empty_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "id": pd.Series(dtype="string"),
+            "datetime": pd.Series(dtype="datetime64[ns, UTC]"),
+            "geometry": gpd.GeoSeries([], crs="EPSG:4326"),
+            "sensor": pd.Series(dtype="string"),
+            "cloud_cover": pd.Series(dtype="float64"),
+            "preview_url": pd.Series(dtype="string"),
+        },
+        geometry="geometry",
+        crs="EPSG:4326",
+    )

--- a/projects/satellite_viewer/src/satellite_viewer/sensors.py
+++ b/projects/satellite_viewer/src/satellite_viewer/sensors.py
@@ -1,0 +1,85 @@
+"""Sensor registry.
+
+Each entry maps a short user-facing key (`"sentinel-2-l2a"`) to a
+`SensorConfig` describing **how to discover scenes** for that sensor:
+which STAC endpoint to hit, which collection ID to search, which
+metadata fields hold the timestamp / cloud-cover, and which asset key
+holds a renderable preview thumbnail.
+
+Scope: polar-orbiting / tasked sensors only. Geostationary platforms
+(GOES, Himawari, Meteosat) are deliberately out of scope here — their
+~5-15 minute cadence makes them a poor fit for "is there imagery over
+my AOI?" preview-style discovery.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SensorConfig:
+    """Static configuration for one sensor."""
+
+    name: str
+    stac_endpoint: str
+    collection_id: str
+    # The STAC asset key that yields a renderable preview/thumbnail.
+    preview_asset: str | None = None
+    # The STAC item property that holds cloud cover percent (0-100).
+    cloud_field: str | None = None
+    # Whether the STAC endpoint requires `planetary-computer` URL signing.
+    requires_pc_signing: bool = False
+    # Human description (shown in the UI dropdown).
+    description: str = ""
+
+
+SENSORS: dict[str, SensorConfig] = {
+    "sentinel-2-l2a": SensorConfig(
+        name="sentinel-2-l2a",
+        stac_endpoint="https://planetarycomputer.microsoft.com/api/stac/v1",
+        collection_id="sentinel-2-l2a",
+        preview_asset="rendered_preview",
+        cloud_field="eo:cloud_cover",
+        requires_pc_signing=True,
+        description="Sentinel-2 L2A surface reflectance (10-60 m, ~5 day revisit)",
+    ),
+    "sentinel-1-grd": SensorConfig(
+        name="sentinel-1-grd",
+        stac_endpoint="https://planetarycomputer.microsoft.com/api/stac/v1",
+        collection_id="sentinel-1-grd",
+        preview_asset="rendered_preview",
+        cloud_field=None,
+        requires_pc_signing=True,
+        description="Sentinel-1 C-band SAR GRD (10 m, all-weather)",
+    ),
+    "landsat-c2-l2": SensorConfig(
+        name="landsat-c2-l2",
+        stac_endpoint="https://planetarycomputer.microsoft.com/api/stac/v1",
+        collection_id="landsat-c2-l2",
+        preview_asset="rendered_preview",
+        cloud_field="eo:cloud_cover",
+        requires_pc_signing=True,
+        description=(
+            "Landsat Collection-2 L2 surface reflectance (30 m, ~16 day revisit)"
+        ),
+    ),
+    "modis-09a1": SensorConfig(
+        name="modis-09a1",
+        stac_endpoint="https://planetarycomputer.microsoft.com/api/stac/v1",
+        collection_id="modis-09A1-061",
+        preview_asset="rendered_preview",
+        cloud_field=None,
+        requires_pc_signing=True,
+        description="MODIS Terra/Aqua 8-day surface reflectance (500 m)",
+    ),
+    "emit-l2a-rfl": SensorConfig(
+        name="emit-l2a-rfl",
+        stac_endpoint="https://planetarycomputer.microsoft.com/api/stac/v1",
+        collection_id="emit-l2a-rfl",
+        preview_asset="rendered_preview",
+        cloud_field=None,
+        requires_pc_signing=True,
+        description="EMIT L2A imaging spectrometer reflectance (60 m, tasked)",
+    ),
+}

--- a/projects/satellite_viewer/tests/test_sensors.py
+++ b/projects/satellite_viewer/tests/test_sensors.py
@@ -1,0 +1,30 @@
+"""Static checks on the sensor registry."""
+
+from __future__ import annotations
+
+from satellite_viewer.sensors import SENSORS, SensorConfig
+
+
+def test_registry_is_nonempty() -> None:
+    assert len(SENSORS) >= 4
+
+
+def test_user_requested_sensors_present() -> None:
+    """The four polar/tasked sensor families in scope must all be reachable."""
+    keys = list(SENSORS)
+    assert any(k.startswith("sentinel") for k in keys)
+    assert any(k.startswith("landsat") for k in keys)
+    assert any(k.startswith("modis") for k in keys)
+    assert any(k.startswith("emit") for k in keys)
+
+
+def test_all_have_endpoint_and_collection() -> None:
+    for key, cfg in SENSORS.items():
+        assert cfg.stac_endpoint, f"{key}: stac_endpoint required"
+        assert cfg.collection_id, f"{key}: collection_id required"
+
+
+def test_key_matches_config_name() -> None:
+    for key, cfg in SENSORS.items():
+        assert isinstance(cfg, SensorConfig)
+        assert cfg.name == key, f"registry key {key!r} != cfg.name {cfg.name!r}"


### PR DESCRIPTION
## Summary

A new sub-project under `projects/satellite_viewer/` for previewing **which satellite scenes intersect an AOI before downloading anything**. The aim is fast inspection: "is there usable imagery here at this time?" — footprints, a timeline, and preview thumbnails — without paying the bandwidth bill on the full COG/HDF reads.

```mermaid
flowchart LR
    A["AOI bbox or<br/>drawn polygon"] --> S["search()"]
    P["sensor + date range +<br/>cloud %"] --> S
    S --> H["GeoDataFrame<br/>(id, datetime,<br/>footprint, preview)"]
    H --> M["Map<br/>(footprints + AOI)"]
    H --> T["Timeline<br/>(time x sensor)"]
    H --> X["Thumbnail strip"]
```

### Scope

Polar-orbiting / tasked sensors only, all via the Microsoft Planetary Computer STAC API (anonymous read, no auth):

| Key              | Description                                                  |
|------------------|--------------------------------------------------------------|
| `sentinel-2-l2a` | Sentinel-2 L2A surface reflectance (10–60 m, ~5 day revisit) |
| `sentinel-1-grd` | Sentinel-1 C-band SAR GRD (10 m, all-weather)                |
| `landsat-c2-l2`  | Landsat C2 L2 surface reflectance (30 m, ~16 day)            |
| `modis-09a1`     | MODIS Terra/Aqua 8-day surface reflectance (500 m)           |
| `emit-l2a-rfl`   | EMIT L2A imaging spectrometer reflectance (60 m, tasked)     |

Geostationary platforms (GOES, Himawari, Meteosat) are deliberately **out of scope** — their ~5–15 minute cadence makes "does my AOI intersect a scene?" a trivially-yes question inside any scan sector, so a preview workflow adds no value.

### What's in here

- **Shared core** (`src/satellite_viewer/`)
  - `sensors.py` — `SensorConfig` registry of the 5 sensors above.
  - `search.py` — one `search(sensor, aoi, start, end, cloud_lt=, max_items=)` entry point returning a uniform `GeoDataFrame[id, datetime, geometry, sensor, cloud_cover, preview_url]`.
- **Three subapps** over the same backend:
  - **Panel** (`apps/panel_app.py`) — leafmap + holoviews + tabulator, served by `panel serve`.
  - **Streamlit** (`apps/streamlit_app.py`) — folium + Draw plugin + altair, single-file rerun-on-change.
  - **Jupyter notebook** (`notebooks/viewer.py`) — jupytext py:percent with ipywidgets + leafmap + matplotlib.
- **Tests** (`tests/test_sensors.py`) — 4 offline registry sanity checks.
- **Pixi wiring** — new `satellite-viewer` feature/environment with `panel-app`, `streamlit-app`, `lab`, and `test-satellite-viewer` tasks.

### How it differs from `geocatalog`

`geocatalog` is the right primitive once you've decided what to keep — it indexes a chosen collection of files. The viewer's job is **upstream of that**: figure out *which* scenes you'd want to put in a catalog in the first place. The natural follow-up after a Search click is `geocatalog.from_stac_items(...)`.

## Test plan

- [x] `pixi run -e satellite-viewer test-satellite-viewer` — 4 offline registry tests pass.
- [x] `ruff check` clean on `projects/satellite_viewer/`.
- [x] `ruff format --check` clean on `projects/satellite_viewer/`.
- [ ] Manual: `pixi run -e satellite-viewer panel-app` and click Search with the default Lake Tahoe AOI + Sentinel-2 — confirm map / timeline / thumbnails render.
- [ ] Manual: `pixi run -e satellite-viewer streamlit-app` and repeat — confirm the drawn-polygon path also works.
- [ ] Manual: open `notebooks/viewer.py` via jupytext in `pixi run -e satellite-viewer lab` — confirm the ipywidgets controls and leafmap map appear and Search updates the matplotlib timeline.

## Notes

- This is a draft because the three UIs have only been smoke-tested via `import`-level lint / format; no one has clicked Search against live MPC yet. Marking ready for review once the three manual checks above are done.
- Open PR URL after push: https://github.com/jejjohnson/research_notebook/pull/new/claude/satellite-timeseries-viewer-lgsPx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmCxiEbbnDeQii5z8o9Y7P)_