### PR TITLE
docs(spectral): design docs for three spectral-analysis sibling apps

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -103,6 +103,17 @@ project:
                 - file: projects/satellite_viewer/plans/satellite_climatology/v2_data_driven_scene_level.md
                 - file: projects/satellite_viewer/plans/satellite_climatology/v2_5_pixel_level.md
                 - file: projects/satellite_viewer/plans/satellite_climatology/v3_pixel_level_global.md
+        - title: Spectral analysis apps
+          children:
+            - title: Pixel spectra
+              children:
+                - file: projects/pixel_spectra/plans/design.md
+            - title: Spectral indices
+              children:
+                - file: projects/spectral_indices/plans/design.md
+            - title: Band matchup
+              children:
+                - file: projects/band_matchup/plans/design.md
         - title: Data assimilation
           children:
             - file: projects/assimilation/README.md

--- a/projects/band_matchup/plans/design.md
+++ b/projects/band_matchup/plans/design.md
@@ -1,0 +1,327 @@
+---
+title: "band_matchup — cross-sensor band comparison and simulation"
+short_title: "band_matchup design"
+---
+
+# `band_matchup` — cross-sensor band comparison and simulation
+
+> *Given two satellite sensors (multispectral, hyperspectral, or
+> geostationary), compare their spectral response functions (SRFs).
+> Which bands of A correspond to which bands of B? Convolve a
+> hyperspectral spectrum with an MSI sensor's SRFs to predict what
+> that MSI sensor "would have seen" at the same pixel.*
+
+**Status**: design only. No code in this PR.
+
+The most underbuilt of the three apps — most cross-sensor SRF tooling
+is buried inside individual mission Python packages (`spectral-tools`,
+sensor-specific calval libraries) and there's no single user-facing
+app that lets you compare any-to-any.
+
+## Question answered
+
+> "If I have a band/pixel from sensor A, what's the best-matching
+> band on sensor B — and what would sensor B's pixel value be?"
+
+Use cases:
+
+- **Matchup studies** validating new sensors against established
+  references.
+- **Cross-calibration** for time-series that span multiple
+  generations of an instrument family (S2A → S2B → S2C).
+- **HSI → MSI simulation**: predict what S2 / Landsat / MODIS would
+  see at an EMIT pixel, useful for synthetic matchups and for
+  product-continuity studies.
+- **Sensor selection**: "I need NIR around 850 nm — which sensors
+  have a band there, and how do their SRFs compare?"
+
+## Scope
+
+### Sensors (SRF library to bundle)
+
+| Family            | Sensors                                                   |
+|-------------------|-----------------------------------------------------------|
+| MSI polar         | Sentinel-2 A / B / C, Landsat 8 OLI, Landsat 9 OLI-2      |
+| MSI moderate      | MODIS Terra / Aqua, VIIRS NPP / JPSS-1 / JPSS-2           |
+| HSI               | EMIT, PRISMA, EnMAP, DESIS                                |
+| Geostationary     | GOES-16 ABI, GOES-18 ABI, Himawari-9 AHI, MTG-I1 FCI,     |
+|                   | Meteosat-11 SEVIRI (legacy)                               |
+
+About 20 sensors covering everyone you'd practically compare.
+
+### Wavelength range
+
+VNIR + SWIR (0.4–2.5 μm). TIR is a separate beast (different
+acquisition mode, different units, different cal); explicit out of
+scope.
+
+### Compute target
+
+- v0/v1: instant — all in-memory SRF math on ~100 KB of data.
+- v2 per pixel: milliseconds.
+- v3 (coincident-scene matchup): same as `pixel_spectra` scale.
+
+## Algorithm
+
+### SRF data shape
+
+Per `(sensor, band)`:
+
+```
+wavelength_nm : ndarray[float]   # nm grid, 1 nm step where possible
+response      : ndarray[float]   # normalised so max = 1
+provenance    : str              # e.g. "ESA S2-MSI 2024 release"
+units         : str              # "relative" or "absolute"
+```
+
+Bundled under `data/srf/<sensor>/<band>.csv` with a top-level
+`data/srf/manifest.json` carrying provenance + URL.
+
+### v0 — SRF plot
+
+```
+For each (sensor, band) the user selects:
+  Plot response vs wavelength on shared axes.
+  Annotate band centre + FWHM.
+```
+
+### v1 — Similarity matrix
+
+For sensors A (`n` bands) and B (`m` bands):
+
+```
+S[i,j] = (∫ SRF_Ai(λ) · SRF_Bj(λ) dλ)
+        / sqrt(∫ SRF_Ai² · ∫ SRF_Bj²)
+```
+
+(Cosine on the sampled SRFs after resampling to a common λ grid.)
+Output: `(n × m)` ndarray, plotted as a heatmap. Each row's argmax
+is "best match for A's band i in sensor B."
+
+### v2 — HSI → MSI simulation
+
+For an HSI sensor (`n_λ` wavelengths) and an MSI sensor with band
+`b` whose SRF is `r_b(λ)`:
+
+```
+B_b = ∫ r_b(λ) · R_HSI(λ) dλ / ∫ r_b(λ) dλ
+```
+
+Equivalent to a weighted average of the HSI reflectance values at
+the SRF support. Per-pixel: one matrix multiply.
+
+### v3 — Coincident-scene matchup
+
+```
+1. Find coincident scenes via satellite_viewer.search for two
+       sensors at the AOI within a time window.
+2. For each pixel:
+     read HSI cube.
+     read MSI bands.
+     simulate MSI from HSI via v2.
+     compare predicted vs observed (residual stats).
+3. Report mean residual + scatter plot per band.
+```
+
+## Stages
+
+| v   | What it does                                                              |
+|-----|---------------------------------------------------------------------------|
+| v0  | SRF browser — pick sensor(s) + band(s), plot overlay.                     |
+| v1  | Similarity matrix between two sensors, heatmap of cosine overlap.         |
+| v2  | HSI → MSI simulation: take a spectrum, predict band values for any        |
+|     | target MSI sensor.                                                        |
+| v3  | End-to-end coincident-scene matchup at an AOI: predicted vs observed.     |
+
+## Architecture
+
+```
+projects/band_matchup/
+├── pyproject.toml
+├── README.md
+├── data/
+│   └── srf/
+│       ├── manifest.json
+│       ├── sentinel-2a/{B1.csv, ..., B12.csv}
+│       ├── landsat-8/{B1.csv, ..., B7.csv}
+│       ├── emit/full_spectrum.csv   # one wavelength axis + a flag
+│       ├── modis-terra/{...}
+│       ├── viirs-npp/{...}
+│       ├── goes-16-abi/{...}
+│       ├── himawari-9-ahi/{...}
+│       └── mtg-i1-fci/{...}
+├── src/band_matchup/
+│   ├── __init__.py
+│   ├── library.py        # load_srf(sensor, band), list_sensors()
+│   ├── similarity.py     # cosine matrix, best-match search
+│   ├── simulate.py       # v2 HSI→MSI convolution
+│   └── matchup.py        # v3 coincident-scene runner
+├── tests/
+│   ├── test_library.py        # SRF JSON parses, shapes are right
+│   ├── test_similarity.py     # similarity(S2A, S2A) == I (sanity)
+│   └── test_simulate.py       # convolve uniform-reflectance HSI
+└── apps/
+    └── (see Stack options)
+```
+
+`georeader` only enters at v3. v0–v2 are SRF math alone — beautifully
+self-contained.
+
+## Output schema
+
+For v1 — similarity matrix as a pandas DataFrame:
+
+```
+index   : sensor_A band ids (rows)
+columns : sensor_B band ids (cols)
+values  : float [0, 1]
+attrs   : sensor_A, sensor_B, wavelength_grid_nm
+```
+
+For v2 — simulated MSI prediction:
+
+```
+DataFrame[
+    band      : str
+    centre_nm : float
+    fwhm_nm   : float
+    value     : float       # the simulated reflectance / radiance
+]
+```
+
+For v3 — matchup statistics:
+
+```
+DataFrame[
+    band, centre_nm, n_pixels,
+    mean_predicted, mean_observed,
+    bias, rmse, r2
+]
+```
+
+## Stack options
+
+### Option A — Pure Python + bundled CSV (recommended)
+
+`pandas`/`numpy` for SRF loading, `scipy` for resampling, `altair`
+or `matplotlib` for plots. ~500 lines total for v0–v2.
+
+**Pro**: tiny dependency surface, easy to host, easy to test, easy
+to embed in a notebook. All SRF math is just integration.
+**Con**: you write the SRF library by hand (provenance + format
+adapter per source). One-time cost; ~1 day of work for the 20-sensor
+set.
+
+### Option B — Wrap `pyrsr` / `spectral-tools`
+
+Re-use existing Python libraries that carry SRF data:
+
+- [`pyrsr`](https://github.com/GFZ/py_tools_ds) (GFZ) — has S2, L7-9,
+  Sentinel-3, MODIS, RapidEye.
+- `spectral` (SPy) — has utilities for SRF convolution.
+
+**Pro**: don't re-implement loading; piggyback on existing
+provenance.
+**Con**: spotty geostationary coverage; geostationary SRFs need
+hand-curating either way. Adds a heavy-ish dependency for what's
+really just a CSV.
+
+### Option C — Browser-first (D3 / Observable / plotly)
+
+Ship the SRF library as static JSON, plot in-browser, no Python
+server at all.
+
+**Pro**: zero server runtime, embeds on a static-site (your MyST
+docs), shareable as a URL.
+**Con**: v2/v3 (simulation, matchup) need pixel reads → Python /
+WebAssembly. Browser-only caps you at v0/v1.
+
+### Option D — Earth Engine
+
+EE has some sensor SRFs but the dataset is incomplete and the API
+isn't designed for SRF comparison. Not a good fit; skip.
+
+### Option E — Pre-compute everything to a static dataset
+
+Pre-compute the full (sensor × band) × (sensor × band) similarity
+tensor for every pair you care about, ship as a single Parquet, the
+app is just a viewer.
+
+**Pro**: tiny runtime, perfectly cacheable, instant heatmaps.
+**Con**: less flexibility (e.g., the user can't change the λ grid
+or add a sensor without rerunning the precompute).
+
+**My recommendation**: A for the library + the apps; E as an
+*output* of the pipeline so the heatmaps land in your MyST docs as
+static images. v3 is where you reach for `satellite_viewer` +
+`georeader`.
+
+## UI integration
+
+```
++--------------------+---------------------------------------+
+| Sensor A : ▾       |  SRF overlay plot                     |
+|   bands  : (multi) |  (wavelength on x, response on y,     |
+| Sensor B : ▾       |   colour by sensor)                   |
+|   bands  : (multi) |                                       |
+| Common λ grid: 1nm |                                       |
++--------------------+---------------------------------------+
+| Similarity matrix  |  Heatmap (A rows × B cols)            |
+|  (cosine overlap)  |  Click → highlight band pair in plot  |
++--------------------+---------------------------------------+
+| Simulator (v2)     |  upload spectrum (CSV) →              |
+|                    |  show simulated bands per target      |
++--------------------+---------------------------------------+
+| Matchup (v3)       |  AOI + date → coincident-scene runner |
++--------------------+---------------------------------------+
+```
+
+## Compute budget
+
+- v0/v1: instant (~100 KB SRF data total).
+- v2: ms per pixel.
+- v3 per AOI: dominated by scene reads; comparable to `pixel_spectra`.
+
+## Risks / open questions
+
+- **SRF provenance is the hard part.** ESA + USGS publish official
+  SRFs; geostationary missions (GOES, Himawari, MTG) sometimes only
+  publish design SRFs not as-built. Each entry needs a citation +
+  date; manifest.json captures this.
+- **Normalisation conventions differ** — some sources publish
+  "relative response" (peak = 1), others "transmittance" (peak < 1),
+  some include out-of-band response (skirts), some don't. The loader
+  must normalise to a single convention (relative, max=1) and record
+  the original convention.
+- **λ grid choice** — 1 nm is fine for VNIR; some SRFs (especially
+  geostationary) are only published at 5–10 nm. Resampling
+  introduces small errors; document the chosen interp scheme.
+- **Geostationary vs. polar** subtlety: geostationary SRFs are full-
+  disk-shared, no per-tile variation. Polar sensors with detectors
+  may have small per-detector SRF differences (S2 has 12 detectors).
+  v0 ships the published mission-mean SRFs and notes the caveat.
+- **EMIT as a "sensor"** — EMIT's "SRF" is its instrument response
+  per wavelength, ~7.4 nm FWHM Gaussians. Special-cased as a wide
+  hyperspectral comb in the library.
+- **TIR scope creep** — geostationary sensors all have TIR bands
+  (GOES ABI's bands 7–16 are TIR). Document that the app handles
+  only VNIR+SWIR (≤ 2.5 μm) and skip TIR bands in the manifest.
+
+## Acceptance
+
+- SRF library bundled for all 20 listed sensors, manifest carries
+  provenance + URL for every file.
+- Self-similarity check: `similarity(S2A, S2A) ≈ I` (within 0.99 on
+  the diagonal, < 0.05 off-diagonal except for adjacent bands).
+- HSI → MSI simulation against a coincident EMIT × S2 scene matches
+  the observed S2 reflectance within 10% RMSE for clear-sky pixels.
+- v0 / v1 UI loads + renders in < 1 s.
+
+## Out of scope
+
+- TIR bands (≥ 3 μm).
+- Polarimetric channels.
+- BRDF / view-angle effects.
+- Atmospheric simulation — `band_matchup` does no RT; users supply
+  L2A reflectance.
+- Calibration adjustments (gains / offsets / dark current).

--- a/projects/pixel_spectra/plans/design.md
+++ b/projects/pixel_spectra/plans/design.md
@@ -1,0 +1,256 @@
+---
+title: "pixel_spectra — pixel-scale spectral inspector"
+short_title: "pixel_spectra design"
+---
+
+# `pixel_spectra` — pixel-scale spectral inspector
+
+> *Given a single pixel, a multi-point selection, or a small polygon
+> AOI, pull the per-pixel reflectance spectrum from a hyperspectral
+> scene, overlay a reference spectrum, and score similarity with a
+> chosen distance metric. Built for **vetting candidate detections**
+> (methane plumes, mineral identifications, snow / vegetation
+> verification) before downstream analysis.*
+
+**Status**: design only. No code in this PR.
+
+## Question answered
+
+> "Does the pixel I clicked on (or the patch I drew) actually look
+> like the thing I think it is — and how close is it?"
+
+This is upstream of the `methane_pod` workflow: before fitting a
+point-process to a list of plume detections, you'd open each
+candidate's AOI here, sanity-check that the spectrum matches a
+methane-enhanced reference (Mag1c-style absorption signature, or a
+HITRAN-derived synthetic), and reject false positives. The same tool
+works for any "is this thing X?" question over a hyperspectral scene.
+
+## Scope
+
+- **Sensors (HSI first)**: EMIT (60 m, 285 bands). Add PRISMA / EnMAP /
+  DESIS later via the same plug-in shape.
+- **AOI**: `shapely.geometry` of any kind. The shape determines pixel
+  selection:
+  - `Point` → snap to nearest pixel.
+  - `MultiPoint` → list of nearest pixels (deduped).
+  - `Polygon` → all enclosed pixel centres.
+  - `LineString` → pixels along the line (transect mode).
+- **Reference spectra**: at minimum, three sources at v0:
+  1. Bundled library (USGS splib07 minerals + ECOSTRESS for
+     vegetation / soil / man-made).
+  2. User-uploaded CSV (`wavelength_nm, reflectance`).
+  3. Synthetic — radiative-transfer or HITRAN-derived for gases (the
+     methane case).
+- **Distance metrics**: SAM, SID, cosine similarity, Euclidean,
+  matched-filter score (for narrow-band gases like CH4).
+- **Compute target**: interactive (< 5 s per pixel-spectrum lookup).
+  Bulk vetting (1k AOIs × 1 scene) is a separate batch mode.
+
+## Algorithm
+
+```
+1. Discover scenes intersecting the AOI for the chosen sensor
+       (delegate to satellite_viewer.search; the SENSORS registry
+       already has emit-l2a-rfl).
+2. For each scene:
+     a. Sign asset hrefs (planetary-computer or earthaccess token).
+     b. Read the full reflectance cube clipped to the AOI bbox via
+        georeader → ndarray of shape (n_bands, h, w) plus the band
+        wavelengths from the asset's metadata.
+     c. Convert AOI geometry → pixel-coordinate list (snap/contains).
+3. Build a pixel-spectra DataFrame: one row per (scene, pixel),
+       columns = [lon, lat, datetime] + 285 reflectance values.
+4. Reference spectrum: resample to scene's wavelength grid (linear
+       interp, drop bands with no overlap).
+5. Apply distance metric per pixel against the reference → one float
+       per (scene, pixel).
+6. (Optional) Mask non-usable bands: EMIT atmospheric water-vapor
+       windows around 1.4 μm and 1.9 μm (~80 of the 285 bands).
+       Mask choice is a knob exposed in the UI.
+```
+
+## Stages
+
+| v   | What it does                                                              |
+|-----|---------------------------------------------------------------------------|
+| v0  | Point AOI → spectrum vs. reference, side-by-side plot. No metric.         |
+| v1  | Add distance metric: single number per pixel, alongside the plot.         |
+| v2  | Polygon / MultiPoint AOI → per-pixel metric histogram + mean spectrum     |
+|     | with uncertainty (±σ) band; "good vs. bad" pixel scatter on the map.      |
+| v3  | Bulk vetting: upload a GeoJSON / CSV of candidate detection AOIs, run     |
+|     | the per-pixel metric over each, return a sorted table with score + the    |
+|     | best-matching scene per candidate.                                        |
+
+You ship after v2 for interactive use; v3 turns it into a vetting
+pipeline.
+
+## Architecture
+
+```
+projects/pixel_spectra/
+├── pyproject.toml
+├── README.md
+├── src/pixel_spectra/
+│   ├── __init__.py
+│   ├── sensors.py        # HSI-only subset of the satellite_viewer registry
+│   ├── reader.py         # AOI → pixel-spectra DataFrame (via georeader)
+│   ├── references.py     # library loader (USGS splib, ECOSTRESS), interp helpers
+│   ├── metrics.py        # SAM, SID, cosine, Euclidean, matched_filter
+│   └── bulk.py           # the v3 vetting pipeline
+├── tests/
+│   ├── test_metrics.py   # numerical correctness vs. hand-computed cases
+│   ├── test_reader.py    # AOI → pixel-coord conversion (offline)
+│   └── test_references.py# library loader + resample
+└── apps/                 # whichever stack we pick from "Stack options"
+```
+
+Repos reused: `satellite_viewer` (discovery + credentials),
+`georeader` (windowed reads). Nothing from the `geotoolz` /
+`geopatcher` / `geocatalog` stack is needed at this scale (single
+scene, ≤ few hundred pixels).
+
+## Output schema
+
+A long-format pandas DataFrame:
+
+```
+scene_id      : string         # STAC item id
+pixel_lon     : float64        # WGS84 lon of the pixel centre
+pixel_lat     : float64        # WGS84 lat of the pixel centre
+datetime      : datetime[UTC]  # acquisition time
+n_bands       : int            # how many bands made it past masking
+distance      : float64        # the chosen metric vs. reference
+spectrum      : object         # list[float] of length n_bands (or
+                               # path to a per-row Zarr for large dumps)
+reference_id  : string         # which reference spectrum was used
+metric        : string         # "SAM" / "SID" / "cosine" / ...
+mask_id       : string         # which band-mask was applied
+```
+
+## Stack options
+
+Different ways to build this, in increasing order of how much exists
+already vs. how much you control.
+
+### Option A — `satellite_viewer` + `georeader` (recommended)
+
+Build on what's already in `research_notebook`:
+
+- `satellite_viewer.search("emit-l2a-rfl", aoi, t0, t1)` for discovery.
+- `satellite_viewer.credentials.earthdata()` for the URS token.
+- `georeader.read_from_window(...)` for the windowed cube read.
+- numpy / scipy for metrics. plotly / altair for the spectrum plot.
+
+**Pro**: zero new dependencies, lights up the existing stack, plays
+nicely with the planned `satellite_climatology` work.
+**Con**: `georeader`'s HSI ergonomics on EMIT specifically still need
+a micro-bench (it was designed against S2/L8 first).
+
+### Option B — `rioxarray` + `pystac-client` directly
+
+Skip `georeader`; open each EMIT asset as an xarray Dataset via
+`rioxarray.open_rasterio(..., chunks={"band": 32})` and use xarray's
+windowed indexing.
+
+**Pro**: industry-standard pipeline, plays well with dask if it
+grows. Every Python remote-sensing engineer can read it.
+**Con**: more boilerplate; loses the `georeader` abstraction for
+non-COG sensors you might add later (PRISMA HDF5).
+
+### Option C — Earth Engine
+
+`ee.ImageCollection("EMIT/L2A").filterBounds(aoi).getRegion(...)`
+returns pixel values directly.
+
+**Pro**: no asset signing, no scene reads, no infrastructure.
+**Con**: EMIT may not be ingested in EE (check at start of M1); EE
+also can't handle 285-band image returns cleanly — you'd hit element
+limits. Probably a dead-end for HSI at this scale.
+
+### Option D — Notebook recipe only
+
+No app, just a Jupyter notebook + a `pixel_spectra.read_aoi(...)`
+helper. Click in JupyterLab via `ipyleaflet` Draw control. Spectrum
+plot inline.
+
+**Pro**: shortest path to a working demo. Matches your geostack
+notebook pattern.
+**Con**: no bulk vetting UI; the v3 pipeline becomes a script not an
+app.
+
+**My recommendation**: A for the library + a *notebook* at v0/v1
+(option D's shape) + a Panel/Streamlit subapp at v2/v3 (option A's
+infra under a UI). Ship v0 as the notebook in week 1; promote to a
+real app once the metric set stabilises.
+
+## UI integration
+
+Single-screen layout:
+
+```
++---------------------------+--------------------------------------+
+| Sensor   : emit-l2a-rfl   |  [ leafmap basemap ]                 |
+| AOI      : draw or upload |  AOI overlay + selected pixels (dots)|
+| Date     : range slider   |                                      |
+| Reference: library | up.. |                                      |
+| Metric   : SAM ▾          |                                      |
+| Mask     : default ▾      |                                      |
+| [ Inspect ]               |                                      |
++---------------------------+--------------------------------------+
+| Spectrum panel  (selected pixel + reference, with mask shaded)   |
++------------------------------------------------------------------+
+| Metric panel    (histogram for multi-pixel AOI, or scalar)       |
++------------------------------------------------------------------+
+| Bulk table      (v3 only: sorted scores per candidate)           |
++------------------------------------------------------------------+
+```
+
+Click on the map → highlight the pixel → re-render the spectrum
+panel against the same reference.
+
+## Compute budget
+
+- Single-pixel × single scene: 2 STAC search + 1 small windowed read
+  + 285-element metric → < 3 s wall-clock.
+- Polygon-AOI (~100 pixels) × single scene: one full-band read of the
+  AOI bbox + 100 metric evaluations → 5–15 s.
+- v3 bulk vet, 1k candidates × ~1 scene each: ~10–30 min on a laptop;
+  parallelisable per-candidate.
+
+Memory: one EMIT scene clipped to a 1 km AOI is ~30 MB float32. Trivial.
+
+## Risks / open questions
+
+- **EMIT atmospheric mask** — water vapour windows render ~80 bands
+  unusable. Default mask must come from the L2A QA mask metadata,
+  not be hand-coded.
+- **Reference resampling** — USGS splib07 is at 1 nm; EMIT is at ~7.4
+  nm. Linear interpolation is the simple answer but introduces error
+  for narrow features; consider Gaussian convolution with EMIT's SRFs
+  if the matched-filter metric matters (App 3 will help).
+- **Methane reference** — no static library entry will work; needs
+  RT model output (e.g., HITRAN convolution at the expected
+  enhancement level). Document as a user-bring-your-own input for now.
+- **Pixel snap semantics** for `Point` AOIs at sub-pixel offsets —
+  pick nearest centre vs. interpolate. Stick with "nearest centre,"
+  document it.
+- **EMIT signing** — Planetary Computer + earthaccess have different
+  signing flows; the credentials module already abstracts this.
+
+## Acceptance
+
+- Point AOI + single EMIT scene → spectrum + reference plot < 5 s.
+- Polygon AOI → per-pixel metric histogram populated.
+- SAM metric numerically matches reference implementation (spec one
+  test case from Kruse et al. 1993).
+- Bulk vetting: 100 candidate AOIs × 1 scene each completes in < 5 min.
+- Spectrum plot correctly shades the water-vapour masked bands.
+
+## Out of scope
+
+- Atmospheric correction (we assume L2A reflectance).
+- Plume strength quantification — that's Mag1c / Matched-Filter
+  inversions; this tool flags candidates, doesn't quantify them.
+- Multi-scene aggregation per AOI (not the use case).
+- Radiative-transfer modelling — the reference spectra are inputs.

--- a/projects/spectral_indices/plans/design.md
+++ b/projects/spectral_indices/plans/design.md
@@ -1,0 +1,271 @@
+---
+title: "spectral_indices — index catalog and transformation engine"
+short_title: "spectral_indices design"
+---
+
+# `spectral_indices` — index catalog and transformation engine
+
+> *Apply named spectral transformations (NDVI, NDWI, NBR, EVI, …) to
+> scenes and time-series across any sensor whose bands you have.
+> Browse a catalog of ~250 named indices; build composed formulas
+> from the algebra; export results as derived bands.*
+
+**Status**: design only. No code in this PR.
+
+## Question answered
+
+> "Given this AOI and this sensor, what does index X look like —
+> as a map for one scene, and as a time-series across many scenes?"
+
+This is the daylight-to-dusk applied tool: most users of remote
+sensing data spend their time computing and comparing indices, and
+right now there isn't a clean local app for it — they either reach
+for Earth Engine or write per-index notebooks by hand.
+
+## Scope
+
+- **Sensors**: any sensor in the `satellite_viewer.SENSORS` registry
+  whose `band → wavelength` mapping is known. v0 ships with Sentinel-2,
+  Landsat 8/9, and MODIS; EMIT is treated as "every band available"
+  and gets the full index catalog automatically.
+- **Index catalog**: the
+  [Awesome Spectral Indices](https://github.com/awesome-spectral-indices/awesome-spectral-indices)
+  JSON registry — ~250 indices with formulas, band requirements,
+  references, and citations. Ship it bundled (~150 KB JSON), refresh
+  by pinned-version bump.
+- **AOI**: any shapely geometry. v0 supports up to MGRS-tile-size
+  AOIs (~110 km); larger goes through `geopatcher`.
+- **Time scope**: single scene at v0, multi-scene time series at v2.
+- **Compute target**: interactive for v0/v1, batch-on-demand for v2/v3.
+
+## Algorithm
+
+```
+1. Index registry: load awesome-spectral-indices/spectral-indices.json
+       into a dict keyed by short_name. Each entry has formula,
+       bands, domain (vegetation/water/fire/...), and reference.
+2. Sensor → band-to-wavelength mapping: maintained as a small per-
+       sensor dict in our own sensors.py (overlays satellite_viewer's
+       registry).
+3. Resolve an index against a sensor: substitute the index's named
+       band slots (B, G, R, RE1, ..., N, S1, S2) with the sensor's
+       actual asset/file keys. If any required band is missing, raise.
+4. Read the required bands at the AOI bbox via georeader (or
+       odc-stac depending on stack choice).
+5. Evaluate the index formula on the band arrays. The formula is a
+       small arithmetic expression — safe to eval through `numexpr`
+       or `asteval`, never raw eval().
+6. Output: derived band raster at the union extent of the input bands,
+       resampled to the coarsest input resolution.
+7. (v2 only) repeat per scene in the catalog, stack along time dim.
+```
+
+## Stages
+
+| v   | What it does                                                              |
+|-----|---------------------------------------------------------------------------|
+| v0  | Pick sensor + AOI + scene + index → derived band map.                     |
+| v1  | Searchable index catalog: filter by domain (vegetation / water /          |
+|     | fire / soil / snow / urban / generic), see formula + bands + citation.    |
+| v2  | Time-series mode: catalog of N scenes (12-month window default) →         |
+|     | derived band per scene → chart of the AOI-mean over time.                 |
+| v3  | Formula builder: user types `(NDVI - NDWI) / (NDVI + NDWI)` and it        |
+|     | gets parsed → safely evaluated → mapped, same as named indices.           |
+
+You ship a useful tool after v1; v2/v3 are the depth.
+
+## Architecture
+
+```
+projects/spectral_indices/
+├── pyproject.toml
+├── README.md
+├── data/
+│   └── spectral-indices.json   # pinned snapshot of the registry
+├── src/spectral_indices/
+│   ├── __init__.py
+│   ├── registry.py     # load_indices(), get(name), filter_by_domain(...)
+│   ├── sensors.py      # per-sensor band→wavelength + asset-key map
+│   ├── resolve.py      # match an index's band slots to a sensor
+│   ├── evaluate.py     # safe formula evaluation on ndarrays
+│   ├── reader.py       # AOI + bands → ndarray (delegates to georeader)
+│   └── series.py       # v2: catalog → time series
+├── tests/
+│   ├── test_registry.py
+│   ├── test_resolve.py
+│   ├── test_evaluate.py    # hand-check NDVI / NDWI on synthetic arrays
+│   └── test_series.py
+└── apps/
+    └── (Panel / Streamlit / notebook subapp; see Stack options)
+```
+
+`geotoolz` is the natural place for `evaluate.py` — each named index
+becomes a tiny `Operator` subclass and the formula builder becomes
+`Sequential` / `Graph` composition. But that's a refactor decision,
+not blocking.
+
+## Output schema
+
+For v0/v1 (single scene): an `xarray.DataArray`:
+
+```
+dims    : (y, x)
+coords  : y, x   (in the sensor's UTM CRS)
+attrs   : index, sensor, scene_id, formula, bands_used, units
+```
+
+For v2 (time series): `xarray.DataArray` with extra `time` dim, or a
+DataFrame for the AOI-mean trace:
+
+```
+columns : [datetime, sensor, scene_id, index, value_mean, value_std,
+           value_p10, value_p90, n_valid_pixels]
+```
+
+## Stack options
+
+### Option A — `geotoolz` operators + `georeader` (recommended)
+
+Each named index is an `Operator` subclass returning a single band:
+
+```python
+class NDVI(Operator):
+    def _apply(self, gt):
+        nir, red = gt.values[NIR_IDX], gt.values[RED_IDX]
+        return gt.array_as_geotensor((nir - red) / (nir + red + 1e-10))
+    def get_config(self):
+        return {"nir_idx": NIR_IDX, "red_idx": RED_IDX}
+```
+
+Composed formulas are `Sequential` / `Graph`. Time series via
+`geocatalog` + a per-scene `Operator` application loop. Reads via
+`georeader`.
+
+**Pro**: showcases the entire `geotoolz` + `geocatalog` + `georeader`
+stack — this is the canonical use case. Reproducibility via
+`Operator.get_config()`.
+**Con**: writing all 250 indices as Operators by hand is silly.
+Better: one generic `IndexOp` that takes a name and looks up the
+formula from the registry, then evaluates it dynamically.
+
+### Option B — Earth Engine
+
+`ee.Image.expression("(N - R) / (N + R)", {"N": img.select("B8"), ...})`
+evaluates band-math in EE natively. Combine with the
+[`eemont`](https://github.com/davemlz/eemont) extension which has
+the same awesome-spectral-indices catalog wired in:
+
+```python
+img = (
+    ee.ImageCollection("COPERNICUS/S2_SR")
+    .filterBounds(aoi)
+    .filterDate(t0, t1)
+    .map(lambda img: img.spectralIndices(["NDVI", "NDWI", "NBR"]))
+)
+```
+
+**Pro**: zero infrastructure, every sensor EE has is pre-supported,
+the index catalog is already wired. Implementation is ~50 lines.
+**Con**: hosted, EE's terms-of-use, doesn't help build out your own
+stack. Best as a comparison / sanity-check tool, not the primary app.
+
+### Option C — `odc-stac` + `xarray` directly
+
+Skip both `geotoolz` and `georeader`:
+
+```python
+items = stac_client.search(...).items()
+ds = odc.stac.load(items, bands=["B04", "B08"], bbox=aoi.bounds)
+ndvi = (ds.B08 - ds.B04) / (ds.B08 + ds.B04 + 1e-10)
+```
+
+**Pro**: industry-standard stack, plays well with dask + zarr, every
+modern Python remote-sensing project uses this shape.
+**Con**: less reproducibility metadata than `Operator.get_config()`;
+doesn't showcase your stack.
+
+### Option D — GDAL band-math via `gdal_calc.py`
+
+Shell-tool / CLI approach. Each index becomes a saved GDAL `--calc`
+expression.
+
+**Pro**: zero Python at compute time; great for batch jobs that
+just need to land COGs on disk.
+**Con**: no interactivity, no time series, no UI.
+
+**My recommendation**: A as the library, with C as the time-series
+back-end if `geocatalog` scaling becomes a bottleneck. B as a
+notebook sibling for "what does Earth Engine say?" cross-check.
+
+## UI integration
+
+Two natural shapes:
+
+1. **Notebook** (always ship this): a `spectral_indices.compute(aoi,
+   sensor, index, t0, t1)` helper that returns an `xarray.DataArray`,
+   plus a `.plot()` recipe. Time-series via `.compute_series(...)`.
+2. **Streamlit / Panel app**: sidebar = sensor + AOI + date + index
+   picker (with searchable catalog) + formula editor; main = map +
+   time-series chart + formula display + citation.
+
+The catalog browser is the headline feature:
+
+```
++---------------------+----------------------------------------+
+| Domain  : water  ▾  |  Search: "modified"                    |
+| Sensor  : sent.-2 ▾ |  Filter: sensors compatible only       |
++---------------------+----------------------------------------+
+| MNDWI - Modified Normalized Difference Water Index           |
+|   formula : (G - S1) / (G + S1)                              |
+|   bands   : G=B3, S1=B11   (Sentinel-2)                      |
+|   citation: Xu (2006)                                        |
+|   [Apply to AOI]                                             |
++--------------------------------------------------------------+
+| WI2015 - Water Index 2015                                    |
+| ...                                                          |
++--------------------------------------------------------------+
+```
+
+## Compute budget
+
+- Single index, single S2 scene, 10×10 km AOI: 2 STAC search + 2 band
+  reads (~30 MB) + arithmetic → ~5 s.
+- 12-month time series, single index, AOI: ~70 scenes × 5 s ÷ 8
+  workers ≈ 1 min in parallel.
+- Continental tile coverage: outside the per-AOI scope, would use
+  `geopatcher`.
+
+## Risks / open questions
+
+- **awesome-spectral-indices schema drift** — pin a version and bump
+  intentionally. Add a CI check that the bundled JSON parses against
+  the loader.
+- **Per-sensor band coverage** is uneven — EVI needs blue, NDSI needs
+  SWIR, etc. Pre-compute a `(sensor, index) → applicable?` table and
+  surface "incompatible" indices as greyed-out in the UI.
+- **Reflectance vs DN** — most indices are defined on
+  surface-reflectance L2A; L1C / L1T won't give meaningful values.
+  Either enforce L2A or warn loudly.
+- **Formula injection at v3** — never use raw `eval`. Use `numexpr`
+  (fast, restricted), `asteval` (Python AST whitelisting), or a
+  micro-parser. Document the safe subset.
+
+## Acceptance
+
+- 10 most-used indices (NDVI, NDWI, NBR, EVI, SAVI, MNDWI, GNDVI,
+  NDBI, NDSI, RVI) compute correctly for both Sentinel-2 and
+  Landsat 8 against a small synthetic test.
+- The bundled awesome-spectral-indices JSON loads ≥ 200 indices.
+- v2 time-series renders a 12-month chart for an AOI < 30 s.
+- v3 formula builder rejects unsafe input (`__import__`, `;`, etc.)
+  and produces correct output for `(NDVI - NDWI) / (NDVI + NDWI)`.
+- `Operator.get_config()` round-trips every shipped index through
+  YAML.
+
+## Out of scope
+
+- Atmospheric correction.
+- Index calibration / empirical-line tuning.
+- ML-derived "indices" (random forests, learned embeddings). Different
+  app.
+- Anomaly detection — could be a v3.5, deferred.


### PR DESCRIPTION
## Summary

Three new sibling sub-projects scaffolded as **design docs only** (no code) for the spectral-analysis trio factored out of the recent brainstorm:

| App                  | Question answered                                                              | Headline use case                                       |
|----------------------|--------------------------------------------------------------------------------|---------------------------------------------------------|
| `pixel_spectra`      | "Does this pixel/patch look like the thing I think it is — and how close?"    | Methane plume vetting (ties into `methane_pod`)         |
| `spectral_indices`   | "What does index X look like for this AOI as a map, and over time?"           | Applied vegetation / water / fire monitoring            |
| `band_matchup`       | "Which bands of sensor A correspond to which bands of sensor B?"              | Cross-sensor calibration + HSI→MSI simulation           |

Unmixing was deliberately tabled — covered in the brainstorm but not in scope here.

Where the spectral apps fit alongside what's already in the repo:

- `satellite_viewer` (shipped) — **discovery** ("what scenes are there?")
- `satellite_climatology` (planned, docs landed in #79) — **cadence** ("when can I see it?")
- **these three** — **analysis** ("what is it / what does it tell me?")

## What's in here

### Three design docs (one per app)

Each doc follows the same shape as the `satellite_climatology` v0–v3 series — goal, question answered, scope, algorithm, staging table (v0–v3), output schema, compute budget, UI integration, risks, acceptance, out-of-scope — plus a new **Stack options** section laying out 4–5 alternative implementations with explicit tradeoffs:

- [`projects/pixel_spectra/plans/design.md`](https://github.com/jejjohnson/research_notebook/blob/claude/spectral-apps-design/projects/pixel_spectra/plans/design.md) (256 lines)
  - AOI = `Point` / `MultiPoint` / `Polygon` / `LineString`
  - Pixel-spectrum extraction via `georeader` (Option A) / `rioxarray` (B) / Earth Engine (C) / notebook-only (D)
  - Reference spectra: USGS splib07 + ECOSTRESS + user-uploaded + synthetic
  - Distance metrics: SAM, SID, cosine, Euclidean, matched-filter (for narrow-band gases like CH4)
  - v3 = bulk vetting: GeoJSON/CSV of candidates → sorted score table

- [`projects/spectral_indices/plans/design.md`](https://github.com/jejjohnson/research_notebook/blob/claude/spectral-apps-design/projects/spectral_indices/plans/design.md) (271 lines)
  - Index registry: pinned snapshot of `awesome-spectral-indices` (~250 named indices)
  - Stack options: `geotoolz` + `georeader` (A) / Earth Engine + `eemont` (B) / `odc-stac` + `xarray` (C) / `gdal_calc.py` (D)
  - v3 = safe formula builder (`numexpr` / `asteval` — never raw `eval`)

- [`projects/band_matchup/plans/design.md`](https://github.com/jejjohnson/research_notebook/blob/claude/spectral-apps-design/projects/band_matchup/plans/design.md) (327 lines)
  - **20-sensor SRF library**, now including the geostationary additions you asked for: GOES-16/18 ABI, Himawari-9 AHI, MTG-I1 FCI, Meteosat-11 SEVIRI (legacy)
  - Stack options: pure Python + bundled CSV (A) / `pyrsr` (B) / browser-first (C) / Earth Engine (D, not recommended) / pre-computed Parquet (E)
  - v2 = HSI→MSI simulation (convolve EMIT pixel through any MSI sensor's SRFs)
  - v3 = end-to-end coincident-scene matchup

### MyST TOC wiring

New "Spectral analysis apps" project section under the Projects tree in `myst.yml`, grouped between `Satellite viewer & climatology` and `Data assimilation`. Each app appears as its own sub-entry containing its `design.md` — leaves room to add a README + notebooks later without TOC restructuring.

## Test plan

- [x] All three design docs have MyST YAML front-matter (`title`, `short_title`) so they render correctly.
- [x] `myst.yml` parses cleanly (verified via Python).
- [x] Indentation in the new TOC block matches the sibling `Satellite viewer & climatology` block.
- [ ] Manual: `pixi run -e docs docs-serve` and confirm the three new pages render in the TOC and link out correctly.

## Notes

- Draft because no live MyST render has been done yet.
- Out-of-scope and deliberately so: any code, `pyproject.toml`, tests, or apps. This PR establishes the contracts; implementation lives in future per-app PRs.
- The `Stack options` section in each doc is the answer to your "give different ways to build based off diff technologies" request — every app explicitly considers your stack + Earth Engine + the industry-standard alternatives, with a recommendation called out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmCxiEbbnDeQii5z8o9Y7P)_