### PR TITLE
docs(plume_simulation): two-axis modeling diagram + retrieval→persistency walkthrough

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -176,6 +176,7 @@ project:
               children:
                 - file: projects/plume_simulation/notes/satellites.md
                 - file: projects/plume_simulation/notes/roadmap.md
+                - file: projects/plume_simulation/notes/end_to_end_retrieval_to_persistency.md
                 - title: Roadmap detail
                   children:
                     - file: projects/plume_simulation/notes/roadmap/README.md

--- a/projects/plume_simulation/notes/end_to_end_retrieval_to_persistency.md
+++ b/projects/plume_simulation/notes/end_to_end_retrieval_to_persistency.md
@@ -1,0 +1,201 @@
+---
+title: "End-to-end: methane retrieval → persistency"
+short_title: "E2E — retrieval → persistency"
+subject: "plumax — the full operational pipeline, stitched"
+authors:
+  - name: J. Emmanuel Johnson
+    affiliations: [UNEP, IMEO, MARS]
+    orcid: 0000-0002-6739-0053
+    email: jemanjohnson34@gmail.com
+license: CC-BY-4.0
+keywords: [plumax, methane, retrieval, emission rate, point process, persistency, MARS, end-to-end, TROPOMI, EMIT, GHGSat]
+---
+
+# End-to-end: methane retrieval → persistency
+
+> One satellite radiance in; a leak-recurrence forecast out. This page is the **connective walkthrough** that threads the per-tier notebooks into a single operational story.
+
+The [roadmap index](roadmap/README.md) lays out the two axes of the architecture: a fixed six-step **inference cycle** and a **complexity axis** (Tier I → V). This page reads the architecture the *other* way — not "how does one tier work," but "how do the tiers **compose** into the pipeline an operational methane-monitoring system (MARS-style) actually runs?"
+
+The pipeline has five stages. Each stage is a hand-off: it consumes the previous stage's output and produces the next stage's input. Every stage is independently swappable for a more complex model (the complexity axis) without changing the contract between stages.
+
+```text
+  L1/L2 radiance                                                          dispatch / tasking
+        │                                                                        ▲
+        ▼                                                                        │
+ ┌──────────────┐   ΔXCH₄    ┌──────────────┐   p(Q)    ┌──────────────┐  f(Q),λ(t) ┌──────────────┐
+ │ 1. RETRIEVAL │ ────────▶ │ 2. INVERSION │ ───────▶ │ 4. POPULATION │ ─────────▶ │ 5. PERSISTENCY│
+ │  radiance →  │  column   │  column → Q  │  per-     │  events →     │  intensity │  λ(t) → wait  │
+ │  ΔXCH₄ field │  enhance.  │  (per event) │  event    │  f(Q), λ(t)   │  + marks   │  time, P(occ.)│
+ └──────────────┘           └──────┬───────┘  posterior└──────────────┘            └──────────────┘
+   RTM stack                       │ 3. FUSION (optional)      Tier V.A / V.B            Tier V.C
+   hapi_lut / radtran /            ▼ multi-instrument joint
+   matched_filter            Tier IV coupled  (Q, bias_inst)
+        ▲                    TROPOMI + EMIT + GHGSat
+        └──── Tier I/II/III transport supplies the forward model used in stages 2–3
+```
+
+:::{tip} The whole pipeline runs at any complexity level
+You can run all five stages with the **cheapest** models (Tier I Gaussian plume + L2 retrieval + single instrument) and get an end-to-end answer in seconds — that is the MARS v1 target. Then climb the complexity axis *one stage at a time*: a 4D-Var inversion (Tier III) here, multi-instrument fusion (Tier IV) there. The hand-off contracts below never change.
+:::
+
+---
+
+## Stage 1 — Retrieval: radiance → column enhancement {#stage1-retrieval}
+
+**Question:** given the at-sensor radiance, how much *extra* methane is in this pixel's column relative to background?
+
+The [RTM stack](roadmap/04_rtm_stack.md) maps a band-integrated radiance to a column enhancement $\Delta\mathrm{XCH_4}$ (mol m⁻² or ppb·m). For a single absorbing layer the Beer–Lambert forward model gives the normalised radiance $L = \exp(-\Delta\tau)$ with optical depth $\Delta\tau$ built from a HITRAN line-by-line Voigt LUT; the hyperspectral **matched filter** turns a per-pixel spectral residual into a column estimate against a robustly-estimated scene background.
+
+- **Forward model:** [`hapi_lut`](roadmap/04_rtm_stack.md) Beer–Lambert + [`radtran`](roadmap/04_rtm_stack.md) SRF band integration.
+- **Estimator:** [`matched_filter`](roadmap/04_rtm_stack.md) (trimmed-mean background + low-rank covariance, Woodbury-dispatched via `gaussx`).
+- **Notebooks:** [Beer–Lambert with a CH₄ LUT](../notebooks/hapi_lut/03_beers_law_with_lut.ipynb) · [SRF band integration](../notebooks/radtran/04_srf_band_integration.ipynb) · [matched-filter retrieval on a turbulent plume](../notebooks/radtran/05_matched_filter_retrieval.ipynb).
+- **Produces:** a 2-D column-enhancement field $\Delta\mathrm{XCH_4}(x, y)$ with a per-pixel retrieval covariance $\mathbf{R}_\text{retr}$.
+
+---
+
+## Stage 2 — Inversion: column → emission rate {#stage2-inversion}
+
+**Question:** what source emission rate $Q$ produced this plume?
+
+The transport forward model relates an emission rate to a concentration / column field. Inverting it gives the per-event **posterior** $p(Q \mid \Delta\mathrm{XCH_4})$ — the load-bearing object the rest of the pipeline consumes. The forward model is the complexity axis in action: a closed-form **Tier I** Gaussian plume/puff, a wind-realistic **Tier II** Lagrangian footprint, or a high-fidelity **Tier III** Eulerian field inverted by 4D-Var.
+
+$$
+\Delta\mathrm{XCH_4} \;=\; \mathbf{A}\,\mathrm{col}_z\!\bigl(\text{transport}(Q, x_0, \text{met})\bigr) \;+\; \boldsymbol{\varepsilon}, \qquad \boldsymbol{\varepsilon}\sim\mathcal N(\mathbf 0,\mathbf R)
+$$
+
+- **Tier I (default):** [Gaussian plume / puff](roadmap/01_tier1_gaussian.md) emission-rate inference — [plume MAP/MCMC](../notebooks/02_emission_rate_parameter_estimation.ipynb), [puff state estimation](../notebooks/gauss_puff/02_emission_rate_parameter_estimation.ipynb).
+- **Tier III (high fidelity):** [Eulerian FV](roadmap/03_tier3_eulerian.md) strong-constraint **4D-Var** with a Laplace / Gauss–Newton posterior covariance — [3D-Var methane retrieval](../notebooks/assimilation/06_3dvar_methane_retrieval.ipynb), [matched filter vs 3D-Var](../notebooks/matched_filter/01_mf_vs_3dvar.ipynb).
+- **Produces:** a per-event posterior $p(Q)$ — full samples *or* a lognormal summary $(\mu_{\log Q}, \sigma_{\log Q})$ — **plus its per-event prior** $\pi_\text{per-event}(Q)$ (required downstream; see Stage 4).
+
+---
+
+## Stage 3 — Fusion (optional): joint multi-instrument posterior {#stage3-fusion}
+
+**Question:** when more than one satellite sees the same event, how do we combine them without double-counting agreement?
+
+[Tier IV](roadmap/05_tier4_coupled.md) keeps each instrument at its **native resolution** (its own AK, footprint, overpass time, quality flags) and fuses at the *likelihood* level — never by pre-regridding. Because the plume is linear in $Q$, the joint posterior over $(Q, \text{bias}_\text{inst})$ across a list of satellites is closed-form, with the per-instrument additive bias a **first-class state element** ($O(\pm10\,\text{ppb})$ documented inter-instrument biases otherwise leak into $Q$).
+
+$$
+\mathbf y \;=\; [\mathbf y_\text{TROPOMI},\,\mathbf y_\text{EMIT},\,\mathbf y_\text{GHGSat},\dots], \qquad
+\mathbf H(\mathbf x) \;=\; \bigl[\mathbf H_\text{inst}(\mathbf x) : \text{inst}\in\text{instruments}\bigr]
+$$
+
+- **Module (upstream):** `plumax.coupled` — `CoupledForward`, `Instrument`, `fuse_observations`, `RadianceObservationOperator`.
+- **Produces:** a *fused* per-event posterior $p(Q)$ — same payload contract as Stage 2, so Stage 4 doesn't care whether one instrument or five produced it.
+
+---
+
+## Stage 4 — Population: events → mark distribution + intensity {#stage4-population}
+
+**Question:** across *many* detected events (and the ones we missed), what is the emission-size distribution $f(Q)$ and the event rate $\lambda(t)$?
+
+[Tier V](roadmap/06_tier5_population.md) sits *above* the per-event physics. It treats each per-event posterior as a **soft observation** of an unknown true mark $Q_i$ and fits a thinned marked temporal point process (TMTPP): intensity $\lambda(t)$, mark distribution $f(Q)$, and per-satellite probability-of-detection $P_d(\cdot)$. The three-term log-likelihood makes $\lambda$ and $P_d$ jointly identifiable:
+
+$$
+\log L \;=\; \sum_{i\in\mathcal D}\log\!\int P_d(Q)\,L_i(Q)\,f(Q)\,\mathrm dQ
+\;+\; \sum_{i\in\mathcal D}\log\lambda(t_i)
+\;-\; \int_0^T \lambda(t)\!\left[\int P_d(Q)\,f(Q)\,\mathrm dQ\right]\mathrm dt
+$$
+
+:::{important} Importance correction is mandatory
+The per-event posterior from Stage 2/3 already absorbs $\pi_\text{per-event}$. Feeding its samples directly into the population fit double-counts that prior and biases both $f(Q)$ and the total-mass estimate. Every per-event posterior consumed here **must carry its prior log-density** so the importance weight $f/\pi_\text{per-event}$ can re-point it at the population mark distribution.
+:::
+
+- **Library:** [`methane_pod`](../../methane_pod/README.md) — intensity zoo, POD zoo, missing-mass paradox simulator, NUTS fitter. Upstream `plumax.population` adds the cross-tier catalog (`event_from_posterior`), the V.A lognormal [size-distribution fit](roadmap/06a_instantaneous.md), and the V.B [point-process core](roadmap/06b_point_process.md).
+- **Notebooks:** [TMTPP theory](../../methane_pod/notebooks/01_mttpp_theory.md) · [missing-mass paradox](../../methane_pod/notebooks/03_missing_mass_paradox.ipynb) · [stationary NUTS fit](../../methane_pod/notebooks/06_stationary_numpyro_mcmc.ipynb).
+- **Produces:** posteriors over $\lambda(t)$, $f(Q)$, $P_d$ — and, via the missing-mass correction, a POD-corrected **total emitted mass** ([Tier V.D](roadmap/06d_total_emission.md)).
+
+---
+
+## Stage 5 — Persistency: intensity → operational forecast {#stage5-persistency}
+
+**Question:** given the inverted $\lambda(t)$, when will this source next emit, and should we send a crew (or re-task a high-resolution satellite) now?
+
+[Tier V.C](roadmap/06c_persistency.md) is the **operational layer** — what an LDAR crew or a satellite-tasking dispatcher consumes. It turns the intensity posterior into four metrics, each propagating full posterior uncertainty (no point estimates):
+
+```{list-table} The four persistency metrics.
+:label: tbl-persistency-metrics
+:header-rows: 1
+
+* - Metric
+  - Formula (inhomogeneous)
+  - Operational use
+* - Expected wait time $\mathbb E[\Delta t\mid t_0]$
+  - $\int_{t_0}^{\infty}\exp\!\big(-\!\int_{t_0}^{t}\lambda(u)\,\mathrm du\big)\,\mathrm dt$
+  - Dispatch timing — arrive in a high-$\lambda$ window
+* - Occurrence prob. $\mathbb P(N(t_1,t_2)\ge1)$
+  - $1-\exp\!\big(-\!\int_{t_1}^{t_2}\lambda(t)\,\mathrm dt\big)$
+  - "Wrench-turning" probability for a maintenance window
+* - Conditional intensity $\lambda(t\mid t_\text{prev})$
+  - $\mu+\alpha\,e^{-\beta(t-t_\text{prev})}$ (Hawkes)
+  - Re-task GHGSat after a TROPOMI alert (clustering)
+* - Cumulative count $\mathbb E[N(0,T)]$
+  - $\Lambda(T)=\int_0^T\lambda(t)\,\mathrm dt$
+  - Annual reporting / regulatory compliance
+```
+
+- **API (upstream):** `plume_simulation.population.persistency` — `expected_wait_time`, `occurrence_probability`, `cumulative_count`, `next_event_quantile`, each taking a posterior sample of the intensity parameters and returning posterior samples of the metric.
+- **Notebook:** [persistency](../../methane_pod/notebooks/08_persistency.md).
+- **Produces:** the dispatch / tasking decision — closing the loop back to Stage 1 (a re-task triggers a new overpass).
+
+---
+
+## The hand-off contract {#handoff-contract}
+
+The pipeline is robust because each stage's output is a *fixed payload* regardless of which model produced it. This is the contract that lets you climb the complexity axis stage-by-stage:
+
+```{list-table} Stage hand-offs — what each stage consumes and produces.
+:label: tbl-handoff
+:header-rows: 1
+
+* - Stage
+  - Consumes
+  - Produces
+  - Complexity-axis options
+* - 1 Retrieval
+  - L1/L2 radiance
+  - $\Delta\mathrm{XCH_4}(x,y)$ + $\mathbf R_\text{retr}$
+  - matched filter → optimal estimation → neural RTM
+* - 2 Inversion
+  - $\Delta\mathrm{XCH_4}$ field
+  - per-event $p(Q)$ + $\pi_\text{per-event}$
+  - Tier I plume → Tier II footprint → Tier III 4D-Var
+* - 3 Fusion *(opt.)*
+  - per-instrument $\{p(Q)\}$
+  - fused $p(Q,\text{bias})$
+  - single-instrument → multi-instrument list
+* - 4 Population
+  - $\{p(Q_i), \pi_i, t_i\}$
+  - $\lambda(t),\,f(Q),\,P_d$, total mass
+  - point estimate → importance-corrected full-sample
+* - 5 Persistency
+  - $\lambda(t)$ posterior
+  - wait time, $P(\text{occur})$, dispatch
+  - Poisson → Hawkes / Cox clustering
+```
+
+:::{important} The required field that is easy to forget
+The single most common cross-tier bug is dropping $\pi_\text{per-event}$ on the floor between Stage 2 and Stage 4. Without the per-event prior log-density, the population fit (Stage 4) is biased — see the [Tier V importance-correction note](roadmap/06_tier5_population.md#tier5-mark-contribution).
+:::
+
+---
+
+## How to reproduce a thin end-to-end slice {#reproduce}
+
+A minimal Tier I slice you can run today from the existing notebooks:
+
+1. **Retrieve** a synthetic plume scene → column enhancement: [matched-filter retrieval](../notebooks/radtran/05_matched_filter_retrieval.ipynb).
+2. **Invert** the column to an emission-rate posterior: [Gaussian plume emission-rate inference](../notebooks/02_emission_rate_parameter_estimation.ipynb).
+3. **Aggregate** many such posteriors into a point-process fit: [stationary NUTS fit](../../methane_pod/notebooks/06_stationary_numpyro_mcmc.ipynb).
+4. **Forecast** wait times / occurrence from the fitted intensity: [persistency](../../methane_pod/notebooks/08_persistency.md).
+
+The stages 3 (multi-instrument fusion) and the importance-corrected Stage 4 path are the upstream-`plumax` deliverables tracked in [Tier IV](roadmap/05_tier4_coupled.md) and [Tier V](roadmap/06_tier5_population.md); this page will gain a fully-executed companion notebook once those land in the in-repo port.
+
+---
+
+## See also {#see-also}
+
+- [Roadmap index — the two-axis modeling cycle](roadmap/README.md)
+- [Tier I — Gaussian family](roadmap/01_tier1_gaussian.md) · [Tier III — Eulerian FV](roadmap/03_tier3_eulerian.md) · [Tier IV — Coupled E2E](roadmap/05_tier4_coupled.md)
+- [Tier V — Population](roadmap/06_tier5_population.md) · [V.B point process](roadmap/06b_point_process.md) · [V.C persistency](roadmap/06c_persistency.md) · [V.D total emission](roadmap/06d_total_emission.md)

--- a/projects/plume_simulation/notes/roadmap.md
+++ b/projects/plume_simulation/notes/roadmap.md
@@ -40,11 +40,18 @@ The detailed roadmap now lives in [`roadmap/`](roadmap/README.md), one file per 
 (roadmap-cycle)=
 ## The cycle, in one diagram
 
-Every tier in `plumax` follows the same six-step loop:
+The architecture has **two axes**: an **inference axis** (the six-step loop, fixed at every tier) and a **complexity axis** (the forward-model fidelity, Tier I → V).
 
 ```text
-Simple model → model-based inference → emulator
-            → emulator-based inference → amortized predictor → improve
+                         MODEL COMPLEXITY  ─────────────────────────▶
+                  Tier I      Tier II     Tier III    Tier IV    Tier V
+  inference  ┌──  Gaussian    Lagrangian  Eulerian    Coupled    Population
+  axis       │    (analytic)  (stoch ODE) (PDE)       (+RTM)     (point proc.)
+    │        │
+    ▼   1 Simple model → 2 Model inference → 3 Emulator
+        → 4 Emulator inference → 5 Amortized predictor → 6 Improve ──┐
+        ▲                                                            │
+        └──────────────  climb one tier (complexity axis)  ◀─────────┘
 ```
 
-The cycle structure is the architecture. Each tier swaps in a richer forward model, but the inference loop, the validation tests, and the upgrade discipline are the same. See the [roadmap index](roadmap/README.md) for the full diagram and the rationale for each step.
+The cycle structure is the architecture. Each tier swaps in a richer forward model, but the inference loop, the validation tests, and the upgrade discipline are the same — and *each of the six steps* can itself become a more complex model as you move right along the complexity axis. Step 6 ("improve") is the move that climbs one tier. See the [roadmap index](roadmap/README.md) for the full two-axis diagram and the rationale for each step.

--- a/projects/plume_simulation/notes/roadmap/05_tier4_coupled.md
+++ b/projects/plume_simulation/notes/roadmap/05_tier4_coupled.md
@@ -15,6 +15,10 @@ keywords: [coupled forward model, multi-instrument fusion, MARS, TROPOMI, EMIT, 
 
 **Forward model:** transport + RTM + multi-instrument fusion, from source parameters all the way to simulated radiances across multiple satellites simultaneously. This is the full operational pipeline.
 
+:::{note} Upstream status (2026-06-02)
+Tier IV is **no longer purely proposed** in the upstream [`plumax`](https://github.com/jejjohnson/plumax) reference: `plumax.coupled` now lands v1 multi-instrument fusion — the Tier I plume + averaging-kernel coupled forward kept per-instrument at native resolution (`CoupledForward`, `Instrument`), a closed-form joint posterior over `(Q, bias_inst)` across satellites (`fuse_observations`), and an additive RTM-based observation operator (`RadianceObservationOperator`, plume column → gas ΔVMR → band-integrated radiance). The module table below keeps the in-repo `plume_simulation` port markers (still ☐ — not yet ported); see the [end-to-end walkthrough](../end_to_end_retrieval_to_persistency.md#stage3-fusion) for how this stage slots into the pipeline.
+:::
+
 ```text
 Source params (Q_{1:K}(t), x₀_{1:K}, t₀_{1:K},  ū, θ_wind, c_bg, α_BC, …)
        ↓  [Tier I/II/III transport]

--- a/projects/plume_simulation/notes/roadmap/06_tier5_population.md
+++ b/projects/plume_simulation/notes/roadmap/06_tier5_population.md
@@ -258,7 +258,8 @@ This isn't a coincidence — it's why `plumax`'s tier structure works: the same 
 
 - **Theory.** TMTPP foundations and the missing-mass paradox are written up in [`methane_pod/notebooks/01_mttpp_theory`](../../../methane_pod/notebooks/01_mttpp_theory.md) and [`03_missing_mass_paradox`](../../../methane_pod/notebooks/03_missing_mass_paradox.ipynb).
 - **`methane_pod` library:** ✓ — intensity, POD, paradox simulator, NUTS fitter all implemented.
-- **Cross-tier integration:** ☐ — per-event posteriors enter the population fit as point estimates (no importance correction). Tier V's main code deliverable.
+- **`plumax.population` subpackage (upstream):** 🚧 — the v1 cross-tier catalog adapter (`event_from_posterior` over Gaussian / lognormal / fusion posteriors), the V.A hierarchical lognormal size-distribution fit with per-event uncertainty propagation, and the V.B point-process core (closed-form Gamma–Poisson rate + log-linear inhomogeneous intensity) have landed. Not yet ported into this repo.
+- **Cross-tier integration:** 🚧 — per-event posteriors now enter the population fit as Gaussian summaries `(emission_rate, emission_std)` with uncertainty propagation; the importance-corrected full-sample path (carrying $\pi_\text{per-event}$) remains Tier V's main outstanding code deliverable.
 - **Synthetic validation.** [`06_stationary_numpyro_mcmc`](../../../methane_pod/notebooks/06_stationary_numpyro_mcmc.ipynb) recovers POD parameters on synthetic data without the soft-observation layer.
 - **Real-data fit.** [`07_pod_fitting_mcmc`](../../../methane_pod/notebooks/07_pod_fitting_mcmc.md) is a placeholder; needs IMEO + Tanager CSV ingestion.
 

--- a/projects/plume_simulation/notes/roadmap/README.md
+++ b/projects/plume_simulation/notes/roadmap/README.md
@@ -22,32 +22,37 @@ This page is the **index** for the architecture roadmap. The detail for each tie
 (cycle-overview)=
 ## The Data-Driven Modeling Cycle
 
-Every tier in `plumax` follows the same loop:
+The architecture has **two axes**:
+
+- The **inference axis** (vertical) is a fixed *six-step loop* — the same recipe at every tier.
+- The **complexity axis** (horizontal) is the *forward-model fidelity* — Tier I analytic → Tier V population.
+
+Every column runs the **same** six steps; what changes left-to-right is how complex the model behind each step is. Step 6 — *improve* — is the move that walks you one column to the right.
 
 ```text
-┌─────────────────────────────────────────────────────────────────┐
-│   (1) Simple Model                                              │
-│       ↓                                                         │
-│   (2) Model-Based Inference                                     │
-│       ↓                                                         │
-│   (3) Model Emulator          ← skip if model is cheap          │
-│       ↓                                                         │
-│   (4) Emulator-Based Inference                                  │
-│       ↓                                                         │
-│   (5) Amortized Inference (Predictor)                           │
-│       ↓                                                         │
-│   (6) Improve  ───────────────────────────────────────────────┐ │
-│       ↑         upgrade model / data / emulator / posterior   │ │
-│       └───────────────────────────────────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┘
+                    MODEL COMPLEXITY  ─────────────────────────────────────────────▶
+                    Tier I         Tier II        Tier III       Tier IV        Tier V
+                    Gaussian       Lagrangian     Eulerian FV    Coupled + RTM  Population
+                    (analytic)     (stoch. ODE)   (adv–diff PDE) (multi-inst)   (point proc.)
+  ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+1 │ Simple model    plume / puff   particles      adv–diff PDE   transport+RTM  λ(t), f(Q), Pd  │
+2 │ Model inference MAP / MCMC     footprint inv  4D-Var         joint fusion   NUTS population │
+3 │ Emulator        skip (cheap)   footprint NN   FNO/neural-ODE coupled net    flow over post. │
+4 │ Emu. inference  —              EKI            PDE-free 4DVar EKI / gradient SVI             │
+5 │ Amortized       Q-predictor    traj-pred.     field-pred.    overpass → Q   basin → λ, tot  │
+6 │ Improve ────────┴──────────────┴──────────────┴──────────────┴──────────────┘  ▲ climb a tier
+  └───────────────────────────────────────────────────────────────── same six steps ──────────┘
+    ▲ INFERENCE AXIS
 ```
 
-- Step 1 gives you a **generative story** — a known mathematical structure you can simulate from.
-- Step 2 gives you **ground truth inference** — slow but exact, used to validate everything downstream.
-- Step 3 makes Step 2 **tractable at scale** — replace the expensive forward model with a fast surrogate.
-- Step 4 is Step 2 again, but now running in seconds instead of hours.
-- Step 5 collapses the inference loop entirely — the predictor learns the posterior map directly.
-- Step 6 closes the loop — every component is independently upgradable, with the previous step as ground truth.
+Read **down** a column for one tier's full cycle; read **across** a row to watch a single step grow in complexity tier-to-tier. The point the diagram makes: this is *not* a single linear "model → amortized predictor" pipeline. **Each of the six steps is itself swappable for a more complex model**, and "improve" (Step 6) is structured — it picks one component (a richer forward model, a higher tier, more data, a better posterior family) and re-enters the loop with the previous step (or tier) as ground truth.
+
+- **Step 1 — Simple Model** gives you a **generative story** — a known mathematical structure you can simulate from.
+- **Step 2 — Model-Based Inference** gives you **ground-truth inference** — slow but exact, used to validate everything downstream.
+- **Step 3 — Model Emulator** makes Step 2 **tractable at scale** — replace the expensive forward model with a fast surrogate (skip if the model is already cheap).
+- **Step 4 — Emulator-Based Inference** is Step 2 again, but now running in seconds instead of hours.
+- **Step 5 — Amortized Inference (Predictor)** collapses the inference loop entirely — the predictor learns the posterior map directly.
+- **Step 6 — Improve** closes the loop — every component is independently upgradable, and the complexity axis tells you *which* component to upgrade and *how* to validate it.
 
 ---
 
@@ -102,6 +107,8 @@ Every tier in `plumax` follows the same loop:
 
 The build order is roughly: **Prerequisites → Tier I → RTM stack (parallel) → Tier II → Tier III → Tier IV → Tier V.** RTM is independent of transport tier, so it can be developed in parallel by a different person without coordination cost. Tier V depends on at least Tier I being usable end-to-end (per-event posteriors are the input), but does not need Tiers II–IV — it can launch with Tier I posteriors and absorb richer ones later.
 
+For how the tiers compose into a single operational pipeline — from a satellite radiance all the way to a leak-recurrence forecast — see the [end-to-end retrieval → persistency walkthrough](../end_to_end_retrieval_to_persistency.md).
+
 ---
 
 (architectural-principles)=
@@ -124,21 +131,21 @@ WRF provides met forcing and benchmark concentration fields. `plumax` learns to 
 :::
 
 :::{important} 5. Improvement is structured
-Step 6 is not vague iteration. Each improvement targets a specific component — better physics, more training data, richer posterior family, tighter observation operator — and the cycle structure tells you which component to upgrade and how to validate it.
+Step 6 is not vague iteration. Each improvement targets a specific component — better physics, more training data, richer posterior family, tighter observation operator — and the cycle structure (which row) and the complexity axis (which column) together tell you which component to upgrade and how to validate it.
 :::
 
 ---
 
 (status-snapshot)=
-## Status snapshot (2026-04-29)
+## Status snapshot (2026-06-02)
 
-Module-level status is tracked per tier. Quick overview:
+Module-level status is tracked per tier. Two things move at different speeds: the **design maturity** (these roadmap pages, kept in sync with the upstream [`plumax`](https://github.com/jejjohnson/plumax) reference implementation) and the **in-repo `plume_simulation` port**, which currently mirrors Tier I + the RTM stack + the Tier III scaffolding. Quick overview:
 
-- **Tier I — Gaussian:** ✓ plume + puff forward models, ✓ MAP/MCMC inversion. Emulator + amortized predictor not yet started.
-- **Tier II — Lagrangian:** ☐ not started. No `gauss_flows`-style trajectory module yet.
-- **Tier III — Eulerian FV:** 🚧 [`les_fvm`](../../src/plume_simulation/les_fvm/) advection/diffusion/dynamics implemented; [`assimilation`](../../src/plume_simulation/assimilation/) cost/control/solve scaffolding present. 4D-Var loop not wired end-to-end.
-- **RTM stack:** 🚧 [`hapi_lut`](../../src/plume_simulation/hapi_lut/) LUT generator + Beer–Lambert in place; [`radtran`](../../src/plume_simulation/radtran/) instrument/SRF/forward modules present; [`matched_filter`](../../src/plume_simulation/matched_filter/) detection pipeline in place. Optimal-estimation retrieval not wired; neural RTM not started.
-- **Tier IV — Coupled:** ☐ not started. Awaiting Tier I + RTM completion before assembling the coupled forward.
-- **Tier V — Population & forecasting:** 🚧 standalone [`methane_pod`](../../../methane_pod/) library is feature-complete (intensity catalog, POD catalog, paradox simulator, NUTS fitter, synthetic-data validation). Missing: cross-tier adapter that turns Tier I–IV per-event posteriors into TMTPP mark likelihoods; real-data CSV ingestion; multi-satellite fusion. See [Tier V index](06_tier5_population.md).
+- **Tier I — Gaussian:** ✓ plume + puff forward models, ✓ MAP/MCMC inversion (port + upstream). Emulator + amortized predictor not yet started.
+- **Tier II — Lagrangian:** 🚧 upstream `plumax.lagrangian` now lands the forward model + model-based inference — Markov-1 Langevin particles, homogeneous + Hanna turbulence, forward residence-time concentration, backward footprint, and closed-form Gaussian / lognormal source inversion with a Matérn-3/2 prior. Not yet ported into this repo. Footprint emulator + predictor (Steps 3–5) not started.
+- **Tier III — Eulerian FV:** 🚧 [`les_fvm`](../../src/plume_simulation/les_fvm/) advection/diffusion/dynamics implemented in-repo; upstream now wires the strong-constraint **4D-Var loop end-to-end** (differentiable emission→column-obs forward, whitened temporal Matérn-3/2 control space, L-BFGS with the exact discrete adjoint via reverse-mode AD through the diffrax FV solver), plus a Gauss–Newton Laplace **posterior covariance** around the MAP (Hessian via `gaussx`). The in-repo [`assimilation`](../../src/plume_simulation/assimilation/) cost/control/solve scaffolding tracks the earlier snapshot.
+- **RTM stack:** 🚧 [`hapi_lut`](../../src/plume_simulation/hapi_lut/) LUT generator + Beer–Lambert, [`radtran`](../../src/plume_simulation/radtran/) instrument/SRF/forward modules, and [`matched_filter`](../../src/plume_simulation/matched_filter/) detection pipeline all in place. Optimal-estimation retrieval not wired; neural RTM not started.
+- **Tier IV — Coupled:** 🚧 upstream `plumax.coupled` lands v1 multi-instrument fusion — the Tier I plume + averaging-kernel coupled forward kept per-instrument at native resolution (`CoupledForward`, `Instrument`), a closed-form joint posterior over `(Q, bias_inst)` across satellites (`fuse_observations`, exploiting the plume's linearity in `Q`), and an additive RTM-based observation operator (`RadianceObservationOperator`) mapping plume column enhancement → gas ΔVMR → band-integrated normalised radiance. Full Tier II/III + RTM coupling, the `Q(t)` stochastic process, and trans-dimensional source count are future work. Not yet ported into this repo.
+- **Tier V — Population & forecasting:** 🚧 the standalone [`methane_pod`](../../../methane_pod/) library is feature-complete (intensity catalog, POD catalog, paradox simulator, NUTS fitter, synthetic-data validation). Upstream now also lands the in-tree `plumax.population` v1 core: the tier-agnostic cross-tier posterior catalog (`event_from_posterior` over Gaussian / lognormal / fusion posteriors), the V.A hierarchical lognormal size-distribution fit with per-event uncertainty propagation, and the V.B point-process core (closed-form Gamma–Poisson rate + log-linear inhomogeneous intensity). Still missing: the importance-corrected TMTPP mark likelihood, real-data CSV ingestion, multi-satellite POD fusion, and the LGCP intensity.
 
-See each tier page for module-level breakdown.
+See each tier page for the module-level breakdown, and the [end-to-end retrieval → persistency walkthrough](../end_to_end_retrieval_to_persistency.md) for how the tiers compose into one operational pipeline.


### PR DESCRIPTION
## Summary

Adjusts the `plume_simulation` modeling docs to match the current `plumax` package + design docs, in three parts:

### 1. Two-axis modeling diagram (complexity axis added)
The old linear `model → … → amortized predictor` loop is reworked into a **grid**: the six-step inference loop runs vertically, model **complexity** (Tier I Gaussian → V population) runs horizontally. Reading *down* a column = one tier's full cycle; reading *across* a row = how a single step grows in complexity tier-to-tier. "Improve" (step 6) is now explicitly the move that climbs one tier — making the point that **each step is itself swappable for a more complex model**, not just `model → amortized inference`. Updated both the full diagram (`roadmap/README.md`) and the one-line version (`roadmap.md`).

### 2. End-to-end retrieval → persistency walkthrough
New `notes/end_to_end_retrieval_to_persistency.md` (wired into `myst.yml`) — a connective story threading the per-tier notebooks into one operational pipeline, with its own ASCII flow diagram and a cross-stage hand-off contract table:

- **Retrieval** (RTM: `hapi_lut` / `radtran` / `matched_filter`) → ΔXCH₄
- **Inversion** (Tier I plume / Tier III 4D-Var) → per-event `p(Q)`
- **Fusion** (Tier IV coupled, optional) → joint `(Q, bias_inst)`
- **Population** (Tier V.A/B TMTPP) → `f(Q)`, `λ(t)`
- **Persistency** (Tier V.C) → wait time / occurrence / dispatch

It flags the easy-to-miss `π_per-event` requirement for the importance correction between inversion and population.

### 3. Status refresh to match `plumax`
The port's status snapshots had drifted (dated 2026-04-29, "Tier II/IV not started", "Tier III 4D-Var not wired"). Refreshed the roadmap index snapshot, the Tier IV upstream-status note (coupled fusion landed), and the Tier V snapshot (`plumax.population` v1 core landed). The **port-vs-upstream distinction is kept honest**: the in-repo `src/` genuinely lacks `lagrangian` / `coupled` / `population`, so these are marked as landed *upstream in `plumax`* / not-yet-ported rather than claiming `plume_simulation.coupled` exists.

## Files
- `projects/plume_simulation/notes/roadmap/README.md` — two-axis diagram + refreshed status snapshot
- `projects/plume_simulation/notes/roadmap.md` — mini two-axis diagram
- `projects/plume_simulation/notes/end_to_end_retrieval_to_persistency.md` — **new** walkthrough
- `projects/plume_simulation/notes/roadmap/05_tier4_coupled.md` — upstream-status note
- `projects/plume_simulation/notes/roadmap/06_tier5_population.md` — refreshed status snapshot
- `myst.yml` — register the new page

## Test plan
- [x] `myst.yml` parses (`yaml.safe_load`)
- [x] All code fences balanced across edited/new markdown
- [x] All cross-linked notebooks / pages resolve on disk
- [x] Docs-only change — no code, tests, or package surface touched

## Notes
- The walkthrough is a **prose story page** (no execution); it ends with a runnable "thin Tier I slice" section. A fully-executed companion notebook is the natural follow-up once `coupled` + the importance-corrected `population` path land in the in-repo port.

https://claude.ai/code/session_01TLZSqaD7ZA1zHfA1ZPPJCu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLZSqaD7ZA1zHfA1ZPPJCu)_