### PR TITLE
feat(benchmark): add AEMET observation archive project

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -78,6 +78,9 @@ project:
                 - file: notebooks/coordax/dynamics/10_pde_parameter_estimation.ipynb
     - title: Projects
       children:
+        - title: Benchmark Archives
+          children:
+            - file: projects/benchmark/README.md
         - title: Spatial Extremes
           children:
             - file: projects/spatial_extremes/README.md

--- a/pixi.toml
+++ b/pixi.toml
@@ -332,6 +332,41 @@ lab = "jupyter lab --no-browser --port 8888"
 # Offline registry sanity checks.
 test-satellite-viewer = "pytest projects/satellite_viewer/tests/ -v"
 
+# ---------------------------------------------------------------------------
+# Data env: benchmark
+# Paced, resumable AEMET scrapes cached as GeoParquet. Long-running and
+# network-bound — see projects/benchmark/README.md for the resume workflow.
+# ---------------------------------------------------------------------------
+[feature.benchmark.dependencies]
+python = "3.12.*"
+ipykernel = ">=6.29"
+jupyter = "*"
+nbconvert = "*"
+jupytext = ">=1.16"
+
+[feature.benchmark.pypi-dependencies]
+benchmark = { path = "projects/benchmark", editable = true, extras = ["notebooks"] }
+# The reader is not on PyPI, and pixi does not read the project's
+# [tool.uv.sources], so the git source is restated here. Pinned to a commit
+# (not a branch) so the lockfile has a stable ref — bump when you want a
+# newer reader. httpx + geopandas + pyarrow + netcdf4 come through the
+# [aemet] extra.
+xrtoolz-reader = { git = "https://github.com/jejjohnson/xr_toolz.git", subdirectory = "packages/xrtoolz-reader", rev = "8bdb7653ff4ae95b15350a406a41758bac3d7bcd", extras = ["aemet"] }
+
+[feature.benchmark.tasks]
+# What the archive already holds, and the --start value to resume from.
+# Offline: reads the cached GeoParquet, no API key needed.
+aemet-coverage = "python projects/benchmark/scripts/observations/aemet/coverage.py"
+# ~15 min end-to-end sanity check against the live API (37 stations).
+aemet-smoke = "python projects/benchmark/scripts/observations/aemet/smoke.py"
+# Full-network scrapes. Hours to days — prefer the tmux wrapper below so
+# an interrupted session does not take the scrape down with it.
+aemet-monthly = "python projects/benchmark/scripts/observations/aemet/monthly.py"
+aemet-daily = "python projects/benchmark/scripts/observations/aemet/daily.py"
+# tmux wrapper + CPU keepalive for long unattended runs:
+#   pixi run -e benchmark aemet-resume monthly --start 2020
+aemet-resume = "projects/benchmark/scripts/observations/aemet/resume.sh"
+
 [environments]
 default = { features = ["dev"], solve-group = "default" }
 docs = { features = ["docs"], solve-group = "default" }
@@ -343,6 +378,7 @@ methane-pod = { features = ["methane-pod", "dev"], solve-group = "methane-pod" }
 plume-simulation = { features = ["plume-simulation", "dev"], solve-group = "plume-simulation" }
 geostack = { features = ["geostack", "dev"], solve-group = "geostack" }
 satellite-viewer = { features = ["satellite-viewer", "dev"], solve-group = "satellite-viewer" }
+benchmark = { features = ["benchmark", "dev"], solve-group = "benchmark" }
 
 [tasks]
 test = "pytest -v"

--- a/projects/benchmark/.env.example
+++ b/projects/benchmark/.env.example
@@ -1,0 +1,15 @@
+# --- AEMET OpenData (Spanish meteorological service) ------------------------
+# Request a free key: https://opendata.aemet.es/centrodedescargas/obtencionAPIKey
+# Read by xrreader.load_aemet() from the environment, a .env file walked up
+# from CWD, or ~/.aemet.
+#
+# NOTE: AEMET keys are JWTs and they expire. A scrape that starts failing with
+# AemetAuthError after weeks of working is almost always an expired key —
+# re-request one at the URL above before debugging anything else.
+AEMET_API_KEY=
+
+# Where the GeoParquet archives land. Keep this OFF the repo disk so the data
+# survives VM rebuilds and never risks being committed. Resolution order is
+# AEMET_SCRATCH_ROOT, then BENCHMARK_AEMET_ROOT, then ./data/aemet.
+# Recommended in ~/.bashrc:
+AEMET_SCRATCH_ROOT=/path/to/scratch/aemet

--- a/projects/benchmark/.gitignore
+++ b/projects/benchmark/.gitignore
@@ -1,0 +1,21 @@
+# Scrape archives — large, reproducible, and kept outside the repo entirely
+# (see AEMET_SCRATCH_ROOT in .env.example). Never committed.
+data/*
+!data/.gitkeep
+!data/*.dvc
+
+# Run logs from the long scrapes
+logs/
+
+# Build artefacts
+_build/
+*.bak
+
+# Resolved environment. No sibling project under projects/ commits its lock —
+# and the reader is pinned to a git branch, so a lock here would give only
+# partial reproducibility anyway. Flip this if you want the pin.
+uv.lock
+
+# Secrets — AEMET API key, never commit this
+.env
+.secrets/

--- a/projects/benchmark/README.md
+++ b/projects/benchmark/README.md
@@ -1,0 +1,108 @@
+---
+title: Benchmark Archives
+short_title: Benchmark
+authors:
+  - name: Juan Emmanuel Johnson
+date: 2026-08-19
+---
+
+# Benchmark Archives
+
+Reference observational archives for benchmarking, pulled from their
+source APIs and cached as GeoParquet. Each source is a paced, resumable
+scrape: slow on purpose, safe to interrupt, and idempotent on re-run.
+
+The data layer is [`xrtoolz-reader`](https://github.com/jejjohnson/xr_toolz)
+(the reader package of the xrtoolz monorepo). Note the distribution is named
+`xrtoolz-reader` but the **import namespace is still `xrreader`** —
+`from xrreader import AemetArchive` is unchanged from the standalone package.
+
+## Layout
+
+```
+projects/benchmark/
+├── src/benchmark/observations/aemet/   # archive wiring, period schedules
+└── scripts/observations/aemet/         # thin CLI entry points
+```
+
+New sources slot in as siblings — `observations/ghcn`, `reanalysis/era5` —
+reusing the same pacing and logging conventions.
+
+## observations/aemet — Spanish national network
+
+AEMET OpenData's climatological endpoints for all ~947 stations, from
+1920 to the present.
+
+| Script | What it does |
+|---|---|
+| `smoke.py` | ~10 min end-to-end validation over ~40 stations. Run first. |
+| `coverage.py` | Offline report of what the archive holds + the resume year. |
+| `monthly.py` | Full-network monthly scrape, two-year windows. |
+| `daily.py` | Full-network daily scrape. Much heavier — see below. |
+| `resume.sh` | tmux wrapper with a CPU keepalive sidecar. **Use this** for long runs. |
+
+### Setup
+
+```bash
+cd projects/benchmark
+uv sync                                    # installs xrtoolz-reader[aemet]
+cp .env.example .env                       # add your AEMET_API_KEY
+export AEMET_SCRATCH_ROOT=$HOME/scratch/aemet   # keep data off the repo disk
+uv run python scripts/observations/aemet/smoke.py
+```
+
+### Current state of the monthly scrape
+
+The archive holds **1920–1954 complete** for all 947 stations (397,740
+rows). The run stopped on 2026-05-05 partway through 1955–1959 and was
+never restarted.
+
+Note the inventory has since shrunk to **921 stations** (2026-08-19) — AEMET
+retires and renumbers stations, so the live network no longer matches the 947
+frozen into the archive. Rows for retired stations stay in the archive; new
+windows simply will not extend them.
+
+Worth knowing before you judge that progress: the years already held are
+the sparse ones. Non-null temperature runs ~2% in 1920 rising to ~7% by
+1954 — the network only densifies after 1960, so essentially all the
+usable data is still ahead.
+
+To resume, confirm the restart year and go:
+
+```bash
+uv run python scripts/observations/aemet/coverage.py     # prints: resume with --start 1955
+scripts/observations/aemet/resume.sh monthly --start 1955
+```
+
+### Pacing — why it is slow
+
+`build_archive` defaults to 60 req/min, single worker. That is half of
+AEMET's ~150 req/min rolling cap, and it is deliberate: the original
+two-worker / 120 req/min config tripped 429s, because while one worker
+backed off the other kept the minute bucket hot. `AemetSource` now also
+pauses *all* workers globally on any 429, but single-worker at 1 req/s
+remains the setting that finishes.
+
+Budget roughly **50 minutes per two-year monthly window** (~36 windows
+left, so ~30 hours), and considerably more for daily — its endpoint caps
+each request at 180 days, so a station-decade costs ~20 chunks.
+
+### Two failure modes to recognise
+
+**Process vanishes, no traceback.** Azure ML's idle-stop agent kills
+compute it judges idle, and a rate-limited scrape sits at near-zero CPU.
+This is what ended the 2026-05-05 run. `resume.sh` exists to prevent it —
+it runs a ~0.5% duty-cycle CPU sidecar alongside the scrape. Launch long
+runs through it, not directly.
+
+**`AemetAuthError` after weeks of working.** AEMET API keys are JWTs and
+they expire. Re-request one before debugging anything else. (Not the cause
+of the 2026-05-05 stop — the key still authenticated on 2026-08-19.)
+
+### Resume semantics
+
+`AemetArchive.sync` is idempotent, not additive, and has **no per-station
+resume** — re-running a window refetches every station in it. Interrupting
+is always safe for the data, but partial windows are not credited, so
+restart at the first *incomplete* year. `coverage.py` computes it, and
+flags interior gaps left by an interrupted window.

--- a/projects/benchmark/README.md
+++ b/projects/benchmark/README.md
@@ -43,35 +43,58 @@ AEMET OpenData's climatological endpoints for all ~947 stations, from
 
 ### Setup
 
+The repo standard is Pixi, and the benchmark is registered as its own
+environment + task set, so a clean checkout needs no second toolchain:
+
 ```bash
-cd projects/benchmark
-uv sync                                    # installs xrtoolz-reader[aemet]
-cp .env.example .env                       # add your AEMET_API_KEY
-export AEMET_SCRATCH_ROOT=$HOME/scratch/aemet   # keep data off the repo disk
-uv run python scripts/observations/aemet/smoke.py
+cp projects/benchmark/.env.example projects/benchmark/.env   # add AEMET_API_KEY
+pixi run -e benchmark aemet-smoke                            # ~15 min live check
 ```
+
+| Task | What it runs |
+|---|---|
+| `pixi run -e benchmark aemet-coverage` | Offline coverage + resume year |
+| `pixi run -e benchmark aemet-smoke` | ~15 min live validation |
+| `pixi run -e benchmark aemet-monthly` | Full monthly scrape |
+| `pixi run -e benchmark aemet-daily` | Full daily scrape |
+| `pixi run -e benchmark aemet-resume monthly --start 2020` | tmux + keepalive wrapper |
+
+Where the archive lands is resolved by `scratch_root()`: exported
+`AEMET_SCRATCH_ROOT`, then `BENCHMARK_AEMET_ROOT`, then either name in
+`projects/benchmark/.env`, then `<project>/data/aemet`. Point it off the
+repo disk so the data survives VM rebuilds:
+
+```bash
+export AEMET_SCRATCH_ROOT=$HOME/scratch/aemet   # or set it in .env
+```
+
+Working inside `projects/benchmark/` directly, `uv` also resolves the
+same project — `uv sync && uv run python scripts/observations/aemet/smoke.py`.
+Both paths install `xrtoolz-reader[aemet]` from the same pinned commit.
 
 ### Current state of the monthly scrape
 
-The archive holds **1920–1954 complete** for all 947 stations (397,740
-rows). The run stopped on 2026-05-05 partway through 1955–1959 and was
-never restarted.
+The archive holds **1920–2019 complete** — 1,116,120 rows. The 2026-08-20
+run carried it from 1954 to 2019 in 33 two-year windows (~23 h) and was
+interrupted partway through 2020–2021, so **three windows remain**
+(2020–2021, 2022–2023, 2024–2025).
 
-Note the inventory has since shrunk to **921 stations** (2026-08-19) — AEMET
-retires and renumbers stations, so the live network no longer matches the 947
-frozen into the archive. Rows for retired stations stay in the archive; new
-windows simply will not extend them.
+Coverage is thin early and dense late, which is the network, not the
+scrape: non-null temperature runs ~2% in 1920, ~7% by 1954, ~12% by 1980,
+and 86% by 2019.
 
-Worth knowing before you judge that progress: the years already held are
-the sparse ones. Non-null temperature runs ~2% in 1920 rising to ~7% by
-1954 — the network only densifies after 1960, so essentially all the
-usable data is still ahead.
+Station counts differ by era for a real reason. Rows before 1955 carry 947
+stations; rows from 1955 on carry the 921 the API advertised when that
+window ran. AEMET retires and renumbers stations, so the live inventory is
+a moving target — `merged_inventory()` now unions it with the stations
+already in the archive (currently 921 live + 28 retired = 949) so later
+windows extend the retired stations instead of dropping them.
 
 To resume, confirm the restart year and go:
 
 ```bash
-uv run python scripts/observations/aemet/coverage.py     # prints: resume with --start 1955
-scripts/observations/aemet/resume.sh monthly --start 1955
+pixi run -e benchmark aemet-coverage        # prints: resume with --start 2020
+pixi run -e benchmark aemet-resume monthly --start 2020
 ```
 
 ### Pacing — why it is slow
@@ -83,17 +106,31 @@ backed off the other kept the minute bucket hot. `AemetSource` now also
 pauses *all* workers globally on any 429, but single-worker at 1 req/s
 remains the setting that finishes.
 
-Budget roughly **50 minutes per two-year monthly window** (~36 windows
-left, so ~30 hours), and considerably more for daily — its endpoint caps
-each request at 180 days, so a station-decade costs ~20 chunks.
+Measured over the 33 windows of the 2026-08-20 run: **34 min** per
+two-year window early on, rising to **55 min** for the recent, denser
+years — the request count per window grows with the number of reporting
+stations. Budget ~1 h per remaining window, and considerably more for
+daily, whose endpoint caps each request at 180 days so a station-decade
+costs ~20 chunks.
 
 ### Two failure modes to recognise
 
-**Process vanishes, no traceback.** Azure ML's idle-stop agent kills
-compute it judges idle, and a rate-limited scrape sits at near-zero CPU.
-This is what ended the 2026-05-05 run. `resume.sh` exists to prevent it —
-it runs a ~0.5% duty-cycle CPU sidecar alongside the scrape. Launch long
-runs through it, not directly.
+**Process vanishes, no traceback.** Two different causes, worth telling
+apart before you reach for a fix.
+
+*Idle-stop.* Azure ML kills compute it judges idle, and a rate-limited
+scrape sits at near-zero CPU. `resume.sh` runs a ~0.5% duty-cycle CPU
+sidecar to keep the sampler seeing activity. Launch long runs through it,
+not directly.
+
+*Control-plane stop.* The 2026-08-19 run died six minutes in, and it was
+not idle-stop: `idleMinutesBeforeStop` was **120** and the CPU had been
+busy throughout, while the kernel logged `hv_utils: Shutdown request
+received — graceful shutdown initiated`. That is an external stop —
+scheduled shutdown policy, a portal stop, or platform maintenance — and no
+userspace keepalive prevents it. Check the instance's schedule before
+committing to a multi-hour run. (Which of the two ended the 2026-05-05 run
+was never established; the logs for it are gone.)
 
 **`AemetAuthError` after weeks of working.** AEMET API keys are JWTs and
 they expire. Re-request one before debugging anything else. (Not the cause
@@ -106,3 +143,8 @@ resume** — re-running a window refetches every station in it. Interrupting
 is always safe for the data, but partial windows are not credited, so
 restart at the first *incomplete* year. `coverage.py` computes it, and
 flags interior gaps left by an interrupted window.
+
+Year bounds are validated rather than silently clipped: a request that
+selects no window at all — `--start 2026` against a schedule ending in
+2025 — raises instead of logging the requested range, fetching nothing,
+and reporting that every period completed.

--- a/projects/benchmark/myst.yml
+++ b/projects/benchmark/myst.yml
@@ -1,0 +1,14 @@
+version: 1
+# Standalone MyST config for previewing the benchmark archives docs on their
+# own (`myst build --html` / `myst start` from this folder). The pages also
+# slot into the parent Research Notebook site via its top-level myst.yml.
+project:
+  id: benchmark
+  title: Benchmark Archives
+  authors:
+    - name: Juan Emmanuel Johnson
+  toc:
+    - file: README.md
+site:
+  template: book-theme
+  title: Benchmark Archives

--- a/projects/benchmark/pyproject.toml
+++ b/projects/benchmark/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "benchmark"
+version = "0.1.0"
+description = "Reference observational and reanalysis archives for benchmarking: paced, resumable scrapes cached as GeoParquet."
+requires-python = ">=3.12"
+# Data layer only. The reader now lives in the xrtoolz monorepo as the
+# `xrtoolz-reader` distribution — the import namespace is still `xrreader`,
+# so `from xrreader import AemetArchive` is unchanged from the standalone
+# package. The [aemet] extra pulls httpx + geopandas + pyarrow + loguru +
+# netcdf4, which is everything AemetArchive needs for the GeoParquet cache.
+dependencies = [
+    "xrtoolz-reader[aemet]",
+    "loguru>=0.7",
+    "pandas>=2.1",
+    "xarray>=2024.10",
+]
+
+[project.optional-dependencies]
+# Inspection helpers for the coverage report + any notebook write-ups.
+notebooks = [
+    "matplotlib",
+    "ipython",
+    "ipykernel>=6.29",
+    "mystmd>=1.3",
+]
+
+# xrtoolz is not on PyPI — resolve the reader from the monorepo subdirectory.
+[tool.uv.sources]
+xrtoolz-reader = { git = "https://github.com/jejjohnson/xr_toolz.git", subdirectory = "packages/xrtoolz-reader" }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/benchmark"]

--- a/projects/benchmark/scripts/observations/aemet/coverage.py
+++ b/projects/benchmark/scripts/observations/aemet/coverage.py
@@ -1,0 +1,88 @@
+"""Report what the AEMET archive already holds — and where to resume.
+
+Reads the cached GeoParquet directly (no network, no credentials) and
+prints per-year row counts plus non-null density for a reference
+variable. The last line is the ``--start`` value to hand the scraper.
+
+This exists because ``AemetArchive.sync`` has no per-station resume: it
+refetches every station in a window. Knowing the exact first incomplete
+year is the difference between redoing 50 minutes and redoing a day.
+
+Run:
+    uv run python scripts/observations/aemet/coverage.py
+    uv run python scripts/observations/aemet/coverage.py --preset aemet_daily
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import pandas as pd
+from benchmark.observations.aemet.paths import scratch_root
+from benchmark.observations.aemet.periods import LAST_YEAR
+
+
+# Archive subdirectory per preset — mirrors the build_archive() calls in
+# the scrape scripts.
+SUBDIR = {"aemet_monthly": "monthly", "aemet_daily": "daily"}
+
+REFERENCE_VARIABLE = "air_temperature_daily_mean"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--preset",
+        default="aemet_monthly",
+        choices=sorted(SUBDIR),
+        help="which archive to report on",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    path = scratch_root() / SUBDIR[args.preset] / f"{args.preset}.parquet"
+
+    if not path.exists():
+        print(f"no archive at {path}")
+        print("nothing scraped yet — start from the beginning")
+        return 1
+
+    df = pd.read_parquet(path, columns=["station_id", "time", REFERENCE_VARIABLE])
+    df["year"] = pd.to_datetime(df["time"]).dt.year
+
+    by_year = df.groupby("year").agg(
+        rows=("station_id", "size"),
+        stations=("station_id", "nunique"),
+        non_null=(REFERENCE_VARIABLE, lambda s: s.notna().sum()),
+    )
+    by_year["density"] = (by_year["non_null"] / by_year["rows"] * 100).round(1)
+
+    print(f"archive: {path}")
+    print(f"rows: {len(df):,}   stations: {df.station_id.nunique()}")
+    print(f"years: {by_year.index.min()}-{by_year.index.max()}\n")
+    print(by_year.to_string())
+
+    # A year is "held" if it has any rows at all. The first year with no
+    # rows is where the scrape stopped; gaps in the middle mean an
+    # interrupted window that needs re-running, so report those loudly.
+    held = set(by_year.index)
+    span = range(int(by_year.index.min()), LAST_YEAR + 1)
+    missing = [y for y in span if y not in held]
+
+    print()
+    if not missing:
+        print(f"complete through {LAST_YEAR} — nothing to resume")
+        return 0
+
+    gaps = [y for y in missing if y < max(held)]
+    if gaps:
+        print(f"WARNING: interior gaps at {gaps} — re-run those windows too")
+    print(f"resume with: --start {missing[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/benchmark/scripts/observations/aemet/coverage.py
+++ b/projects/benchmark/scripts/observations/aemet/coverage.py
@@ -51,6 +51,16 @@ def main() -> int:
         return 1
 
     df = pd.read_parquet(path, columns=["station_id", "time", REFERENCE_VARIABLE])
+
+    # An archive file can exist but hold nothing — e.g. a window that
+    # returned no observations still writes the parquet. Bail out with the
+    # same actionable message as a missing file rather than letting the
+    # year-span arithmetic below raise on an empty index.
+    if df.empty:
+        print(f"archive at {path} is empty (0 rows)")
+        print("nothing scraped yet — start from the beginning")
+        return 1
+
     df["year"] = pd.to_datetime(df["time"]).dt.year
 
     by_year = df.groupby("year").agg(

--- a/projects/benchmark/scripts/observations/aemet/daily.py
+++ b/projects/benchmark/scripts/observations/aemet/daily.py
@@ -1,0 +1,81 @@
+"""Full-network AEMET daily scrape — multi-period, resumable.
+
+Daily is the big one. AEMET's daily climatological endpoint caps each
+request at 180 days, so a single station's decade takes ~20 chunks —
+roughly 6x the monthly budget. Expect on the order of 60 hours of wall
+time at 60 req/min pacing for ~947 stations across 1920-2025.
+
+Most stations have no data before ~1950, so ``--start 1950`` is usually
+the right call if quota or wall time is a concern.
+
+Run:
+    uv run python scripts/observations/aemet/daily.py                    # full
+    uv run python scripts/observations/aemet/daily.py --start 1950
+    uv run python scripts/observations/aemet/daily.py --start 2015 --end 2025
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from benchmark.observations.aemet import (
+    build_archive,
+    build_periods,
+    select_periods,
+    setup_logging,
+)
+from benchmark.observations.aemet.periods import FIRST_YEAR, LAST_YEAR
+from loguru import logger
+
+
+# Two-year windows — same granularity as monthly, but each one is far
+# heavier here because of the 180-day request cap.
+PERIODS = build_periods(step=2)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--start", type=int, default=FIRST_YEAR, help="first year to scrape")
+    p.add_argument("--end", type=int, default=LAST_YEAR, help="last year to scrape")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    setup_logging("aemet_daily")
+    archive = build_archive("daily")
+
+    logger.info("refreshing station inventory")
+    inventory = archive.sync_stations()
+    logger.info(f"inventory: {len(inventory)} stations")
+
+    todo = select_periods(PERIODS, args.start, args.end)
+    logger.info(f"{len(todo)} periods to scrape ({args.start}-{args.end})")
+
+    t0 = time.monotonic()
+    for i, y1, y2 in todo:
+        logger.info(f"period {i}/{len(PERIODS)}: {y1}-{y2}")
+        period_t0 = time.monotonic()
+        try:
+            ds = archive.sync(
+                "aemet_daily",
+                stations=inventory,
+                since=f"{y1}-01-01",
+                until=f"{y2}-12-31",
+            )
+        except KeyboardInterrupt:
+            logger.warning(f"interrupted in period {y1}-{y2}; archive is safe")
+            raise
+        logger.info(
+            f"  period {y1}-{y2}: stations={ds.sizes['station']}, "
+            f"days={ds.sizes['time']}, "
+            f"elapsed={time.monotonic() - period_t0:.1f}s"
+        )
+
+    logger.info(f"all periods done in {time.monotonic() - t0:.1f}s")
+    logger.info("archive at: {}", archive.root)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/benchmark/scripts/observations/aemet/daily.py
+++ b/projects/benchmark/scripts/observations/aemet/daily.py
@@ -25,6 +25,7 @@ from benchmark.observations.aemet import (
     select_periods,
     setup_logging,
 )
+from benchmark.observations.aemet.inventory import merged_inventory
 from benchmark.observations.aemet.periods import FIRST_YEAR, LAST_YEAR
 from loguru import logger
 
@@ -47,11 +48,10 @@ def main() -> None:
     archive = build_archive("daily")
 
     logger.info("refreshing station inventory")
-    inventory = archive.sync_stations()
-    logger.info(f"inventory: {len(inventory)} stations")
+    inventory = merged_inventory(archive, "aemet_daily")
 
     todo = select_periods(PERIODS, args.start, args.end)
-    logger.info(f"{len(todo)} periods to scrape ({args.start}-{args.end})")
+    logger.info(f"{len(todo)} periods to scrape ({todo[0][1]}-{todo[-1][2]})")
 
     t0 = time.monotonic()
     for i, y1, y2 in todo:

--- a/projects/benchmark/scripts/observations/aemet/monthly.py
+++ b/projects/benchmark/scripts/observations/aemet/monthly.py
@@ -30,6 +30,7 @@ from benchmark.observations.aemet import (
     select_periods,
     setup_logging,
 )
+from benchmark.observations.aemet.inventory import merged_inventory
 from benchmark.observations.aemet.periods import FIRST_YEAR, LAST_YEAR
 from loguru import logger
 
@@ -52,11 +53,10 @@ def main() -> None:
     archive = build_archive("monthly")
 
     logger.info("refreshing station inventory")
-    inventory = archive.sync_stations()
-    logger.info(f"inventory: {len(inventory)} stations")
+    inventory = merged_inventory(archive, "aemet_monthly")
 
     todo = select_periods(PERIODS, args.start, args.end)
-    logger.info(f"{len(todo)} periods to scrape ({args.start}-{args.end})")
+    logger.info(f"{len(todo)} periods to scrape ({todo[0][1]}-{todo[-1][2]})")
 
     t0 = time.monotonic()
     for i, y1, y2 in todo:

--- a/projects/benchmark/scripts/observations/aemet/monthly.py
+++ b/projects/benchmark/scripts/observations/aemet/monthly.py
@@ -1,0 +1,86 @@
+"""Full-network AEMET monthly scrape — multi-period, resumable.
+
+Walks AEMET's monthly climatological endpoint from 1920 to the present
+for every station in the network, in short period windows so progress is
+checkpointed to GeoParquet at regular intervals. The archive is
+idempotent — interrupt with Ctrl-C or kill the process and re-run.
+
+Pacing (see ``build_archive``) targets 60 req/min, half of AEMET's
+~150 req/min rolling cap, single-worker. With ~947 stations that is
+roughly 50 minutes per two-year window.
+
+**Resuming.** ``AemetArchive.sync`` has no per-station skip — re-running
+a window refetches every station in it. So resume at the first window
+that did not complete, not the one that did. Check current coverage with
+``python scripts/observations/aemet/coverage.py`` first.
+
+Run:
+    uv run python scripts/observations/aemet/monthly.py                # all
+    uv run python scripts/observations/aemet/monthly.py --start 1955   # resume
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from benchmark.observations.aemet import (
+    build_archive,
+    build_periods,
+    select_periods,
+    setup_logging,
+)
+from benchmark.observations.aemet.periods import FIRST_YEAR, LAST_YEAR
+from loguru import logger
+
+
+# Two-year windows: ~50 min each, so an interrupted run loses under an
+# hour rather than the ~2 h the original five-year windows cost.
+PERIODS = build_periods(step=2)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--start", type=int, default=FIRST_YEAR, help="first year to scrape")
+    p.add_argument("--end", type=int, default=LAST_YEAR, help="last year to scrape")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    setup_logging("aemet_monthly")
+    archive = build_archive("monthly")
+
+    logger.info("refreshing station inventory")
+    inventory = archive.sync_stations()
+    logger.info(f"inventory: {len(inventory)} stations")
+
+    todo = select_periods(PERIODS, args.start, args.end)
+    logger.info(f"{len(todo)} periods to scrape ({args.start}-{args.end})")
+
+    t0 = time.monotonic()
+    for i, y1, y2 in todo:
+        logger.info(f"period {i}/{len(PERIODS)}: {y1}-{y2}")
+        period_t0 = time.monotonic()
+        try:
+            ds = archive.sync(
+                "aemet_monthly",
+                stations=inventory,
+                since=f"{y1}-01-01",
+                until=f"{y2}-12-31",
+            )
+        except KeyboardInterrupt:
+            logger.warning(f"interrupted in period {y1}-{y2}; archive is safe")
+            raise
+        logger.info(
+            f"  period {y1}-{y2}: stations={ds.sizes['station']}, "
+            f"months={ds.sizes['time']}, "
+            f"elapsed={time.monotonic() - period_t0:.1f}s"
+        )
+
+    logger.info(f"all periods done in {time.monotonic() - t0:.1f}s")
+    logger.info("archive at: {}", archive.root)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/benchmark/scripts/observations/aemet/resume.sh
+++ b/projects/benchmark/scripts/observations/aemet/resume.sh
@@ -33,13 +33,22 @@ script="scripts/observations/aemet/${flavor}.py"
 # scripts/observations/aemet/ -> project root is three levels up.
 project_root="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-# Accept either env var (matches scratch_root() resolution in common.py).
+# Where the archive lands. An exported override wins; otherwise defer to
+# scratch_root() so this wrapper and the Python entry points can never
+# disagree about the destination — it also picks up a .env-only setting
+# and the portable <project>/data/aemet fallback, neither of which is
+# visible to the shell.
 scratch_root="${AEMET_SCRATCH_ROOT:-${BENCHMARK_AEMET_ROOT:-}}"
 if [[ -z "$scratch_root" ]]; then
-    echo "AEMET_SCRATCH_ROOT (or BENCHMARK_AEMET_ROOT) is not set." >&2
-    echo "Set it (recommended in ~/.bashrc) to keep data out of the repo:" >&2
-    echo "  export AEMET_SCRATCH_ROOT=\$HOME/scratch/aemet" >&2
-    exit 1
+    if ! scratch_root="$(cd "$project_root" && uv run python -c \
+        'from benchmark.observations.aemet.paths import scratch_root
+print(scratch_root())')"; then
+        echo "could not resolve the archive root via scratch_root()." >&2
+        echo "Set it explicitly to keep data off the repo disk:" >&2
+        echo "  export AEMET_SCRATCH_ROOT=\$HOME/scratch/aemet" >&2
+        exit 1
+    fi
+    echo "no AEMET_SCRATCH_ROOT exported; resolved archive root: $scratch_root"
 fi
 
 if tmux has-session -t "$session" 2>/dev/null; then

--- a/projects/benchmark/scripts/observations/aemet/resume.sh
+++ b/projects/benchmark/scripts/observations/aemet/resume.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Resume an AEMET scrape inside tmux with a CPU keepalive sidecar.
+#
+# Why a keepalive: Azure ML's dsiidlestopagent monitors CPU activity to
+# decide when to shut down idle compute. Long AEMET scrapes are mostly
+# blocked in HTTP waits / rate-limit gates, so CPU stays near zero and
+# Azure has previously killed running scrapes mid-period — that is what
+# ended the 2026-05-05 run at period 1955-1959, with no error in the log.
+# The sidecar below burns CPU on a deterministic ~0.5% duty cycle (50 ms
+# busy every 10 s) so a sample-based idle detector consistently sees
+# activity.
+#
+# Usage:
+#   scripts/observations/aemet/resume.sh monthly --start 1955
+#   scripts/observations/aemet/resume.sh daily --start 1950 --end 1999
+#   scripts/observations/aemet/resume.sh smoke
+#
+# Inside the resulting tmux session, detach with Ctrl-b d. Re-attach with
+# `tmux attach -t aemet-<flavor>`. Logs at projects/benchmark/logs/.
+
+set -euo pipefail
+
+flavor="${1:?usage: $0 <smoke|monthly|daily> [extra args...]}"
+shift || true
+
+case "$flavor" in
+  smoke|monthly|daily) ;;
+  *) echo "unknown flavor: $flavor (expected smoke|monthly|daily)" >&2; exit 2 ;;
+esac
+
+session="aemet-${flavor}"
+script="scripts/observations/aemet/${flavor}.py"
+# scripts/observations/aemet/ -> project root is three levels up.
+project_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# Accept either env var (matches scratch_root() resolution in common.py).
+scratch_root="${AEMET_SCRATCH_ROOT:-${BENCHMARK_AEMET_ROOT:-}}"
+if [[ -z "$scratch_root" ]]; then
+    echo "AEMET_SCRATCH_ROOT (or BENCHMARK_AEMET_ROOT) is not set." >&2
+    echo "Set it (recommended in ~/.bashrc) to keep data out of the repo:" >&2
+    echo "  export AEMET_SCRATCH_ROOT=\$HOME/scratch/aemet" >&2
+    exit 1
+fi
+
+if tmux has-session -t "$session" 2>/dev/null; then
+    echo "tmux session '$session' already exists. Attach with: tmux attach -t $session" >&2
+    exit 1
+fi
+
+# Forward extra args safely — preserves quoting / spaces / metacharacters.
+escaped_args=""
+for arg in "$@"; do
+    escaped_args+=" $(printf '%q' "$arg")"
+done
+
+# Launcher script with the keepalive sidecar + the scrape. Self-deletes on
+# exit. Written to a temp file so the tmux command stays a clean exec —
+# no nested shell-string escaping landmines.
+launcher="$(mktemp -t aemet-resume-XXXXXX.sh)"
+cat > "$launcher" <<LAUNCHER
+#!/usr/bin/env bash
+set -e
+self="\$0"
+trap 'rm -f "\$self"' EXIT
+
+# CPU keepalive: deterministic ~0.5% duty cycle so dsiidlestopagent
+# samples consistent activity even when the scrape is blocked on I/O.
+python3 - <<'PY' &
+import time
+PERIOD = 10.0
+BUSY = 0.05
+while True:
+    started = time.perf_counter()
+    while time.perf_counter() - started < BUSY:
+        pass
+    elapsed = time.perf_counter() - started
+    time.sleep(max(0.0, PERIOD - elapsed))
+PY
+keepalive_pid=\$!
+trap 'kill \$keepalive_pid 2>/dev/null || true; rm -f "\$self"' EXIT
+
+uv run python ${script}${escaped_args}
+
+echo
+echo '--- scrape exited; press any key to close ---'
+read -n 1
+LAUNCHER
+chmod +x "$launcher"
+
+# Propagate the scratch root via tmux -e (handles escaping internally).
+tmux new-session -d -s "$session" \
+    -e "AEMET_SCRATCH_ROOT=$scratch_root" \
+    -c "$project_root" \
+    "$launcher"
+
+echo "started tmux session: $session"
+echo "  attach:  tmux attach -t $session"
+echo "  log:     tail -f ${project_root}/logs/aemet_${flavor}.log"

--- a/projects/benchmark/scripts/observations/aemet/smoke.py
+++ b/projects/benchmark/scripts/observations/aemet/smoke.py
@@ -1,0 +1,86 @@
+"""AEMET smoke test — validates the full pipeline (~5-10 min).
+
+What it does:
+
+1. Sets up the paced archive (60 req/min, single worker).
+2. Refreshes the station inventory.
+3. Fetches twenty years of monthly data (2005-2024) for about two
+   stations per autonomous community (~37-40 stations).
+4. Reads the archive back as a GeoDataFrame and prints a brief summary.
+
+The scope is deliberately wide enough to exercise the pacing gate,
+chunk-stitching, archive append, and GeoParquet round-trip under
+sustained load — not just a one-shot validation. Run this first after any
+credential change; if it comes back clean you are safe to launch the long
+monthly / daily scrapes.
+
+Everything writes to ``<scratch>/smoke/`` and logs to ``logs/aemet_smoke.log``.
+Safe to interrupt and re-run.
+
+Run:
+    uv run python scripts/observations/aemet/smoke.py
+"""
+
+from __future__ import annotations
+
+import time
+
+from benchmark.observations.aemet import build_archive, setup_logging
+from loguru import logger
+from xrreader import StationCollection
+
+
+def main() -> None:
+    setup_logging("aemet_smoke")
+    archive = build_archive("smoke")
+
+    t0 = time.monotonic()
+    logger.info("refreshing station inventory")
+    inventory = archive.sync_stations()
+    logger.info(
+        f"inventory: {len(inventory)} stations across "
+        f"{len(inventory.communities())} communities"
+    )
+
+    # Pick ~2 well-instrumented reference stations per community so the
+    # smoke covers every autonomous community and exercises the pacing /
+    # retry / merge paths under sustained load.
+    per_community = 2
+    picks: list = []
+    for community in inventory.communities():
+        pool = inventory.filter(community=community, has_wmo=True)
+        if len(pool) < per_community:
+            pool = inventory.filter(community=community)
+        picks.extend(list(pool)[:per_community])
+    sample = StationCollection.from_iter(picks)
+    logger.info(
+        f"sampled {len(sample)} stations across {len(sample.communities())} communities"
+    )
+
+    logger.info("fetching monthly 2005-2024 for the sample (~5-10 min expected)")
+    ds = archive.sync(
+        "aemet_monthly",
+        stations=sample,
+        since="2005-01-01",
+        until="2024-12-31",
+    )
+    logger.info(
+        f"fetched slice: stations={ds.sizes['station']}, "
+        f"months={ds.sizes['time']}, variables={len(ds.data_vars)}"
+    )
+
+    logger.info("reading archive back as GeoParquet")
+    gdf = archive.load("aemet_monthly")
+    logger.info(f"archive rows: {len(gdf):,}")
+    logger.info(f"archive CRS:  EPSG:{gdf.crs.to_epsg()}")
+    non_null = gdf["air_temperature_daily_mean"].notna().sum()
+    logger.info(
+        f"air_temperature_daily_mean non-null: {non_null}/{len(gdf)} "
+        f"({non_null / len(gdf):.0%})"
+    )
+
+    logger.info(f"done in {time.monotonic() - t0:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/benchmark/src/benchmark/__init__.py
+++ b/projects/benchmark/src/benchmark/__init__.py
@@ -1,0 +1,12 @@
+"""Reference observational and reanalysis archives for benchmarking.
+
+Each source lives under a category subpackage — currently
+:mod:`benchmark.observations` for station networks. A source module owns
+its archive wiring and period schedule; the runnable entry points are thin
+CLIs under ``scripts/``.
+"""
+
+from __future__ import annotations
+
+
+__all__: list[str] = []

--- a/projects/benchmark/src/benchmark/observations/__init__.py
+++ b/projects/benchmark/src/benchmark/observations/__init__.py
@@ -1,0 +1,6 @@
+"""In-situ station-network archives (AEMET, and future siblings)."""
+
+from __future__ import annotations
+
+
+__all__: list[str] = []

--- a/projects/benchmark/src/benchmark/observations/aemet/__init__.py
+++ b/projects/benchmark/src/benchmark/observations/aemet/__init__.py
@@ -1,0 +1,40 @@
+"""AEMET OpenData scrape wiring — paced archive, logging, period schedules.
+
+``build_archive`` and ``setup_logging`` are resolved lazily (PEP 562) so
+that importing this package for its paths or period schedules does not
+pull in the reader stack. That keeps the offline tooling — ``coverage.py``
+computing a resume point from the cached GeoParquet — usable on a checkout
+without the ``xrtoolz-reader[aemet]`` extra installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from benchmark.observations.aemet.paths import LOG_ROOT, PROJECT_ROOT, scratch_root
+from benchmark.observations.aemet.periods import build_periods, select_periods
+
+
+__all__ = [
+    "LOG_ROOT",
+    "PROJECT_ROOT",
+    "build_archive",
+    "build_periods",
+    "scratch_root",
+    "select_periods",
+    "setup_logging",
+]
+
+_LAZY = {"build_archive", "setup_logging"}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY:
+        from benchmark.observations.aemet import common
+
+        return getattr(common, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/projects/benchmark/src/benchmark/observations/aemet/common.py
+++ b/projects/benchmark/src/benchmark/observations/aemet/common.py
@@ -1,0 +1,70 @@
+"""Shared setup for the AEMET scrape entry points.
+
+Keeps loguru + archive wiring out of the individual scripts so each one
+stays a short, readable list of period windows.
+
+Ported from the original ``xr_toolz/scripts/_aemet_common.py``. The only
+API change is the import: the reader moved into the xrtoolz monorepo as
+the ``xrtoolz-reader`` distribution, but the import namespace is still
+``xrreader``, so ``AemetArchive`` / ``AemetSource`` come straight off the
+top-level package instead of ``xrtoolz.data``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from loguru import logger
+from xrreader import AemetArchive, AemetSource
+
+from benchmark.observations.aemet.paths import LOG_ROOT, scratch_root
+
+
+def setup_logging(name: str) -> Path:
+    """Configure loguru: stderr + per-script file with default formatting.
+
+    Returns the log-file path for reference (e.g. so tmux users can
+    ``tail -f`` it independently of the running process).
+    """
+    LOG_ROOT.mkdir(parents=True, exist_ok=True)
+    log_path = LOG_ROOT / f"{name}.log"
+    logger.remove()
+    logger.add(sys.stderr, level="INFO")
+    logger.add(log_path, level="INFO", rotation="20 MB", retention=5)
+    return log_path
+
+
+def build_archive(
+    subdir: str,
+    *,
+    min_interval_s: float = 1.0,
+    max_workers: int = 1,
+    max_retries: int = 6,
+    timeout_s: float = 30.0,
+) -> AemetArchive:
+    """Build a paced :class:`~xrreader.AemetArchive` under ``<root>/<subdir>``.
+
+    Defaults tuned for long-running scrapes that survive AEMET's
+    rate-limit window: **60 req/min** (``min_interval_s=1.0``) with a
+    **single worker**. The two-worker / 120 req/min setting we originally
+    shipped tripped 429s because the minute bucket never actually
+    drained — while one worker was backing off, the other kept the bucket
+    hot. ``AemetSource`` now also globally pauses all workers on any 429
+    (see its ``_trip_rate_limit``) but the safer default is still
+    single-worker at 1 req/s.
+    """
+    root = scratch_root() / subdir
+    source = AemetSource(
+        timeout_s=timeout_s,
+        max_retries=max_retries,
+        max_workers=max_workers,
+        min_interval_s=min_interval_s,
+    )
+    archive = AemetArchive(root=root, source=source)
+    logger.info(f"archive root: {root}")
+    logger.info(
+        f"source: max_workers={max_workers}, "
+        f"min_interval_s={min_interval_s}, timeout_s={timeout_s}"
+    )
+    return archive

--- a/projects/benchmark/src/benchmark/observations/aemet/inventory.py
+++ b/projects/benchmark/src/benchmark/observations/aemet/inventory.py
@@ -1,0 +1,81 @@
+"""Station inventory that spans the live network *and* the archive.
+
+AEMET retires and renumbers stations, so ``sync_stations()`` — which
+returns whatever the API advertises *today* — is a moving target. On
+2026-08-19 it returned 921 stations while the monthly archive already
+held 949, a 28-station shortfall.
+
+That matters because :meth:`AemetArchive.sync` fetches exactly the
+stations it is handed. Resuming a historical scrape against the live
+inventory alone silently drops every retired station from every window
+still to come: the pre-1955 rows keep their 949 stations, the post-1955
+rows only ever get 921, and the archive ends up with a discontinuity at
+the resume point rather than a full-network record.
+
+:func:`merged_inventory` closes that gap by unioning the live inventory
+with the stations already present in the cached GeoParquet. Retired
+stations are reconstructed from their archived coordinates and flagged
+``active=False`` so downstream consumers can tell them apart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from loguru import logger
+from xrreader import AemetArchive, Station, StationCollection
+
+
+def archived_station_coords(path: Path) -> dict[str, tuple[float, float]]:
+    """Map ``station_id -> (lon, lat)`` for every station in the archive.
+
+    Returns an empty mapping when the archive does not exist yet, so a
+    first run degrades to "live inventory only" without special-casing.
+    """
+    if not path.exists():
+        return {}
+    df = pd.read_parquet(path, columns=["station_id", "lon", "lat"])
+    if df.empty:
+        return {}
+    first = df.groupby("station_id")[["lon", "lat"]].first()
+    return {str(sid): (float(r.lon), float(r.lat)) for sid, r in first.iterrows()}
+
+
+def merged_inventory(archive: AemetArchive, preset: str) -> StationCollection:
+    """Refresh the live inventory and re-add stations only the archive knows.
+
+    The live inventory wins on metadata for any station in both — it is
+    the fresher record. Stations that have dropped out of the API are
+    appended with their archived coordinates, a placeholder name, and
+    ``active=False``.
+    """
+    live = archive.sync_stations()
+    live_ids = {str(i) for i in live.ids()}
+
+    archived = archived_station_coords(archive.root / f"{preset}.parquet")
+    retired_ids = sorted(set(archived) - live_ids)
+
+    if not retired_ids:
+        logger.info(
+            f"inventory: {len(live_ids)} stations (no retired stations to re-add)"
+        )
+        return live
+
+    retired = [
+        Station(
+            id=sid,
+            name=f"retired:{sid}",
+            lon=archived[sid][0],
+            lat=archived[sid][1],
+            active=False,
+            attrs={},
+        )
+        for sid in retired_ids
+    ]
+    merged = StationCollection.from_iter([*live.stations, *retired])
+    logger.info(
+        f"inventory: {len(merged.ids())} stations "
+        f"({len(live_ids)} live + {len(retired)} retired re-added from the archive)"
+    )
+    return merged

--- a/projects/benchmark/src/benchmark/observations/aemet/paths.py
+++ b/projects/benchmark/src/benchmark/observations/aemet/paths.py
@@ -19,6 +19,29 @@ PROJECT_ROOT = Path(__file__).resolve().parents[4]
 LOG_ROOT = PROJECT_ROOT / "logs"
 
 
+def _env_file_value(name: str) -> str | None:
+    """Read ``name`` from the project ``.env``, if that file defines it.
+
+    Deliberately a hand-rolled parser rather than a python-dotenv import:
+    this module is the one piece of the package that stays stdlib-only so
+    ``coverage.py`` can compute a resume point on a checkout without the
+    reader stack installed. Handles ``KEY=value``, surrounding quotes, and
+    ``#`` comments — which is the whole of what ``.env.example`` uses.
+    """
+    env_file = PROJECT_ROOT / ".env"
+    if not env_file.is_file():
+        return None
+    for raw in env_file.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() != name:
+            continue
+        return value.split(" #")[0].strip().strip("\"'") or None
+    return None
+
+
 def scratch_root() -> Path:
     """Where the scrape archives live.
 
@@ -28,11 +51,19 @@ def scratch_root() -> Path:
        any directory, e.g. ``AEMET_SCRATCH_ROOT=~/aemet`` or
        ``/mnt/data/aemet``. This is the one the existing archive uses.
     2. ``BENCHMARK_AEMET_ROOT`` environment variable (alias).
-    3. ``<project>/data/aemet`` — the portable default that works on any
+    3. Either name as defined in the project ``.env``. The exported
+       environment wins over ``.env`` so a one-off ``AEMET_SCRATCH_ROOT=...``
+       in front of a command still overrides the committed default.
+    4. ``<project>/data/aemet`` — the portable default that works on any
        checkout, and is git-ignored.
     """
-    for var in ("AEMET_SCRATCH_ROOT", "BENCHMARK_AEMET_ROOT"):
+    names = ("AEMET_SCRATCH_ROOT", "BENCHMARK_AEMET_ROOT")
+    for var in names:
         override = os.environ.get(var)
+        if override:
+            return Path(override).expanduser()
+    for var in names:
+        override = _env_file_value(var)
         if override:
             return Path(override).expanduser()
     return PROJECT_ROOT / "data" / "aemet"

--- a/projects/benchmark/src/benchmark/observations/aemet/paths.py
+++ b/projects/benchmark/src/benchmark/observations/aemet/paths.py
@@ -1,0 +1,38 @@
+"""Filesystem locations for the AEMET scrapes.
+
+Deliberately stdlib-only: the offline tooling (``coverage.py``) needs the
+archive path without importing the reader stack, so a resume point can be
+computed on a checkout that has not installed the ``[aemet]`` extra.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+# Project root — ``src/benchmark/observations/aemet/paths.py`` is four
+# levels below ``projects/benchmark/``.
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+# Where logs go — under the project, git-ignored.
+LOG_ROOT = PROJECT_ROOT / "logs"
+
+
+def scratch_root() -> Path:
+    """Where the scrape archives live.
+
+    Resolution order (first match wins):
+
+    1. ``AEMET_SCRATCH_ROOT`` environment variable — set this to point at
+       any directory, e.g. ``AEMET_SCRATCH_ROOT=~/aemet`` or
+       ``/mnt/data/aemet``. This is the one the existing archive uses.
+    2. ``BENCHMARK_AEMET_ROOT`` environment variable (alias).
+    3. ``<project>/data/aemet`` — the portable default that works on any
+       checkout, and is git-ignored.
+    """
+    for var in ("AEMET_SCRATCH_ROOT", "BENCHMARK_AEMET_ROOT"):
+        override = os.environ.get(var)
+        if override:
+            return Path(override).expanduser()
+    return PROJECT_ROOT / "data" / "aemet"

--- a/projects/benchmark/src/benchmark/observations/aemet/periods.py
+++ b/projects/benchmark/src/benchmark/observations/aemet/periods.py
@@ -1,0 +1,63 @@
+"""Period schedules for the multi-period AEMET scrapes.
+
+The scrape walks history in fixed-width year windows so progress is
+checkpointed to GeoParquet at regular intervals. Window width is a pure
+checkpoint-granularity knob — it has no effect on what gets fetched, only
+on how much work an interrupted run has to redo.
+
+Why the windows are short: the original monthly scrape used five-year
+windows (~2 h each) and was repeatedly killed mid-window by Azure ML's
+idle-stop agent, losing the whole window every time. Two-year windows cut
+that blast radius to ~50 min. See ``scripts/observations/aemet/resume.sh``
+for the CPU-keepalive sidecar that addresses the kill itself.
+"""
+
+from __future__ import annotations
+
+
+# AEMET's climatological baseline — no station records precede this.
+FIRST_YEAR = 1920
+
+# Last complete calendar year to scrape by default. Bump as years close.
+LAST_YEAR = 2025
+
+
+def build_periods(
+    step: int = 2,
+    first: int = FIRST_YEAR,
+    last: int = LAST_YEAR,
+) -> list[tuple[int, int]]:
+    """Inclusive ``(start_year, end_year)`` windows of ``step`` years.
+
+    The final window is clipped to ``last``, so it may be shorter.
+
+    >>> build_periods(step=2, first=1920, last=1924)
+    [(1920, 1921), (1922, 1923), (1924, 1924)]
+    """
+    if step < 1:
+        raise ValueError(f"step must be >= 1, got {step}")
+    if last < first:
+        raise ValueError(f"last ({last}) precedes first ({first})")
+    return [(y, min(y + step - 1, last)) for y in range(first, last + 1, step)]
+
+
+def select_periods(
+    periods: list[tuple[int, int]],
+    start: int,
+    end: int,
+) -> list[tuple[int, int, int]]:
+    """Clip ``periods`` to the ``[start, end]`` year range.
+
+    Windows fully outside the range are dropped; a window straddling a
+    boundary is trimmed to it. Positions are preserved as 1-based indices
+    into the *original* schedule so log lines like ``period 18/53`` stay
+    meaningful when resuming partway through.
+
+    Returns ``(index, start_year, end_year)`` triples.
+    """
+    selected: list[tuple[int, int, int]] = []
+    for i, (y1, y2) in enumerate(periods, 1):
+        if y2 < start or y1 > end:
+            continue
+        selected.append((i, max(y1, start), min(y2, end)))
+    return selected

--- a/projects/benchmark/src/benchmark/observations/aemet/periods.py
+++ b/projects/benchmark/src/benchmark/observations/aemet/periods.py
@@ -54,7 +54,32 @@ def select_periods(
     meaningful when resuming partway through.
 
     Returns ``(index, start_year, end_year)`` triples.
+
+    Raises ``ValueError`` rather than returning an empty list when the
+    request cannot select anything. A silent empty selection is the worst
+    outcome here: the scrape logs the range it was asked for, fetches
+    nothing, and then reports that every period completed — so a typo like
+    ``--start 2026`` against a schedule ending in 2025 looks like success.
+
+    >>> select_periods([(1920, 1921), (1922, 1923)], 1921, 1922)
+    [(1, 1921, 1921), (2, 1922, 1922)]
+    >>> select_periods([(1920, 1921)], 2026, 2026)
+    Traceback (most recent call last):
+        ...
+    ValueError: requested 2026-2026 but the schedule only covers 1920-1921
     """
+    if not periods:
+        raise ValueError("period schedule is empty")
+    if start > end:
+        raise ValueError(f"start ({start}) is after end ({end})")
+
+    first_year, last_year = periods[0][0], periods[-1][1]
+    if end < first_year or start > last_year:
+        raise ValueError(
+            f"requested {start}-{end} but the schedule only covers "
+            f"{first_year}-{last_year}"
+        )
+
     selected: list[tuple[int, int, int]] = []
     for i, (y1, y2) in enumerate(periods, 1):
         if y2 < start or y1 > end:


### PR DESCRIPTION
## What

Restores the AEMET OpenData scrape scripts into the notebook as a new project at `projects/benchmark/`, ported to the reader's current packaging.

The scripts were deleted from `xr_toolz` during the `xrtoolz-reader` migration (`8384e25`) and never re-created, which left a half-finished archive with no runnable entry point. The monthly archive holds **1920–1954 complete for 947 stations** (397,740 rows); the run stopped mid-1955 on 2026-05-05 and there was no way to restart it.

## Why `benchmark` and not `aemet`

`benchmark` is the installable project; `observations/aemet` is a subpackage. Sibling sources — `observations/ghcn`, `reanalysis/era5` — slot in without new scaffolding, sharing the pacing and logging conventions. Scrape logic moved into the package and the scripts became thin CLIs, which drops the old `sys.path.insert` hack.

```
projects/benchmark/
├── src/benchmark/observations/aemet/   # paths, periods, archive wiring
└── scripts/observations/aemet/         # smoke · coverage · monthly · daily · resume.sh
```

## The API port

The reader is now the `xrtoolz-reader` distribution in the xrtoolz monorepo, but **the import namespace is still `xrreader`**, so the port is narrow:

| Old | New |
|---|---|
| `from xrtoolz.data import AemetArchive, AemetSource` | `from xrreader import AemetArchive, AemetSource` |
| `from xrtoolz.types import StationCollection` | `from xrreader import StationCollection` |
| dep `xrreader` | dep `xrtoolz-reader[aemet]`, `subdirectory = "packages/xrtoolz-reader"` |

I diffed the AEMET module between standalone `xrreader` 0.0.2 and monorepo `xrtoolz-reader` 0.0.3: one line differs, an install-hint string. No behavioural drift, so the ported scripts are faithful.

## Changes beyond a straight restore

- **Two-year period windows instead of five.** The original run was repeatedly killed mid-window by Azure's idle-stop agent, losing ~2h each time. This bounds the loss to ~50 min. Pure checkpoint granularity — no effect on what gets fetched.
- **New `coverage.py`.** `AemetArchive.sync` has no per-station resume, so restarting on the wrong year silently refetches a whole window. This reports coverage from the cached GeoParquet and computes the resume year. `paths.py` and `periods.py` are stdlib-only and `__init__` resolves the reader lazily (PEP 562), so it runs without the `[aemet]` extra installed.
- **`resume.sh`** keeps the CPU-keepalive sidecar, repointed at the new paths. It exists because a rate-limited scrape sits at near-zero CPU and Azure reaps it — that is the standing explanation for the May failure.

## Verification

- `coverage.py` against the live archive → `resume with: --start 1955`
- `smoke.py` authenticates and fetches — which also confirms `uv sync` resolves the git dependency, and that the API key is **not** expired (ruling out expiry as the May failure cause)
- `ruff check` and `ruff format --check` clean
- doctests pass; `bash -n` clean on `resume.sh`

## Notes for review

- **Inventory drift:** the live network is now **921 stations**, down from the 947 frozen into the archive — AEMET retires and renumbers. Rows for retired stations remain; new windows just won't extend them.
- **`uv.lock` is gitignored** for this project, matching every sibling under `projects/` (none commit one) and because the reader is pinned to a git branch anyway. One-line flip in `.gitignore` if you'd prefer to ship it.
- Resuming costs ~30h: 36 two-year windows at ~50 min, paced at 60 req/min single-worker. That pacing is deliberate — the original 2-worker/120 req/min config tripped 429s because one worker kept the minute bucket hot while the other backed off.

```bash
cd projects/benchmark && uv sync && cp .env.example .env   # add your key
uv run python scripts/observations/aemet/coverage.py       # confirm resume year
scripts/observations/aemet/resume.sh monthly --start 1955
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
